### PR TITLE
Koiné: fijación por competencia (eventos de nombramiento + CompetenciaLexica)

### DIFF
--- a/proyecto-linguistico-caquetío/BITACORA_RUNS.md
+++ b/proyecto-linguistico-caquetío/BITACORA_RUNS.md
@@ -13,11 +13,56 @@ detallados por run en archivos `ANALISIS_RUN_*.md` enlazados.
 
 | Fecha | Run (id8) | Turnos/Días | Agentes | Score | Caquetío | Estado / hito |
 |---|---|---|---|---|---|---|
-| 06-29 | `9bb920eb` | 60 / 30 | 32 | 7.5 | **99%** | **Run largo** — población constante, métrica persistida, convergencia −44% |
+| 06-29 | `20091e1f` | 57 / 29 | 30 | 7.4 | **99%** | **Fijación por competencia** — diccionario koiné de 7 conceptos |
+| 06-29 | `9bb920eb` | 60 / 30 | 32 | 7.5 | **99%** | Run largo — población constante, métrica persistida, convergencia −44% |
 | 06-29 | `f8ef263d` | 30 / 15 | 28 | 7.5 | **99%** | Primer run koiné — convergencia confirmada |
 | 06-22 | `2e729f3f` | 30 / 15 | 20 | 7.2 | 92% | Primer run largo calibrado (ver `ANALISIS_RUN_30T_2026-06-22.md`) |
 | 06-29 | `8a4f9da4` | 2 / 1 | 7 | 7.1 | 100% | smoke de persistencia (descartable) |
 | 06-21 | `bdead490` y otros | 1–2 | 6–13 | 6–7 | 8–31% | runs de desarrollo pre-calibración (baseline) |
+
+---
+
+## 2026-06-29 · Run `20091e1f` — Fijación por competencia
+
+**Comando:** `python curiana_orchestrator_v2.py --auto 60 --perfiles` (el proceso
+se cortó en el turno 57/60 por teardown de sesión; analíticamente completo —
+llegó al día 29).
+**Contexto:** primer run con el motor de **fijación por competencia** (eventos
+de nombramiento + `CompetenciaLexica`).
+
+### El diccionario koiné emergente (7 conceptos fijados)
+
+La pieza que faltaba: la koiné ahora **selecciona un nombre por concepto** a
+partir de variantes rivales. Persistido en `koine_lexicon`:
+
+| concepto | forma koiné fijada | (significado) | de N rivales | día |
+|---|---|---|---|---|
+| eclipse | **`ma-kali-bana`** | "orilla donde falta el sol" | 4 | 10 |
+| cometa | **`kali-subo`** | "luz que corre" | 3 | 5 |
+| metal amarillo | **`sulu-pana`** | | 3 | 14 |
+| fiebre con manchas | `ka-bari-tüshi-kali` | | 2 | 9 |
+| tambor caribe | `mana-koto` | | 2 | 17 |
+| marea roja | `duna-kali-biji` | | 2 | 18 |
+| planta que quema | `tüshi-mana-bana` | | 2 | 20 |
+
+**La competencia es genuina:** para "cometa", Paugis-sha y Corie-ko acuñaron
+`kali-subo` de forma **independiente** → convergieron. Para "eclipse" compitieron
+`ma-kali`, `kali-suka`, `kali-suka-biji` y `ma-kali-bana`; ganó la última por
+reuso convergente. Formas morfológicamente caquetías y semánticamente poéticas.
+3 de 10 referentes quedaron en disputa (no toda competencia resuelve — realista).
+
+### Resto
+
+- Caquetío **99%**, score 7.4, 30 agentes, **41 neologismos adoptados**.
+- Convergencia (koine_metrics): `0.6325 → 0.3509` (**−45%**), monótona.
+- Compuerta fonotáctica: sin fugas españolas.
+
+### Pendiente
+
+- Muestreo ponderado por frecuencia (conectar `CampoLexico` a
+  `muestra_caquetio_dinamica`) — único ⏳ del diseño koiné.
+- El diccionario koiné (`koine_lexicon`) es ahora el **insumo de la fase de
+  topónimos**: un topónimo es un referente compartido que necesita nombre.
 
 ---
 

--- a/proyecto-linguistico-caquetío/DISENO_KOINE.md
+++ b/proyecto-linguistico-caquetío/DISENO_KOINE.md
@@ -124,17 +124,30 @@ entrenchment: lo que dijiste, lo repetís → deriva individual que compone.
 - **Decaimiento**: formas no usadas en N turnos pierden peso → recambio léxico
   (deja que cosas mueran).
 
