### PR TITLE
fix(sim): sincronizar adopcion de neologismos con Supabase

### DIFF
--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
@@ -7052,8 +7052,12 @@ class LexicoComunitario:
                 "dia": neo.dia,
             }
 
-    def adoptar(self, forma: str, agente: str, turno: int):
-        """Un agente adopta una palabra propuesta."""
+    def adoptar(self, forma: str, agente: str, turno: int) -> Optional["Neologismo"]:
+        """
+        Un agente adopta una palabra propuesta. Retorna el Neologismo si la
+        adopción se OFICIALIZA recién en esta llamada (2do adoptante distinto),
+        o None si no hubo transición (para que el caller sepa cuándo sincronizar
+        el estado con Supabase sin tener que diffear él mismo)."""
         for neo in self._neologismos:
             if neo.forma == forma and neo.estado == "propuesto":
                 if agente not in neo.adoptado_por:
@@ -7067,7 +7071,9 @@ class LexicoComunitario:
                         "autor": neo.autor,
                         "dia": neo.dia,
                     }
+                    return neo
                 break
+        return None
 
     def rechazar(self, forma: str, agente: str, turno: int):
         """Un agente rechaza o ignora activamente una palabra propuesta."""

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
@@ -216,15 +216,21 @@ Responde en JSON:
 
     # ── Detección de adopciones/rechazos ─────────────────────────────
 
-    def procesar_adopciones(self, texto: str, agente: str, turno: int):
+    def procesar_adopciones(self, texto: str, agente: str, turno: int) -> list:
         """
         Detecta si un agente usó palabras propuestas por otros,
-        registrándolo como adopción.
+        registrándolo como adopción. Retorna los Neologismo que se
+        OFICIALIZARON recién (2do adoptante distinto) en esta llamada, para
+        que el caller pueda sincronizar su estado con Supabase.
         """
         texto_lower = texto.lower()
+        oficializados = []
         for neo in self.lexico.neologismos_pendientes():
             if neo.forma in texto_lower and neo.autor != agente:
-                self.lexico.adoptar(neo.forma, agente, turno)
+                resultado = self.lexico.adoptar(neo.forma, agente, turno)
+                if resultado is not None:
+                    oficializados.append(resultado)
+        return oficializados
 
     # ── Feedback para próximo turno ───────────────────────────────────
 

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -395,7 +395,7 @@ def run_turn(
         )
 
         # Detectar adopciones de palabras propuestas por otros
-        observer.procesar_adopciones(response, agent_name, state.turno)
+        neos_oficializados = observer.procesar_adopciones(response, agent_name, state.turno)
 
         # Contagio: propagar exposición de las palabras emergentes que usó este
         # agente (no las del vocabulario base) a sus vecinos sociales.
@@ -444,6 +444,21 @@ def run_turn(
                         )
                     except Exception:
                         pass  # No interrumpir por neologismo fallido
+
+                # Sincronizar adopciones oficializadas este turno (antes solo
+                # se actualizaba el LexicoComunitario en memoria; Supabase
+                # quedaba con status="propuesto" para siempre)
+                for neo_oficial in neos_oficializados:
+                    try:
+                        db.update_neologism_status(
+                            form=neo_oficial.forma,
+                            run_id=run_id,
+                            status="adoptado",
+                            adopted_by=neo_oficial.adoptado_por,
+                            adopted_turn_id=turn_id,
+                        )
+                    except Exception:
+                        pass
 
             except Exception as e:
                 if verbose:


### PR DESCRIPTION
## Summary
Analizando el run real de 30 turnos para el análisis final: `LexicoComunitario` marcaba neologismos como "adoptado" en memoria (2+ agentes distintos usándolos), pero `db.update_neologism_status()` nunca se llamaba desde el orquestador. Todo neologismo quedaba en `status="propuesto"` para siempre en Supabase.

- `LexicoComunitario.adoptar()` ahora retorna el `Neologismo` si la adopción se oficializa recién en esa llamada.
- `ObserverAgent.procesar_adopciones()` propaga eso.
- El orquestador llama a `db.update_neologism_status()` cuando corresponde.
- Reparado retroactivamente el run de 30 turnos ya corrido: 20/27 neologismos existentes en Supabase corregidos a `adoptado`.

## Hallazgo pendiente (no resuelto aquí)
De 89 neologismos en memoria, solo 28 llegaron a `db.save_neologism()` en Supabase. Posible causa: el patrón de extracción solo detecta `[forma: componentes = significado]` la primera vez que se escribe explícito; usos posteriores no vuelven a calzar. Requiere investigar el flujo completo antes de decidir un fix — queda para otra sesión.

## Test plan
- [x] `test_quick.py` → 8/8
- [x] Verificado contra `curiana_lexico.json` del run real (estado en memoria vs Supabase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)