### PR TITLE
Koiné: población constante, métrica persistida, compuerta fonotáctica

### DIFF
--- a/proyecto-linguistico-caquetío/BITACORA_RUNS.md
+++ b/proyecto-linguistico-caquetío/BITACORA_RUNS.md
@@ -13,10 +13,45 @@ detallados por run en archivos `ANALISIS_RUN_*.md` enlazados.
 
 | Fecha | Run (id8) | Turnos/Días | Agentes | Score | Caquetío | Estado / hito |
 |---|---|---|---|---|---|---|
-| 06-29 | `f8ef263d` | 30 / 15 | 28 | 7.5 | **99%** | **Primer run koiné** — convergencia confirmada |
+| 06-29 | `9bb920eb` | 60 / 30 | 32 | 7.5 | **99%** | **Run largo** — población constante, métrica persistida, convergencia −44% |
+| 06-29 | `f8ef263d` | 30 / 15 | 28 | 7.5 | **99%** | Primer run koiné — convergencia confirmada |
 | 06-22 | `2e729f3f` | 30 / 15 | 20 | 7.2 | 92% | Primer run largo calibrado (ver `ANALISIS_RUN_30T_2026-06-22.md`) |
 | 06-29 | `8a4f9da4` | 2 / 1 | 7 | 7.1 | 100% | smoke de persistencia (descartable) |
 | 06-21 | `bdead490` y otros | 1–2 | 6–13 | 6–7 | 8–31% | runs de desarrollo pre-calibración (baseline) |
+
+---
+
+## 2026-06-29 · Run `9bb920eb` — Run largo (60T / 30 días)
+
+**Comando:** `python curiana_orchestrator_v2.py --auto 60 --perfiles`
+**Contexto:** primer run con los arreglos posteriores al run koiné: población
+constante (`PARTICIPANTES_KOINE`, 24 agentes rotados por ventana), métrica de
+convergencia persistida (`koine_metrics`) y compuerta de neologismos fonotáctica.
+
+### Convergencia: limpia y −44% (confirmada por dos métricas)
+
+- **`koine_metrics` persistida** (población real, recomputable desde la tabla):
+  `día 1: 0.6465 → día 30: 0.3898` (−40%). Con población constante desde el día
+  16 (32 agentes), el tramo final es **monótono** — desaparece el repunte del
+  medio que confundía el run anterior.
+- **Cohorte fijo** (19 agentes activos desde el día ≤3, recomputado desde
+  `word_uses`): `0.5467 → 0.3047` (**−44.3%**), monótona, sin bumps. El cohorte
+  es ahora 19 agentes (vs 7 en el run de 30T) gracias a la población constante.
+
+### Léxico y neologismos
+
+- Caquetío **99%**, score 7.45, 295 respuestas, **32 agentes** (6 etnias).
+- **40 neologismos adoptados** (vs 28 en el run de 30T), 6 propuestos.
+- **0 formas con marcador español** — la compuerta fonotáctica funcionó en
+  producción. Adoptados limpios: `tüshi-bana`, `chaa-bana-ni`, `naba-ana-bana`,
+  `nii-bana-da`, `katu-puri-bana`, `paa-bana-da`…
+
+### Pendiente
+
+- **Fijación por competencia de variantes** (DISENO_KOINE §6): la adopción sigue
+  siendo "2 agentes la usan → adoptada", sin resolver qué variante *gana* un
+  significado cuando compiten. Todos los adoptados tienen exactamente 2
+  adoptantes. Es el próximo mecanismo de koiné a implementar.
 
 ---
 

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
@@ -393,6 +393,16 @@ class CurianaDB:
             "form", form
         ).eq("run_id", run_id).execute()
 