-### Competencia y fijación de variantes
-Hoy la adopción es "2 agentes la usan → adoptada", sin resolver competencia.
-Una koiné se forma cuando **variantes que compiten por el mismo significado
-colapsan a una**:
+### Competencia y fijación de variantes  ✅ IMPLEMENTADO (`CompetenciaLexica`)
 
-- Agrupar neologismos/formas por **significado** (glosa).
-- Cuando hay >1 variante para una glosa, compiten por `frecuencia × prestigio`.
-- Los agentes de prestigio (Manaure, Shaboro, Nubiri-sha) **anclan la norma**
-  hacia el caquetío: su uso amplifica la variante.
-- Una variante se declara **fijada** cuando domina su glosa por un umbral de
-  turnos. El conjunto de variantes fijadas = el diccionario de la koiné.
+> **Hallazgo (run 9bb920eb):** la competencia NO ocurre sola. Agrupar por glosa
+> dio CERO competencia — cada agente acuña para un concepto distinto (46
+> neologismos → 46 conceptos). Una koiné nace de una **necesidad referencial
+> compartida**: algo nuevo que VARIOS deben nombrar. Por eso la fijación vino en
+> dos piezas, no una.
+
+**(1) Inductor — eventos de nombramiento.** `REFERENTES_NOVEDOSOS` (10 cosas sin
+palabra caquetía: cuentas de vidrio, cometa, eclipse, metal amarillo, marea
+roja, bestia varada…). Cada ~4 turnos el orquestador presenta un referente a
+TODOS los agentes activos con el mismo `concepto_id` → acuñan formas rivales
+para el MISMO concepto.
+
+**(2) `CompetenciaLexica` — resolución.**
+- Cada variante acumula soporte = `frecuencia × prestigio` de quienes la usan
+  (`proponer` al acuñar, `registrar_uso` al reusar; los agentes de prestigio
+  anclan la norma).
+- `prompt_competencias()` surface las competencias abiertas en el prompt →
+  empuja a REUSAR una forma rival en vez de inventar otra (así una se impone).
+- Una variante se **fija** cuando domina su concepto (≥55% del soporte, soporte
+  mínimo). El conjunto de fijadas = el **diccionario koiné**, persistido en
+  `koine_lexicon`.
+- Validado (run dd1d0c9c): `cuentas_vidrio` → `kali-pica` fijada de 3 rivales.
 
 ### Guardarraíl (prerrequisito, no opcional)
 Si se refuerza frecuencia sin filtrar, la koiné fija basura española
@@ -175,14 +188,16 @@ corpus de topónimos reales del territorio.
 
 ## 9. Orden de implementación
 
-1. `EMOCIONAR` por agente (tier 1 primero) + inyección en el prompt.
-2. `IdiolectoAgente` + `CampoLexico` (estado por run) + pre-carga desde el emocionar.
-3. Inyección "tu manera de hablar" (reemplaza los snippets).
-4. Muestreo ponderado por frecuencia + decaimiento.
-5. Competencia/fijación de variantes por glosa.
-6. Métricas (distancia idiolectal, fijación) + persistencia.
-7. Activar agentes foráneos/periféricos en el loop.
-8. (Prerrequisito de calidad) compuerta de neologismos.
+1. ✅ `EMOCIONAR` por agente + inyección en el prompt.
+2. ✅ `IdiolectoAgente` + `CampoLexico` (estado por run) + pre-carga desde el emocionar.
+3. ✅ Inyección "tu manera de hablar" (reemplaza los snippets).
+4. ⏳ Muestreo ponderado por frecuencia + decaimiento (`CampoLexico` listo; falta
+   conectar los pesos a `muestra_caquetio_dinamica`).
+5. ✅ Competencia/fijación — vía eventos de nombramiento (no por glosa; ver §6).
+6. ✅ Métricas (distancia idiolectal + fijación) + persistencia (`koine_metrics`,
+   `koine_lexicon`).
+7. ✅ Población constante de participantes en el loop (`PARTICIPANTES_KOINE`).
+8. ✅ Compuerta de neologismos (fonotáctica: blocklist + marcadores + bigramas).
 
 ## 10. Referencias
 

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
@@ -403,6 +403,18 @@ class CurianaDB:
             on_conflict="run_id,day",
         ).execute()
 
