### PR TITLE
fix(observer): subir max_tokens de analizar_agente_curado a 2048

### DIFF
--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
@@ -480,7 +480,10 @@ Responde SOLO con JSON válido, sin texto adicional, con esta forma exacta:
         try:
             resp = self.client.messages.create(
                 model="claude-haiku-4-5-20251001",
-                max_tokens=1024,
+                # 1024 no alcanzaba para agentes con muchas intervenciones
+                # (ej. protagonistas con 20+ respuestas): el JSON se cortaba
+                # a mitad de la última cita, rompiendo el parseo.
+                max_tokens=2048,
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = "".join(b.text for b in resp.content if hasattr(b, "text")).strip()


### PR DESCRIPTION
## Summary
- Corrida real de 30 turnos: 4/20 perfiles curados fallaron con "Unterminated string" al parsear el JSON.
- Causa: `max_tokens=1024` no alcanzaba para protagonistas con muchas intervenciones (Manaure 23, Dare-nu 21, Buio-sha 22 respuestas) — la respuesta se truncaba a mitad de la última cita.

## Test plan
- [x] Regenerados los 4 perfiles fallidos (Manaure, Dare-nu, Naure-sha, Buio-sha) con `max_tokens=2048`, reconstruyendo el historial desde Supabase sin re-correr la simulación
- [x] Resultado final: 20/20 perfiles, 99 frases curadas
- [x] `test_quick.py` → 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)