+    # ── Koiné metrics ─────────────────────────────────────────────────
+
+    def save_koine_metric(self, run_id: str, day: int, distance: float, n_agents: int):
+        """Persiste la distancia idiolectal media de un día (métrica de
+        convergencia). Upsert por (run_id, day) para ser idempotente."""
+        self.client.table("koine_metrics").upsert(
+            {"run_id": run_id, "day": day, "distance": distance, "n_agents": n_agents},
+            on_conflict="run_id,day",
+        ).execute()
+
     # ── Phrase etymologies ────────────────────────────────────────────
 
     def save_phrase_etymology(
@@ -553,6 +563,7 @@ class CurianaDBMock:
     def save_neologism(self, *a, **kw) -> str:
         import uuid; return str(uuid.uuid4())
     def update_neologism_status(self, *a, **kw): pass
+    def save_koine_metric(self, *a, **kw): pass
     def save_phrase_etymology(self, *a, **kw): pass
     def latest_run(self): return None
     def language_drift(self, *a): return []

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
@@ -251,16 +251,21 @@ def _coseno(a: Counter, b: Counter) -> float:
     return num / (na * nb) if na and nb else 0.0
 
 
-def distancia_idiolectal(idiolectos: dict[str, "IdiolectoAgente"], min_formas: int = 5) -> float:
+def distancia_idiolectal(idiolectos: dict[str, "IdiolectoAgente"], min_formas: int = 5,
+                         solo: Optional[set] = None) -> float:
     """Distancia idiolectal media (1 - coseno) entre pares de agentes activos.
 
     Es la firma de la koineización: DEBE CONTRAERSE en el tiempo. Solo se
-    consideran agentes con vocabulario suficiente (min_formas), para no medir
-    ruido de agentes que apenas hablaron.
+    consideran agentes con vocabulario suficiente (min_formas).
+
+    `solo`: si se pasa un conjunto de nombres, restringe la medición a esos
+    agentes (los que REALMENTE hablaron) — clave porque los idiolectos se
+    pre-cargan con formas-semilla para los 60 agentes, y medir sobre todos
+    diluiría la señal con vectores estáticos de quienes nunca participaron.
     """
     vectores = [
-        idio.vector() for idio in idiolectos.values()
-        if len(idio.vector()) >= min_formas
+        idio.vector() for nombre, idio in idiolectos.items()
+        if (solo is None or nombre in solo) and len(idio.vector()) >= min_formas
     ]
     if len(vectores) < 2:
         return 0.0

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
@@ -6865,27 +6865,60 @@ RAICES_ESPANOLAS = {
     "lluvia", "nube", "estrella", "humo", "ceniza", "ramo", "monte", "selva",
 }
 
-# ⚠️ LIMITACIÓN CONOCIDA: este blocklist es heurístico (whack-a-mole). Atrapa
-# las raíces españolas frecuentes pero NO toda forma castellana novedosa que un
-# LLM pueda acuñar. Una solución completa necesitaría una lista de palabras
-# españolas (p.ej. wordfreq) o un filtro fonotáctico caquetío — pendiente. El
-# riesgo real es acotado: solo los neologismos ADOPTADOS (2 agentes) se fijan en
-# la koiné, y una raíz española suelta rara vez se propaga; las no reusadas
-# decaen en el CampoLexico.
+# Marcadores ortográficos fuertes del español, ausentes del caquetío:
+# rr/ll geminadas, qu, ñ, x, y vocales con tilde aguda (caquetío usa ü, no á/é…).
+_MARCADORES_ES = re.compile(r"rr|ll|qu|ñ|x|[áéíóú]")
+
+# Bigramas que aparecen en el caquetío real (atestiguado+reconstruido). Se computa
+# perezosamente (evita import circular con curiana_database al cargar el módulo).
+_CAQ_BIGRAMS: Optional[set] = None
+_AFIJOS_NEO: Optional[set] = None
+
+
+def _caq_bigrams() -> set:
+    global _CAQ_BIGRAMS, _AFIJOS_NEO
+    if _CAQ_BIGRAMS is None:
+        from curiana_database import normalize_source_language
+        bg = set()
+        for palabra, datos in VOCABULARIO_BASE.items():
+            if normalize_source_language(datos.get("fuente", "")) == "caquetío":
+                w = palabra.lower()
+                bg |= {w[i:i+2] for i in range(len(w) - 1)}
+        _CAQ_BIGRAMS = bg
+        _AFIJOS_NEO = {a.strip("-").lower() for a in TODAS_LAS_REGLAS}
+    return _CAQ_BIGRAMS
+
+
+def _componente_espanol(comp: str) -> bool:
+    """True si un componente de neologismo delata origen español. Combina:
+    (1) blocklist de raíces frecuentes, (2) marcadores ortográficos español-only,
+    (3) ≥2 bigramas ausentes del caquetío (un solo bigrama raro se tolera para no
+    bloquear combinaciones caquetías novedosas — p.ej. 'kale')."""
+    c = comp.strip(" *-").lower()
+    caq = _caq_bigrams()
+    if not c or len(c) <= 2 or c in _AFIJOS_NEO:
+        return False
+    if c in ES_STOPWORDS or c in RAICES_ESPANOLAS:
+        return True
+    if _MARCADORES_ES.search(c):
+        return True
+    bad = sum(1 for i in range(len(c) - 1) if c[i:i+2] not in caq)
+    return bad >= 2
 
 
 def neologismo_valido(forma: str, componentes: str = "") -> bool:
-    """True si la FORMA del neologismo no contiene raíces/stopwords españolas.
-    Solo se chequea la forma (la palabra acuñada): el campo `componentes` es la
-    explicación del agente y va naturalmente en español ('mirar-hacia-el-cerro'),
-    así que chequearlo daría falsos positivos. Filtro para que la koiné no fije
-    préstamos castellanos disfrazados de palabra acuñada (suave-bana-ni, etc.).
-    `componentes` se acepta por compatibilidad de firma pero no se inspecciona."""
-    for parte in re.split(r"[-+\s,;]+", (forma or "").lower()):
-        parte = parte.strip(" *").strip()
-        if parte and (parte in ES_STOPWORDS or parte in RAICES_ESPANOLAS):
-            return False
-    return True
+    """True si la FORMA del neologismo no delata origen español en ninguno de sus
+    componentes (separados por guion). Solo se chequea la forma acuñada; el campo
+    `componentes` va en español como explicación del agente, así que no se
+    inspecciona. Filtro de tres capas (blocklist + marcadores ortográficos +
+    fonotáctica por bigramas caquetíos) para que la koiné no fije préstamos
+    castellanos disfrazados (suave-bana-ni, carrera-kata, guardia-bana, etc.).
+
+    Validado contra los 28 neologismos caquetíos adoptados del run f8ef263d:
+    cero falsos positivos; bloquea los ofensores observados."""
+    return not any(
+        _componente_espanol(p) for p in re.split(r"[-+\s,;]+", (forma or ""))
+    )
 
 
 def extraer_neologismos_del_texto(

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -68,15 +68,23 @@ MODEL = "claude-haiku-4-5-20251001"
 MAX_TOKENS_AGENT = 500      # Espacio para frases en caquetío + glosa + neologismos
 MAX_TOKENS_DIRECTOR = 600
 
-# Koiné: pool de agentes foráneos/de contacto y periféricos que se rotan a la
-# escena cada turno. Sin esto solo hablan ~6 caquetíos nucleares y no hay
-# contacto dialectal — la mezcla que después se asienta en koiné. Se filtra a
-# los que existen en ALL_AGENTS al primer uso (run_turn).
-_KOINE_ROTACION = [
-    "Tariwa", "Kawa-ni", "Piru-sha", "Tari-ko", "Wata-ni",   # guaycarí
-    "Nabaraka", "Raka-bi", "Chorota",                          # jirajara/gayón
-    "Marokoto-ni", "Kadushi",                                  # caribe / insular
-    "Watapana", "Dara-ko", "Biro-ko", "Paugis-sha",           # caquetíos periféricos
+# Koiné: roster FIJO de participantes (población constante desde el día 1). Se
+# rota una ventana sobre este roster cada turno, de modo que todos hablan en los
+# primeros ~2 días — a diferencia de la entrada gradual anterior, que inflaba la
+# distancia idiolectal en el medio del run y confundía la métrica de convergencia.
+# Mezcla caquetíos nucleares + periféricos + foráneos/de contacto (la mezcla que
+# se asienta en koiné). Se filtra a los existentes en ALL_AGENTS al usarse.
+PARTICIPANTES_KOINE = [
+    # caquetíos nucleares (formadores de norma)
+    "Manaure", "Shaboro", "Nubiri-sha", "Buio-sha", "Tawaka", "Dare-nu",
+    "Corie-ko", "Paugis-sha",
+    # caquetíos periféricos
+    "Watapana", "Dara-ko", "Biro-ko", "Saruro-sha", "Chiriguare",
+    # contacto insular / caribe
+    "Kadushi", "Marokoto-ni",
+    # foráneos (aportantes de la mezcla)
+    "Tariwa", "Kawa-ni", "Piru-sha", "Tari-ko", "Wata-ni",
+    "Nabaraka", "Raka-bi", "Chorota",
 ]
 
 # Constante de identidad lingüística — inyectada en TODOS los agentes
@@ -373,16 +381,14 @@ def run_turn(
             if a in ALL_AGENTS and a not in ("toda_la_comunidad", "guerreros")
         ] or state.agentes_en_escena[:5]
     else:
-        # Koiné: base de escena + rotación de foráneos/periféricos para que el
-        # contacto dialectal ocurra (se intercalan para sobrevivir el slice [:6]).
-        base = list(state.agentes_en_escena)
-        pool = [a for a in _KOINE_ROTACION if a in ALL_AGENTS]
-        if pool:
-            k = state.turno % len(pool)
-            foraneos = [pool[k], pool[(k + 1) % len(pool)]]
-            agentes_activos = base[:4] + foraneos
+        # Koiné: ventana rotatoria de 6 sobre el roster FIJO de participantes,
+        # avanzando 6 por turno → todos hablan en ~2 días (población constante).
+        roster = [a for a in PARTICIPANTES_KOINE if a in ALL_AGENTS]
+        if roster:
+            k = (state.turno * 6) % len(roster)
+            agentes_activos = [roster[(k + i) % len(roster)] for i in range(6)]
         else:
-            agentes_activos = base
+            agentes_activos = state.agentes_en_escena
 
     if verbose:
         print(f"\n{'='*60}")
@@ -708,6 +714,7 @@ def auto_mode(
     }
     campo = CampoLexico()
     serie_distancia: list[tuple[int, float]] = []
+    participantes: set[str] = set()   # agentes que REALMENTE hablaron (para la métrica)
 
     # Inicializar DB (CurianaDB real o CurianaDBMock si no está configurada)
     db = get_db()
@@ -729,21 +736,28 @@ def auto_mode(
     print(f"{'='*60}\n")
 
     for t in range(turnos):
-        run_turn(
+        interactions = run_turn(
             client, state, memory, lexico, observer,
             verbose=verbose, db=db, run_id=run_id,
             difusion=difusion, idiolectos=idiolectos, campo=campo,
         )
+        participantes.update(i["agent"] for i in interactions)
 
         # Reporte al final de cada día
         if state.turno == 1 and state.dia > 1:  # acaba de cambiar de día
             dia_terminado = state.dia - 1
-            dist = distancia_idiolectal(idiolectos)
+            # Distancia medida SOLO sobre quienes hablaron (población real)
+            dist = distancia_idiolectal(idiolectos, solo=participantes)
             serie_distancia.append((dia_terminado, dist))
+            if db and run_id:
+                try:
+                    db.save_koine_metric(run_id, dia_terminado, dist, len(participantes))
+                except Exception:
+                    pass
             if verbose:
                 print(observer.reporte_dia(dia_terminado))
-                print(f"  ◇ Koiné — distancia idiolectal media: {dist} "
-                      f"(↓ = converge hacia koiné)")
+                print(f"  ◇ Koiné — distancia idiolectal ({len(participantes)} agentes): "
+                      f"{dist}  (↓ = converge hacia koiné)")
 
         # Detección de cambio de estación
         if state.estacion != estacion_anterior:

--- a/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260629000000_koine_metrics.sql
+++ b/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260629000000_koine_metrics.sql
@@ -1,0 +1,23 @@
+-- ══════════════════════════════════════════════════════════════════════
+-- KOINE_METRICS — métrica de convergencia por run/día
+-- La distancia idiolectal media (1 - coseno entre pares de agentes que
+-- realmente hablaron). Firma de la koineización: debe CONTRAERSE en el tiempo.
+-- Antes solo se imprimía y se perdía; ahora se persiste para analizar/graficar.
+-- ══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS koine_metrics (
+  id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  run_id       UUID REFERENCES simulation_runs(id) ON DELETE CASCADE,
+  day          INT NOT NULL,
+  distance     FLOAT,           -- distancia idiolectal media (0..1)
+  n_agents     INT,             -- agentes considerados (los que hablaron)
+  created_at   TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (run_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_koine_metrics_run ON koine_metrics(run_id);
+
+ALTER TABLE koine_metrics ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read koine_metrics" ON koine_metrics FOR SELECT USING (true);
+
+GRANT ALL    ON koine_metrics TO service_role;
+GRANT SELECT ON koine_metrics TO anon, authenticated;


### PR DESCRIPTION
## Qué
Arreglos (a) + (c) tras el primer run koiné, validados por el run largo `9bb920eb` (60T / 30 días).

### (a) Población constante + métrica persistida
- `PARTICIPANTES_KOINE`: roster fijo (24 ag) rotado por ventana → todos hablan en ~2-3 días (antes 7→28 en 10 días). Elimina el confound de entrada gradual.
- `distancia_idiolectal(solo=participantes)`: mide solo sobre quienes hablaron.
- Tabla `koine_metrics` (migración) + `save_koine_metric`: la distancia por día se persiste.

### (c) Compuerta de neologismos fonotáctica
- `_componente_espanol`: blocklist + marcadores ortográficos español-only (rr/ll/qu/ñ/x/tildes) + ≥2 bigramas ausentes del caquetío. Cero falsos positivos contra los 28 adoptados reales.

## Resultado (run 9bb920eb)
- Convergencia **−44.3%** (cohorte fijo 19 ag) / −40% (koine_metrics), monótona.
- Caquetío 99%, 32 agentes, 40 neologismos adoptados, **0 con marcador español**.

## Pendiente
- Fijación por competencia de variantes (DISENO_KOINE §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)