+    def save_koine_lexicon(self, run_id: str, concepto_id: str, descripcion: str,
+                           form: str, fijada_dia: int,
+                           soporte: Optional[float] = None, n_variantes: Optional[int] = None):
+        """Persiste una entrada del diccionario koiné (forma fijada por
+        competencia para un referente nuevo). Upsert por (run_id, concepto_id)."""
+        self.client.table("koine_lexicon").upsert(
+            {"run_id": run_id, "concepto_id": concepto_id, "descripcion": descripcion,
+             "form": form, "fijada_dia": fijada_dia, "soporte": soporte,
+             "n_variantes": n_variantes},
+            on_conflict="run_id,concepto_id",
+        ).execute()
+
     # ── Phrase etymologies ────────────────────────────────────────────
 
     def save_phrase_etymology(
@@ -564,6 +576,7 @@ class CurianaDBMock:
         import uuid; return str(uuid.uuid4())
     def update_neologism_status(self, *a, **kw): pass
     def save_koine_metric(self, *a, **kw): pass
+    def save_koine_lexicon(self, *a, **kw): pass
     def save_phrase_etymology(self, *a, **kw): pass
     def latest_run(self): return None
     def language_drift(self, *a): return []

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
@@ -302,6 +302,135 @@ def prompt_idiolecto(idio: "IdiolectoAgente") -> str:
 
 
 # ══════════════════════════════════════════════════════════════════════
+# VI. FIJACIÓN POR COMPETENCIA — la koiné selecciona un nombre por concepto
+# ══════════════════════════════════════════════════════════════════════
+# Hallazgo (run 9bb920eb): la competencia NO ocurre sola — cada agente acuña
+# para un concepto distinto, así que no hay variantes rivales que fijar. Una
+# koiné, en cambio, nace de una NECESIDAD REFERENCIAL COMPARTIDA: aparece algo
+# nuevo que VARIOS deben nombrar, cada uno propone, y la comunidad fija una
+# forma. Por eso la fijación viene en dos piezas: (a) inducir la competencia con
+# "eventos de nombramiento" (REFERENTES_NOVEDOSOS), y (b) resolverla aquí.
+
+# Referentes sin palabra caquetía: cosas nuevas (contacto, novedad natural) que
+# la comunidad necesita nombrar. Cada uno dispara una competencia.
+REFERENTES_NOVEDOSOS: list[dict] = [
+    {"id": "cuentas_vidrio", "desc": "unas cuentas brillantes y duras que un mercader trajo de tierras lejanas, nunca vistas aquí"},
+    {"id": "cometa",         "desc": "una estrella con cola que cruza el cielo varias noches seguidas"},
+    {"id": "eclipse",        "desc": "el sol se oscurece en pleno día y luego vuelve, como si algo lo cubriera"},
+    {"id": "fiebre_manchas", "desc": "una fiebre nueva que llena la piel de manchas, que ningún piache había visto"},
+    {"id": "metal_amarillo", "desc": "un trozo de metal amarillo y pesado, distinto del oro conocido, llegado por trueque"},
+    {"id": "bestia_orilla",  "desc": "un animal enorme nunca visto, varado y muerto en la orilla del golfete"},
+    {"id": "marea_roja",     "desc": "el agua del golfete se tiñe de rojo durante días y mata a los peces"},
+    {"id": "tambor_caribe",  "desc": "un tambor de los caribe con un sonido grave y distinto a los nuestros"},
+    {"id": "planta_quema",   "desc": "una planta nueva que cura la herida pero quema la boca al probarla"},
+    {"id": "cuenta_insular", "desc": "una forma de contar el valor del trueque que enseñó el mensajero de las islas"},
+]
+
+
+class CompetenciaLexica:
+    """Acumula soporte (frecuencia × prestigio) de las formas rivales que
+    compiten por un MISMO concepto nuevo, y fija una como entrada koiné cuando
+    domina su concepto por encima de un umbral."""
+
+    def __init__(self, umbral_fijacion: float = 0.55, soporte_minimo: float = 3.0):
+        # concepto_id -> {desc, variantes: Counter(forma->soporte), fijada, fijada_dia}
+        self.referentes: dict[str, dict] = {}
+        self._forma2concepto: dict[str, str] = {}
+        self.umbral = umbral_fijacion
+        self.soporte_min = soporte_minimo
+
+    def _prestigio(self, agente: str) -> float:
+        try:
+            from curiana_social import prestigio_de
+            return prestigio_de(agente)
+        except Exception:
+            return 0.3
+
+    def activar(self, concepto_id: str, desc: str):
+        self.referentes.setdefault(concepto_id, {
+            "desc": desc, "variantes": Counter(), "fijada": None, "fijada_dia": None})
+
+    def proponer(self, concepto_id: str, forma: str, agente: str):
+        """Un agente acuña `forma` para `concepto_id` en un evento de nombramiento."""
+        ref = self.referentes.get(concepto_id)
+        if ref is None or ref["fijada"] or not forma:
+            return
+        ref["variantes"][forma] += 1.0 + self._prestigio(agente)
+        self._forma2concepto[forma.lower()] = concepto_id
+
+    def registrar_uso(self, forma: str, agente: str):
+        """Reuso posterior de una forma en competencia → suma soporte (más leve
+        que proponer). Es lo que hace que una variante gane sobre las otras."""
+        cid = self._forma2concepto.get((forma or "").lower())
+        if not cid:
+            return
+        ref = self.referentes[cid]
+        if ref["fijada"]:
+            return
+        ref["variantes"][forma] += 0.5 + self._prestigio(agente)
+
+    def evaluar_fijacion(self, dia: int) -> list[tuple[str, str]]:
+        """Fija las competencias donde una variante domina. Devuelve las recién
+        fijadas [(concepto_id, forma)]."""
+        nuevas = []
+        for cid, ref in self.referentes.items():
+            if ref["fijada"] or len(ref["variantes"]) < 2:
+                continue
+            total = sum(ref["variantes"].values())
+            forma, sup = ref["variantes"].most_common(1)[0]
+            if total >= self.soporte_min and sup / total >= self.umbral:
+                ref["fijada"] = forma
+                ref["fijada_dia"] = dia
+                nuevas.append((cid, forma))
+        return nuevas
+
+    def activas(self) -> dict[str, dict]:
+        return {cid: ref for cid, ref in self.referentes.items()
+                if not ref["fijada"] and ref["variantes"]}
+
+    def prompt_competencias(self, top: int = 4) -> str:
+        """Surface las competencias abiertas para que los agentes REUSEN una
+        forma rival en vez de inventar otra — así una se impone."""
+        lineas = []
+        for ref in self.activas().values():
+            formas = [f for f, _ in ref["variantes"].most_common(top)]
+            if formas:
+                lineas.append(f"{ref['desc']} → {', '.join(formas)}")
+        if not lineas:
+            return ""
+        return ("[La comunidad aún busca nombre para cosas nuevas. Si hablas de "
+                "alguna, ELIGE una de las formas que ya circulan, no inventes otra]:\n  "
+                + "\n  ".join(lineas))
+
+    def diccionario_koine(self) -> dict[str, dict]:
+        """{concepto_id: {desc, forma, dia, soporte, n_variantes}} de las fijadas."""
+        out = {}
+        for cid, ref in self.referentes.items():
+            if ref["fijada"]:
+                out[cid] = {
+                    "desc": ref["desc"], "forma": ref["fijada"],
+                    "dia": ref["fijada_dia"],
+                    "soporte": round(ref["variantes"][ref["fijada"]], 2),
+                    "n_variantes": len(ref["variantes"]),
+                }
+        return out
+
+    def reporte(self) -> str:
+        lines = ["\n  ── KOINÉ — fijación por competencia ──"]
+        fijadas = self.diccionario_koine()
+        lines.append(f"  Conceptos nombrados: {len(self.referentes)} | "
+                     f"fijados: {len(fijadas)} | en disputa: {len(self.activas())}")
+        for cid, d in fijadas.items():
+            lines.append(f"    ✓ {d['desc'][:42]:42} → {d['forma']}  "
+                         f"(de {d['n_variantes']} variantes, día {d['dia']})")
+        for cid, ref in self.activas().items():
+            top = ref["variantes"].most_common(3)
+            comp = ", ".join(f"{f}({s:.1f})" for f, s in top)
+            lines.append(f"    … {ref['desc'][:42]:42} ⚔ {comp}")
+        return "\n".join(lines)
+
+
+# ══════════════════════════════════════════════════════════════════════
 # Smoke test
 # ══════════════════════════════════════════════════════════════════════
 
@@ -332,4 +461,18 @@ if __name__ == "__main__":
     campo.registrar(comunes)
     campo.registrar(["taya", "para"])
     print(f"\n  campo léxico top: {campo.top(4)}")
+
+    # ── competencia: 3 agentes acuñan rivales para un concepto; uno gana ──
+    comp = CompetenciaLexica(soporte_minimo=2.0)
+    comp.activar("cometa", "estrella con cola")
+    comp.proponer("cometa", "kali-dusha", "Manaure")   # cacique, prestigio alto
+    comp.proponer("cometa", "suka-wana", "Tariwa")      # foráneo, prestigio bajo
+    comp.proponer("cometa", "kali-rua", "Kawa-ni")
+    # reuso: la forma del prestigioso se propaga
+    for _ in range(4):
+        comp.registrar_uso("kali-dusha", "Shaboro")
+    fij = comp.evaluar_fijacion(dia=5)
+    print(f"  competencia 'cometa' fijada: {fij}")
+    assert any(f == "kali-dusha" for _, f in fij), "debería ganar la forma del prestigioso reusada"
+    print(f"  diccionario koiné: {comp.diccionario_koine()}")
     print("  ✓ smoke test OK")

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -53,6 +53,8 @@ from curiana_social import (
 from curiana_koine import (
     IdiolectoAgente,
     CampoLexico,
+    CompetenciaLexica,
+    REFERENTES_NOVEDOSOS,
     emocionar_de,
     prompt_emocionar,
     prompt_idiolecto,
@@ -176,6 +178,7 @@ def call_agent(
     agent_memory: Optional[str] = None,
     difusion: Optional[DifusionLexica] = None,
     idiolectos: Optional[dict] = None,
+    competencia: Optional["CompetenciaLexica"] = None,
 ) -> str:
     agent = ALL_AGENTS.get(agent_name)
     if not agent:
@@ -237,6 +240,12 @@ def call_agent(
         system_parts.append(bloque_lexico)
     if sugerencia_contagio:
         system_parts.append(sugerencia_contagio)
+    # Competencias léxicas abiertas: empuja a reusar una forma rival que ya
+    # circula (en vez de inventar otra) → una se impone y se fija en la koiné.
+    if competencia is not None:
+        bloque_comp = competencia.prompt_competencias()
+        if bloque_comp:
+            system_parts.append(bloque_comp)
     # Idiolecto acumulado (entrenchment): "tu manera de hablar" derivada del
     # perfil de frecuencia del agente. Reemplaza/enriquece la memoria cruda.
     if idiolectos is not None and agent_name in idiolectos:
@@ -352,8 +361,18 @@ def run_turn(
     difusion: Optional[DifusionLexica] = None,
     idiolectos: Optional[dict] = None,
     campo: Optional[CampoLexico] = None,
+    competencia: Optional[CompetenciaLexica] = None,
+    naming_referente: Optional[dict] = None,
 ) -> list[dict]:
     interactions = []
+
+    # Evento de nombramiento: aparece un referente sin palabra caquetía y se
+    # presenta a TODOS los agentes activos este turno → acuñan formas rivales
+    # para el MISMO concepto (induce la competencia que la koiné luego fija).
+    naming_concepto: Optional[str] = None
+    if naming_referente and competencia is not None:
+        naming_concepto = naming_referente["id"]
+        competencia.activar(naming_concepto, naming_referente["desc"])
 
     # 0. Registrar turno en DB
     turn_id: Optional[str] = None
@@ -399,7 +418,16 @@ def run_turn(
         print(f"{'='*60}\n")
 
     # 2. Estímulo del turno
-    if user_input:
+    if naming_concepto:
+        stimulus = (
+            f"[ALGO NUEVO EN LA CURIANA]: {naming_referente['desc']}. "
+            f"Esto no tiene nombre en caquetío todavía. Nómbralo TÚ con morfemas "
+            f"caquetíos y dilo: [forma: componentes = significado]. Reacciona a la "
+            f"cosa nueva y nómbrala."
+        )
+        if verbose:
+            print(f"  ✦ NOMBRAMIENTO: {naming_referente['desc'][:60]}")
+    elif user_input:
         stimulus = user_input
     elif state.evento_del_turno:
         stimulus = f"[Situación]: {state.evento_del_turno}. ¿Cómo reaccionas?"
@@ -418,7 +446,7 @@ def run_turn(
         mem = memory.get(agent_name)
         response = call_agent(
             client, agent_name, state, lexico, observer, stimulus, mem,
-            difusion=difusion, idiolectos=idiolectos,
+            difusion=difusion, idiolectos=idiolectos, competencia=competencia,
         )
 
         interactions.append({
@@ -451,6 +479,18 @@ def run_turn(
                     difusion.propagar_uso(forma, agent_name, state)
             for neo in getattr(registro, "neologismos_extraidos", []):
                 difusion.propagar_uso(neo.forma, agent_name, state)
+
+        # Competencia léxica: en un turno de nombramiento, las formas acuñadas
+        # son variantes rivales del concepto presentado. En cualquier turno, el
+        # reuso de una forma ya en competencia le suma soporte (la hace ganar).
+        if competencia is not None:
+            for neo in getattr(registro, "neologismos_extraidos", []):
+                if naming_concepto:
+                    competencia.proponer(naming_concepto, neo.forma, agent_name)
+                else:
+                    competencia.registrar_uso(neo.forma, agent_name)
+            for forma in getattr(registro, "palabras_caquetias", []):
+                competencia.registrar_uso(forma, agent_name)
 
         # Koiné: actualizar idiolecto del agente (entrenchment) y campo léxico
         # comunitario (frecuencia para muestreo + métrica de convergencia).
@@ -589,6 +629,7 @@ def interactive_mode(client: anthropic.Anthropic):
         for nm, a in ALL_AGENTS.items()
     }
     campo = CampoLexico()
+    competencia = CompetenciaLexica()
 
     # Inicializar DB (gracefully degraded si no hay Supabase)
     db = get_db()
@@ -607,7 +648,8 @@ def interactive_mode(client: anthropic.Anthropic):
 
         if not user_input:
             run_turn(client, state, memory, lexico, observer, db=db, run_id=run_id,
-                     difusion=difusion, idiolectos=idiolectos, campo=campo)
+                     difusion=difusion, idiolectos=idiolectos, campo=campo,
+                     competencia=competencia)
         elif user_input.lower() == "salir":
             break
         elif user_input.lower() == "estado":
@@ -662,6 +704,7 @@ def interactive_mode(client: anthropic.Anthropic):
                 client, state, memory, lexico, observer,
                 user_input=user_input, db=db, run_id=run_id,
                 difusion=difusion, idiolectos=idiolectos, campo=campo,
+                competencia=competencia,
             )
 
     # Guardar todo
@@ -716,6 +759,13 @@ def auto_mode(
     serie_distancia: list[tuple[int, float]] = []
     participantes: set[str] = set()   # agentes que REALMENTE hablaron (para la métrica)
 
+    # Koiné: competencia léxica (fijación por significado). Cada ~4 turnos se
+    # introduce un referente novedoso sin nombre → varios agentes acuñan formas
+    # rivales → la comunidad fija una por frecuencia × prestigio.
+    competencia = CompetenciaLexica()
+    cadencia_nombramiento = 4
+    referentes_pendientes = list(REFERENTES_NOVEDOSOS)
+
     # Inicializar DB (CurianaDB real o CurianaDBMock si no está configurada)
     db = get_db()
     run_id = db.create_run(
@@ -736,10 +786,16 @@ def auto_mode(
     print(f"{'='*60}\n")
 
     for t in range(turnos):
+        # ¿Toca evento de nombramiento? (cada `cadencia` turnos, si quedan referentes)
+        naming_referente = None
+        if referentes_pendientes and t > 0 and t % cadencia_nombramiento == 0:
+            naming_referente = referentes_pendientes.pop(0)
+
         interactions = run_turn(
             client, state, memory, lexico, observer,
             verbose=verbose, db=db, run_id=run_id,
             difusion=difusion, idiolectos=idiolectos, campo=campo,
+            competencia=competencia, naming_referente=naming_referente,
         )
         participantes.update(i["agent"] for i in interactions)
 
@@ -749,15 +805,23 @@ def auto_mode(
             # Distancia medida SOLO sobre quienes hablaron (población real)
             dist = distancia_idiolectal(idiolectos, solo=participantes)
             serie_distancia.append((dia_terminado, dist))
+            # Evaluar fijación de competencias léxicas del día
+            fijadas = competencia.evaluar_fijacion(dia_terminado)
             if db and run_id:
                 try:
                     db.save_koine_metric(run_id, dia_terminado, dist, len(participantes))
+                    for cid, forma in fijadas:
+                        d = competencia.diccionario_koine().get(cid, {})
+                        db.save_koine_lexicon(run_id, cid, d.get("desc", ""), forma,
+                                              dia_terminado, d.get("soporte"), d.get("n_variantes"))
                 except Exception:
                     pass
             if verbose:
                 print(observer.reporte_dia(dia_terminado))
                 print(f"  ◇ Koiné — distancia idiolectal ({len(participantes)} agentes): "
                       f"{dist}  (↓ = converge hacia koiné)")
+                for cid, forma in fijadas:
+                    print(f"  ◆ Koiné fija: '{cid}' → {forma}")
 
         # Detección de cambio de estación
         if state.estacion != estacion_anterior:
@@ -808,6 +872,9 @@ def auto_mode(
     print("\n  Diccionario koiné emergente (formas más extendidas):")
     for forma, peso in campo.top(15):
         print(f"    {forma:18} {peso:.1f}")
+
+    # ── Fijación por competencia: el diccionario koiné de conceptos nuevos ──
+    print(competencia.reporte())
 
     if reporte_anual:
         print(observer.reporte_anual_llm(anio_simulado))

--- a/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260629120000_koine_lexicon.sql
+++ b/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260629120000_koine_lexicon.sql
@@ -1,0 +1,28 @@
+-- ══════════════════════════════════════════════════════════════════════
+-- KOINE_LEXICON — diccionario koiné por fijación de competencia
+-- Cuando varios agentes acuñan formas rivales para un MISMO referente nuevo
+-- (evento de nombramiento) y la comunidad fija una por frecuencia × prestigio,
+-- esa entrada se guarda aquí: el concepto, la forma ganadora, y de cuántas
+-- variantes salió. Es el producto del motor koiné — y el insumo de la fase de
+-- topónimos (un topónimo es un referente compartido que necesita nombre).
+-- ══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS koine_lexicon (
+  id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  run_id       UUID REFERENCES simulation_runs(id) ON DELETE CASCADE,
+  concepto_id  TEXT NOT NULL,        -- referente (cometa, metal_amarillo, ...)
+  descripcion  TEXT,                 -- qué es el referente
+  form         TEXT NOT NULL,        -- la forma koiné fijada
+  fijada_dia   INT,                  -- día simulado en que se fijó
+  soporte      FLOAT,                -- soporte acumulado (frecuencia × prestigio)
+  n_variantes  INT,                  -- de cuántas formas rivales salió
+  created_at   TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (run_id, concepto_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_koine_lexicon_run ON koine_lexicon(run_id);
+
+ALTER TABLE koine_lexicon ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read koine_lexicon" ON koine_lexicon FOR SELECT USING (true);
+
+GRANT ALL    ON koine_lexicon TO service_role;
+GRANT SELECT ON koine_lexicon TO anon, authenticated;


### PR DESCRIPTION
## Qué
Cierra el motor koiné: la comunidad ahora **selecciona un nombre por concepto** a partir de variantes rivales.

**Hallazgo:** la competencia no ocurre sola (cada agente acuña para un concepto distinto). Una koiné nace de necesidad referencial compartida → se induce.

- **Inductor:** `REFERENTES_NOVEDOSOS` (10 cosas sin nombre). Cada ~4 turnos un "evento de nombramiento" presenta un referente a todos los agentes activos → formas rivales para el mismo `concepto_id`.
- **`CompetenciaLexica`:** acumula soporte (frecuencia × prestigio), surface las competencias en el prompt (empuja reuso), fija la variante dominante (≥55%). Diccionario en tabla `koine_lexicon`.

## Resultado (run 20091e1f, 57T/29d)
- **Diccionario koiné de 7 conceptos** fijados: eclipse→`ma-kali-bana` ("orilla donde falta el sol", de 4 rivales), cometa→`kali-subo`, metal_amarillo→`sulu-pana`...
- Competencia genuina: Paugis-sha y Corie-ko acuñaron `kali-subo` independientemente → convergieron.
- Caquetío 99%, 41 neologismos, convergencia −45%, 0 fugas españolas.

## Verificación
- test_quick 8/8, smoke de competencia OK, run largo persistido.

## Pendiente
- Muestreo ponderado por frecuencia (único ⏳ del diseño koiné).
- El `koine_lexicon` es el insumo de la fase de topónimos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)