### PR TITLE
fix(simulador): regenerar seed del lexicón sin las 441 hipotéticas aisladas

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,9 @@
     {
       "name": "curiana-radio",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "-p", "3010"],
-      "port": 3010
+      "runtimeArgs": ["run", "dev"],
+      "port": 3010,
+      "autoPort": true
     }
   ]
 }

--- a/content/simulador/lexicon.json
+++ b/content/simulador/lexicon.json
@@ -361,15 +361,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "3614b905-1655-4aac-8b1e-9d7032ca1cef",
-      "word": "aaca",
-      "meaning": "entre",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "156a5aef-8a60-4b8d-bc96-877bae6a92fe",
       "word": "aainjala",
       "meaning": "acción mala",
@@ -397,15 +388,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "5ca77f8f-91fb-448f-a631-c506986c096b",
-      "word": "aaliyaua",
-      "meaning": "estar de parto",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a4631d66-8c7d-465b-9e4b-b3506fcca886",
       "word": "aaluwain",
       "meaning": "tobillo",
@@ -424,15 +406,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "73791232-1ebb-4367-b2d6-0e86389315c2",
-      "word": "aana",
-      "meaning": "armar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "879a31b8-cbae-4395-ab10-043d358d6a69",
       "word": "aanala",
       "meaning": "cobija",
@@ -440,15 +413,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "1c81172c-0c39-4c74-aa71-a31ee9e747e8",
-      "word": "aanaua",
-      "meaning": "aakkuuaaippa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "16d6c9c8-ff17-4911-8836-9a86e4fdeaab",
@@ -496,33 +460,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ee9004d7-dbb9-4137-bf53-e07a98f7080c",
-      "word": "aata",
-      "meaning": "a'anawaa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d56ec649-5151-4a30-9a4a-311db402deb7",
-      "word": "aatabaya",
-      "meaning": "esperar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "8459efcf-894b-4392-8386-54f292e61eff",
-      "word": "aatou",
-      "meaning": "al lado de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7c2254d4-d07c-499f-9a9e-e5d5cb9a53be",
       "word": "aawain",
       "meaning": "peso",
@@ -550,24 +487,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "a1391f12-a317-4dd0-8c8f-7b70dfa3591f",
-      "word": "aaya",
-      "meaning": "quemar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "432837ce-cea2-4b36-8d89-9900e2b2be39",
-      "word": "aayula",
-      "meaning": "calor, temperatura",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "fc52ab47-0ead-4b40-a334-a512943a2de1",
       "word": "aba",
       "meaning": "uno, un (numeral y artículo indefinido)",
@@ -577,42 +496,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "649ed774-cc2e-4602-807f-3f1b8218cef4",
-      "word": "abachera",
-      "meaning": "dedo (del pie)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1aa3e5cb-50ca-4f71-b7d7-75ce22371b31",
-      "word": "abalalaya",
-      "meaning": "ir de compras",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7f242f3a-8da4-46ed-b39e-887639dc68c8",
-      "word": "abalanayaua",
-      "meaning": "fluir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "730836c4-c665-43f1-942e-ee314cf55364",
-      "word": "abaliraya",
-      "meaning": "mezclar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "db62ea47-8c74-4278-949b-158d2e097a56",
       "word": "aban",
       "meaning": "uno",
@@ -620,51 +503,6 @@
       "source_language": "kalinago",
       "attested": false,
       "source_ref": "kalinago"
-    },
-    {
-      "id": "6875df33-0962-44d8-b020-7dec60b6d5f2",
-      "word": "abanabaya",
-      "meaning": "encontrarse con una",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e1b5ffe8-3e06-4719-96b2-c656c542781d",
-      "word": "abantayaua",
-      "meaning": "irse corriendo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3036af7e-22ea-4b92-9935-233e77e053c0",
-      "word": "abasiayaua",
-      "meaning": "hacer una visita",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "230abaf8-3d43-461c-8756-01a841bd390d",
-      "word": "abatou",
-      "meaning": "uña, garra, pezuña",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ccdfdf98-79da-4915-8dc8-e45b040a8856",
-      "word": "abaua",
-      "meaning": "tomar, coger",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "17a09994-51f7-4e20-8ae5-84fbf91c0828",
@@ -703,177 +541,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "40ce59f6-14d9-4c1a-b597-261654fd77dc",
-      "word": "abuchi",
-      "meaning": "familia, pariente",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e8b75c7c-a76e-4d1d-991b-6e0a04284cf2",
-      "word": "abula",
-      "meaning": "ser",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "5e0e2da9-bef8-4801-a78b-77ca1757890c",
-      "word": "abulabuna",
-      "meaning": "antes de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1eae9ff3-d459-4cda-9906-bd60b9738070",
-      "word": "abulaya",
-      "meaning": "prohibir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1cd346dc-0411-4727-8423-a1f660708662",
-      "word": "abule",
-      "meaning": "lugar, sitio, puesto",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4f27e514-c78d-4764-80fc-7cd7cd8e392f",
-      "word": "abulerua",
-      "meaning": "delante de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "b0a46eda-69ed-4c47-b431-59a977dd6065",
-      "word": "abulii",
-      "meaning": "tener vergüenza",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "96ba6290-6f01-43cb-8219-2c7c3778b858",
-      "word": "abuna",
-      "meaning": "camino, sendero",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "21ea5a37-94fe-4e91-945b-772a63a7f6f0",
-      "word": "abunaya",
-      "meaning": "sembrar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "acbfaa8a-f72a-4f5b-b7fe-0d7e7ebaae45",
-      "word": "abuta",
-      "meaning": "dejar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e5103832-3e88-4d5b-891d-339c6caf63bd",
-      "word": "abuu",
-      "meaning": "muslo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4acea921-22f3-4e6f-b877-c08f57e2a08c",
-      "word": "acachera",
-      "meaning": "colgar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c122818a-f9a3-4b8a-95a1-ad36ad08c937",
-      "word": "acaisaa",
-      "meaning": "pero, sin embargo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6b96efb5-819d-4f55-b2bd-6e0adc628aba",
-      "word": "acaiya",
-      "meaning": "fumar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "8abdc036-d02e-4a60-b53b-f59ac87be564",
-      "word": "acaluuya",
-      "meaning": "llenar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a7a8644c-3723-45c2-ad1c-ee34bb5c7345",
-      "word": "acanaya",
-      "meaning": "ganar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "20e6bcd6-84e9-4f27-b054-a7cfd3f47e08",
-      "word": "acata",
-      "meaning": "quitar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "9af16039-9c5c-4fa9-b88d-e935201e6b5b",
-      "word": "acatala",
-      "meaning": "separar, apartar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "9db7ed38-8347-40da-850c-79e8260af3f0",
-      "word": "acatalaua",
-      "meaning": "apartarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b9673645-9fda-49af-a878-2aa0b1a95e3d",
       "word": "acha'a",
       "meaning": "excremento",
@@ -881,33 +548,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "fa85edba-545d-4b32-a9ac-0b0d29e9d5c1",
-      "word": "achaa",
-      "meaning": "excremento",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7ead0444-774a-4d03-ba10-65882ebfb5c0",
-      "word": "achabataua",
-      "meaning": "preocuparse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d549ee4b-b8b8-4f5c-839e-795c7ea229e3",
-      "word": "achaitta",
-      "meaning": "jugar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "7768a7c5-b2f1-4895-8b51-79296f6b969a",
@@ -919,33 +559,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "a90e47d4-35a6-4921-a1db-33489e7d275f",
-      "word": "achata",
-      "meaning": "sanar (una herida)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1c08eb6a-be4c-4ef9-a30c-93c6ecba6261",
-      "word": "achaualaua",
-      "meaning": "ponerse de pie",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "856c0215-0785-40d5-bbcd-0dafd8bda210",
-      "word": "achayaua",
-      "meaning": "buscar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "50b6f8db-c849-4dbc-8549-38a8e05e43ec",
       "word": "ache'e",
       "meaning": "oreja, oído",
@@ -955,24 +568,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "feee5c9e-1aba-4d37-84da-e22658326b60",
-      "word": "achebu",
-      "meaning": "pintura para la cara",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f8bb0aa8-f65d-43b7-a0e1-7f429d4acfd9",
-      "word": "achechera",
-      "meaning": "apretar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a8a9c2b2-6dc4-42f5-b954-12c0672a5483",
       "word": "achecheraa",
       "meaning": "apretar",
@@ -980,33 +575,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "46ae813a-12df-4a40-b2de-76175cdab7c7",
-      "word": "achee",
-      "meaning": "oreja, oído",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6fccea16-3836-4f13-8c06-bf7c3e75e22a",
-      "word": "acheeta",
-      "meaning": "golpear, patear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "914690d2-cea1-4b24-8735-0ce8636edf56",
-      "word": "acheeyiraua",
-      "meaning": "pelear con puños",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "954a6231-ab9c-4b66-ae0f-3c14add8d537",
@@ -1063,42 +631,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "241fa913-8407-403e-9b3a-d37379625b0f",
-      "word": "achichiyaua",
-      "meaning": "enojarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "703833cf-a5a8-4afa-9ea1-82da4c54e890",
-      "word": "achiciruu",
-      "meaning": "después de la salida aikkaa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "54b54cd6-7e85-4c32-a214-1d2a11711f27",
-      "word": "achiciye",
-      "meaning": "después de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e7fb21e1-fe69-4fe9-b77b-fcfde12ba663",
-      "word": "achicu",
-      "meaning": "soltar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ea98bd88-e469-4273-a928-9ae0914a5b1c",
       "word": "achiirua",
       "meaning": "detrás de",
@@ -1106,15 +638,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "285ed7d8-d9bc-484d-9f8e-de0df97b8708",
-      "word": "achiita",
-      "meaning": "orinar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "e57977e2-ea48-48ef-bcc3-1f3910a0c280",
@@ -1171,24 +694,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b3f7fb23-932a-44c2-a470-61da32ecd07e",
-      "word": "achimia",
-      "meaning": "suegro (de varón)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3b94cd3f-3936-4435-98c3-2d6e4a29b2f1",
-      "word": "achin",
-      "meaning": "según",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7a6c6251-12cb-41c0-8058-3e6fb854eb23",
       "word": "achira",
       "meaning": "seno",
@@ -1207,15 +712,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b50103e3-263b-4192-8c7e-c319b6233531",
-      "word": "achita",
-      "meaning": "martillar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "2392b284-05b0-47db-9873-3b8e120e0783",
       "word": "achitaa",
       "meaning": "martillar",
@@ -1223,42 +719,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "b60d9075-1baf-4842-bdd0-82bdcd1ec832",
-      "word": "achiyachi",
-      "meaning": "padrastro",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "08b435ff-4e55-46c6-a74d-4ef1264aa044",
-      "word": "achiyaua",
-      "meaning": "lavar (ropa)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "552c2f25-1fc3-48e6-aa7e-8ac7f4de4452",
-      "word": "achiyira",
-      "meaning": "despertar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "eb647ceb-5438-4547-b50f-bcc6c16c9134",
-      "word": "achiyiraua",
-      "meaning": "despertarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "7800fe6d-c78d-448f-b249-1d635b213ec3",
@@ -1279,15 +739,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "1e108097-ab75-40d5-8fa6-eca836945ab3",
-      "word": "achoniru",
-      "meaning": "sobrino, -na",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "961bf146-c0eb-4080-9693-8990d9621164",
       "word": "achu'laa",
       "meaning": "besar",
@@ -1295,15 +746,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "2a82c53a-b863-4eea-a82e-466027de2d41",
-      "word": "achucuta",
-      "meaning": "pisar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "f827042b-bcaa-425d-9c84-ee77bfa2c77f",
@@ -1315,15 +757,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "82f4845c-4633-4680-a43d-3585ca3b8663",
-      "word": "achula",
-      "meaning": "besar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "4420b055-f886-45c1-9919-3f23b09b8193",
       "word": "achumajaa",
       "meaning": "estar aiwaa",
@@ -1331,24 +764,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "d6477e2a-6468-4751-82cd-56e8fd9d81ce",
-      "word": "achumaya",
-      "meaning": "estar aiwaa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "550644c9-c4ba-4223-992e-eaee92f6857f",
-      "word": "achunta",
-      "meaning": "pedir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "d33fdb0a-7226-475d-a3d6-fb4a66712147",
@@ -1360,33 +775,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "502de946-fb82-4e53-ad7d-0b86f59b65a5",
-      "word": "achunuu",
-      "meaning": "hermana menor (de varón)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e2f91ca3-9ce2-45a5-87e6-9724ab0c0951",
-      "word": "achuta",
-      "meaning": "meterse, entrar a la",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4c526a43-e131-4dd8-96b0-11872467e170",
-      "word": "achuuua",
-      "meaning": "ser agrio, -a",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "d38b93ea-560a-4de0-a28f-ee913884fab5",
       "word": "acoa",
       "meaning": "pie",
@@ -1394,42 +782,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taino"
-    },
-    {
-      "id": "dc000492-a8df-46ce-8be0-e8d6c57e3841",
-      "word": "acotchaya",
-      "meaning": "ajurulajaa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4cb075b3-31c4-4b1d-9f69-c198f944da68",
-      "word": "acunula",
-      "meaning": "masticar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "30806de3-ddaf-4eca-993b-e9494815036d",
-      "word": "acurula",
-      "meaning": "tener frío",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "27817111-f5fb-4529-b637-ec32e2af8503",
-      "word": "acutcuyaua",
-      "meaning": "temblar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "a60fb06b-5f44-4f15-b54f-a8b703bb2f56",
@@ -1513,15 +865,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "85fc75b3-5b16-4cb1-a30f-916796f4b8a3",
-      "word": "aikcalaua",
-      "meaning": "sentarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "334a59b0-ed4b-4813-b553-50c3d09d5386",
       "word": "aikkalawaa",
       "meaning": "sentarse",
@@ -1529,24 +872,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "59e28eaf-2c92-45b6-a88e-79d9059c6d38",
-      "word": "ainra",
-      "meaning": "hacer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "8d3b0d1f-6915-4f2d-9570-5ad17cf6bd74",
-      "word": "ainyaya",
-      "meaning": "colgar una hamaca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "dc4864cd-b2cf-45d3-aff2-406c01853871",
@@ -1576,15 +901,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "94a9396a-41a6-4438-a2a7-36e392a78e88",
-      "word": "airu",
-      "meaning": "tía (materna)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "0eece3ea-bae6-4a51-a7ce-7146cf8921d8",
       "word": "airu'u",
       "meaning": "en la horqueta de, entre",
@@ -1594,15 +910,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "403f5b44-079f-4ba6-bc9f-7bd46d7b40ca",
-      "word": "airuu",
-      "meaning": "en la horqueta de, entre",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "48fa99c7-a73a-4104-8297-9ea01e3d8a2c",
       "word": "aithi",
       "meaning": "hijo (término de parentesco inalienable)",
@@ -1610,24 +917,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "3093b87c-7dd1-4fcb-8369-2cfe1c9739e6",
-      "word": "aiua",
-      "meaning": "estar caliente",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f51a3f92-9db1-4c9e-9577-50672ae07c72",
-      "word": "aiyaua",
-      "meaning": "faltar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "5c6feb99-5d5b-4fd6-b8c4-2c90573a89c9",
@@ -1972,15 +1261,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "772a932d-46a1-4349-92e2-6e75eb42af3d",
-      "word": "aktutayaua",
-      "meaning": "sufrir un ataque",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "2bc19671-1f45-47da-b174-91f130207fe9",
       "word": "akua",
       "meaning": "viaje",
@@ -2035,15 +1315,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "9d2a9e56-95fe-4be4-b7cc-d81c00fee5a0",
-      "word": "ala",
-      "meaning": "dónde estar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b5373d11-827e-4624-a295-d1353ebbc25c",
       "word": "alaain",
       "meaning": "amor, afecto, querer profundo (raíz raka-)",
@@ -2051,15 +1322,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki/lokono"
-    },
-    {
-      "id": "87e92f6b-8dbd-4c0a-a8bb-92bf4abb2bdd",
-      "word": "alabaya",
-      "meaning": "lamentar la muerte de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "a10b80fe-9be4-4acc-96d0-2f131d2468de",
@@ -2089,24 +1351,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "073b01b0-e442-4cab-abf9-44952ca38607",
-      "word": "alechi",
-      "meaning": "cuñado (de mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "50a874fb-5476-4897-87df-de0a6fcd282c",
-      "word": "aleeruu",
-      "meaning": "en el vientre de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "26b9bd8f-af79-4b21-b503-4d2aefe359e6",
       "word": "aleewaa",
       "meaning": "tener amistad",
@@ -2134,15 +1378,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "577b9526-1c0c-4075-aa64-b25103b561e8",
-      "word": "aleraya",
-      "meaning": "sentir asco por",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a1a7a77a-5929-4f80-bb2b-c6ef6de9d9ba",
       "word": "aleshi",
       "meaning": "cuñado (de mujer)",
@@ -2150,15 +1385,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "ecfdae8c-1a50-45ab-acd6-c56efb1c0e9c",
-      "word": "aleua",
-      "meaning": "tener amistad",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "f6f1ae22-6e68-4c78-acb9-163f22472b15",
@@ -2170,24 +1396,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "6bac649d-7213-43b9-95ce-3a34e5141572",
-      "word": "alican",
-      "meaning": "quién (interrogativo)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "af9a9e6f-0fa9-420a-b6f2-198356729577",
-      "word": "aliicayaua",
-      "meaning": "subir, subirse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "23cef4d3-14f7-4099-b343-5e84e1662427",
       "word": "aliichajaa",
       "meaning": "ordeñar",
@@ -2195,15 +1403,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "a5f3c8f7-0b4f-473c-9201-99c6970b0f37",
-      "word": "aliichaya",
-      "meaning": "ordeñar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "43e992c0-f0b3-48fe-87d6-b6c45b1f9617",
@@ -2323,15 +1522,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "4cb7a04b-7a87-4f77-ad2d-facb647239f4",
-      "word": "aluin",
-      "meaning": "nieto, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "83ff8276-b124-4cb2-821f-a414ed1bc784",
       "word": "alüin",
       "meaning": "nieto, -ta",
@@ -2339,15 +1529,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "bc78242c-accc-450a-bdbc-540ed22a4f25",
-      "word": "aluinyuu",
-      "meaning": "cuñada (de varón)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "6a7b796c-f90b-4c4f-a6a6-a5c8cc52eacf",
@@ -2377,33 +1558,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "831c6f9f-5cd5-4b1d-b5e8-35af6fa426e6",
-      "word": "aluu",
-      "meaning": "dentro de, en",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "78e761ba-542c-4ae5-984c-d76170a46ff0",
-      "word": "aluuain",
-      "meaning": "tobillo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "edc5f9b6-a246-4ccd-918f-f27344870316",
-      "word": "aluuuain",
-      "meaning": "pecho",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "f2ddf8c1-c11b-4dc2-880c-09bc954fbdd2",
       "word": "aluuwain",
       "meaning": "pecho",
@@ -2411,33 +1565,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "cfa74a71-4ae8-4a7a-8898-5812f104f281",
-      "word": "aluuya",
-      "meaning": "llevar, cargar, traer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c800df05-f2e7-4d4b-80c1-7dac9a6049f6",
-      "word": "aluuyasaa",
-      "meaning": "pero",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6a01cd7e-fc8e-4c6a-a13e-157450bfa12c",
-      "word": "aluya",
-      "meaning": "rastrear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "a61a64a5-023f-4f10-805f-0938c1466b53",
@@ -2485,33 +1612,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "60937de1-aa4c-4844-bf79-c8411b6f5258",
-      "word": "amaichici",
-      "meaning": "antes",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "87280013-1592-463b-abed-82aa70dbeb78",
-      "word": "amainruu",
-      "meaning": "mientras",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f0a91b26-c3c4-4af3-a8e0-3d58a81cfc21",
-      "word": "amama",
-      "meaning": "ser liviano, -na",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a4d8da41-80dc-43d5-9af4-73e233d398e8",
       "word": "amana",
       "meaning": "fuego, lumbre, brasa",
@@ -2548,15 +1648,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "3a68e07c-470e-41d1-b6e7-b218cef769ac",
-      "word": "amausiya",
-      "meaning": "domar, amansar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "0ea29e72-c279-4ff6-ae5f-dc50419024ab",
       "word": "amojujaa",
       "meaning": "dañar, perjudicar",
@@ -2575,15 +1666,6 @@
       "source_ref": "kalinago-caribe-overlay"
     },
     {
-      "id": "434167ec-be35-47a1-ae7a-fbf42728fd38",
-      "word": "amoyuya",
-      "meaning": "dañar, perjudicar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "4e541aa3-c67e-4b3a-a67f-b516bbe58fb6",
       "word": "amüchi",
       "meaning": "múcura (vasija de barro",
@@ -2591,15 +1673,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "89f4197e-e968-45ea-85a5-2041be48271f",
-      "word": "amuin",
-      "meaning": "a, para",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "fe89004f-9ae0-4062-a8a5-f3f45f0fe1ed",
@@ -2629,24 +1702,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "74c59b62-187a-48b4-86fc-e449d39e3cce",
-      "word": "amuliaya",
-      "meaning": "compadecerse de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c955b086-f63d-4e52-bca0-99d3ecbbcf07",
-      "word": "amulira",
-      "meaning": "vello",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "15313b13-8d5f-4889-9d69-97cd97b59d34",
       "word": "amülira",
       "meaning": "vello",
@@ -2654,15 +1709,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "7941ef1b-50ed-4737-be4e-ba7af3b7698a",
-      "word": "amuloulii",
-      "meaning": "perderse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "58fb74da-1522-4e16-88f9-b6f03577fe6c",
@@ -2683,24 +1729,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "1aca8ba0-f7c2-4aab-aff4-81af0e676a8e",
-      "word": "amurayuin",
-      "meaning": "novio, -via",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3e7d0257-3797-4082-a6ca-14775f60ce31",
-      "word": "amusain",
-      "meaning": "humo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "9acac5ec-757e-40a2-a38b-4ef7f39148fa",
       "word": "amüsain",
       "meaning": "humo",
@@ -2719,15 +1747,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "41bf20cf-2b11-42dd-94ef-4d25a343a8c1",
-      "word": "amuscheya",
-      "meaning": "atragantarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "4434a3c7-2c74-42a7-adc8-59235bb4c8f0",
       "word": "amuuyuu",
       "meaning": "cementerio",
@@ -2735,15 +1754,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "be9d9941-c86f-40bf-8b2d-025cded39c0a",
-      "word": "amuya",
-      "meaning": "ayunar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "71fdae12-0390-408a-829d-43ba0434ebe1",
@@ -2782,33 +1792,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ae826ee2-bb2c-49d3-a647-e376347a7611",
-      "word": "anaca",
-      "meaning": "alumbrar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "93c12538-2a60-4df6-8329-57babb2d9737",
-      "word": "anacan",
-      "meaning": "centro, punto medio (concepto espacial)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "eebaa5b1-0532-4bb2-a72d-a55cffab4cf2",
-      "word": "anachonba",
-      "meaning": "ser bonito, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7b50d1c5-7517-405b-82c8-3d3d90fd0f0f",
       "word": "anachonwaa",
       "meaning": "ser bonito, -ta",
@@ -2827,15 +1810,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b0a7e2b7-0e9b-4a97-9b07-0583db0d621d",
-      "word": "anainje",
-      "meaning": "de, por",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "f682443f-de01-4088-b845-aea74cb1bc57",
       "word": "anainjee",
       "meaning": "de, por",
@@ -2843,15 +1817,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "db7e8a73-151f-4475-a457-b9b15ade8bdb",
-      "word": "anainmuin",
-      "meaning": "a, hacia",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "0a9b40a6-c622-46a6-96a5-695716ec4c9e",
@@ -2881,15 +1846,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b72dab5d-dd2d-4bbe-a56e-e98d060f2140",
-      "word": "analaua",
-      "meaning": "averiguar qué es",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "f23e3279-7b86-45c5-8924-e96c9ec7a67e",
       "word": "analawaa",
       "meaning": "averiguar qué es",
@@ -2897,15 +1853,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "be8d8820-6ad7-471d-a2be-5ce8d0124743",
-      "word": "analu",
-      "meaning": "estar mejor de salud",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "ac8b8e30-5b14-48f7-a78d-bd3acad0948d",
@@ -2935,15 +1882,6 @@
       "source_ref": "wayunaiki-cogn"
     },
     {
-      "id": "eb7c043b-aafc-4a2a-8633-d5e922ab9326",
-      "word": "anaya",
-      "meaning": "mirar, observar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "560be903-ee81-4036-b0a2-e1195ab01088",
       "word": "andyn",
       "meaning": "llegar, arribar",
@@ -2951,15 +1889,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "f7804b03-45bc-4e8d-b961-0f9f17e052d9",
-      "word": "aneca",
-      "meaning": "escoger",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "e560372b-f68a-4e09-b42b-1905a63d4095",
@@ -3016,15 +1945,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "5cb2ee87-d787-4175-a0db-2161450752e4",
-      "word": "anoi",
-      "meaning": "terreno despejado",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "db95b292-f0ef-4704-a6b3-e50a60dbc3e7",
       "word": "anooi",
       "meaning": "terreno despejado",
@@ -3041,15 +1961,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "7e171d49-295e-4ffe-8628-6f7de48425f4",
-      "word": "anoukta",
-      "meaning": "corregir, arreglar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "f9c77854-cb34-4919-9220-32eb8dd89279",
@@ -3079,15 +1990,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "37b7bd4b-16c9-4251-ba3a-f9dc572a3a1c",
-      "word": "antira",
-      "meaning": "traer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "63688717-3d1a-4aef-877f-53e3385e46cc",
       "word": "antiraa",
       "meaning": "traer",
@@ -3095,15 +1997,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "4af2c753-9239-4436-979d-47a43e23e545",
-      "word": "anucu",
-      "meaning": "boca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "08373e8f-c7b3-4771-8518-9f5f4139ef14",
@@ -3140,15 +2033,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "f4da7e7d-f217-4f8c-8499-aa4b04bef5fe",
-      "word": "apa",
-      "meaning": "uno, un (numeral y artículo indefinido)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "55639b4d-0f62-4f24-a5c8-668936afd1f2",
@@ -3430,15 +2314,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "9b5cdf98-b87c-4424-a60d-b18b485e9616",
-      "word": "aralaya",
-      "meaning": "dejar en remojo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "fb4672cf-2d67-4801-91e7-f24ed88017a1",
       "word": "areito",
       "meaning": "areíto, danza ritual narrativa, celebración colectiva",
@@ -3475,15 +2350,6 @@
       "source_ref": "caquetío-reconstruido"
     },
     {
-      "id": "15d90c0b-63ad-4d66-b0ea-9be201ba3090",
-      "word": "asabu",
-      "meaning": "espalda, columna",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ed96ebc3-04ca-4365-ab03-453e38df1f01",
       "word": "asala",
       "meaning": "a causa de, por",
@@ -3500,15 +2366,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "6d6689ce-11c7-44ab-8814-9152160d3584",
-      "word": "asalaya",
-      "meaning": "afilar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "876f7086-9731-4564-aec1-bf4b1d3261ce",
@@ -3545,24 +2402,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "065089e8-6956-4ce9-a2f0-30d9eb6d1f24",
-      "word": "asebu",
-      "meaning": "pared",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e97cfb97-82b2-4aa2-8b2a-a10d1f392dfb",
-      "word": "aseeruu",
-      "meaning": "mitad, cintura",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "c5788c08-e14c-4e01-bebb-70075bb9399d",
@@ -3781,15 +2620,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "0ac5025b-c1cd-4d3c-abdb-a4c082dbe600",
-      "word": "asibala",
-      "meaning": "cicatriz",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "650603a0-51aa-440f-9206-015d27c92f60",
       "word": "asii",
       "meaning": "flor",
@@ -3815,15 +2645,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "b343cd27-0cdd-42eb-8247-6e04ec8dd4f0",
-      "word": "asiiyayaua",
-      "meaning": "ensillar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "d250c359-523b-40cc-8bc2-76024091ea9f",
@@ -3880,24 +2701,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "8c9c0f02-8b4d-4561-b909-70685cec3ce1",
-      "word": "asiranayaua",
-      "meaning": "resbalarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6ff634ed-3c68-4d93-9536-3df86a49e043",
-      "word": "asiraya",
-      "meaning": "reirse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "33efe979-d6af-4ad6-9231-4282bd8b8442",
       "word": "asirü",
       "meaning": "presa",
@@ -3907,15 +2710,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "1592e796-b2c9-413a-a40b-92a61e166c25",
-      "word": "asiuata",
-      "meaning": "desatar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ecdf7870-d825-48e2-b984-2ed13229ff53",
       "word": "asiwataa",
       "meaning": "desatar",
@@ -3923,24 +2717,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "7d328d0e-be22-4208-9105-b8394f6cf8b7",
-      "word": "asiya",
-      "meaning": "asar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0e0f51f3-c49d-4a94-95be-02cc42ccad24",
-      "word": "asoukta",
-      "meaning": "responder",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "c25ef45e-d210-44b3-a51e-16b79f0f9f3c",
@@ -3961,24 +2737,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "0df8657b-8041-4694-8d20-e28ca47078ba",
-      "word": "asuca",
-      "meaning": "recoger leña",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "76e51eb6-8048-4bbc-b3c8-a5be145382e1",
-      "word": "asucuita",
-      "meaning": "rasgarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "1aeff375-e439-4c5f-855d-bdc5d5c01127",
       "word": "asukaa",
       "meaning": "recoger leña",
@@ -3997,15 +2755,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "d256448a-74fc-4b1e-8b38-63f1e751c53c",
-      "word": "asuuta",
-      "meaning": "arrancar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "93671c53-5693-4d49-87eb-113b8d8d4668",
       "word": "ataa",
       "meaning": "atragantarse",
@@ -4022,15 +2771,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "44bae192-9721-4e3d-a5ea-7144f9f08b1a",
-      "word": "atamaua",
-      "meaning": "levantarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "da0e4a64-7a0a-4a43-964e-7799adb83b4f",
@@ -4058,24 +2798,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "d7cb0f68-43b1-4b5d-bb67-95af26afda60",
-      "word": "atauyaua",
-      "meaning": "violar (a una mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1a183c9a-0f7e-4d5b-8dd1-9c5baa9233ff",
-      "word": "atcaua",
-      "meaning": "pelear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "69abd5dc-4dad-46cf-9f4a-cc6eabe08adc",
@@ -4114,15 +2836,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ed7a90ab-9d8e-4ecf-bb6e-4e1996901875",
-      "word": "atpaya",
-      "meaning": "recolectar (alimento)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "8c508563-287c-4a06-aa8f-8eaa89b34127",
       "word": "atsüin",
       "meaning": "fuerza",
@@ -4139,15 +2852,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "a21737a1-a872-4fee-bd58-174142a07aa8",
-      "word": "atucaua",
-      "meaning": "atascarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "2ae88ef3-392f-4cc7-959e-d398f242e061",
@@ -4177,15 +2881,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "68901258-6fff-4cfd-a51a-a8704cc38a68",
-      "word": "atuma",
-      "meaning": "por",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "75d63edd-7d80-4406-bb9f-88d9ccaaaa91",
       "word": "atüma",
       "meaning": "por",
@@ -4193,15 +2888,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "b06bdac7-0a7f-4e02-b258-04c14277e8ea",
-      "word": "atuna",
-      "meaning": "brazo, ala",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "5b4be0f1-7e40-4a81-bcd5-2fca916e00c1",
@@ -4222,24 +2908,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "28bd28c4-ad63-4cbf-b421-9e7e677891c1",
-      "word": "atunayutu",
-      "meaning": "amigo, -ga",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "35dff97e-e427-438c-a3e8-d12773f613a1",
-      "word": "aturula",
-      "meaning": "trueno, paso",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "52bb267d-5fcb-495c-bda2-016eb1482722",
       "word": "atürüla",
       "meaning": "trueno, paso",
@@ -4258,33 +2926,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "f05aa3aa-9e82-4fcd-b366-18f68992e0df",
-      "word": "atutuya",
-      "meaning": "animar, ayolojo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "09133c52-0b52-4b1e-beec-e2840b798257",
-      "word": "atuu",
-      "meaning": "superficie interior",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "041e4dad-5492-401c-b278-8bf07317b567",
-      "word": "atuuchi",
-      "meaning": "abuelo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "c52125f0-6e94-4869-8bf1-1a48213f9ddc",
       "word": "atuushi",
       "meaning": "abuelo",
@@ -4292,213 +2933,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "b76535c8-19ad-4bed-8853-18514849f8ce",
-      "word": "atuya",
-      "meaning": "saber",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d91509d1-df9b-43f6-80ca-3085d0689d5c",
-      "word": "au",
-      "meaning": "en",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "bc88ef9f-423a-4cb2-8ed8-772b9b73ec09",
-      "word": "aua",
-      "meaning": "saliva",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "eb4facea-ceac-494d-98c5-13dfd770f3ef",
-      "word": "auaaua",
-      "meaning": "estar flojo, -ja",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6620007e-a084-4aad-9e4e-e86cc216275e",
-      "word": "auala",
-      "meaning": "cabello",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "17116f1b-067d-47d7-8413-7780cf521924",
-      "word": "auala-2",
-      "meaning": "hermano, -na",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ae0d4ec9-a7d8-4797-91f1-400bd1150e4d",
-      "word": "auala-3",
-      "meaning": "aflojar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "b2a73d47-a6c1-43ff-b491-43b2f10e5b89",
-      "word": "aualabaa",
-      "meaning": "mejilla",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0271ea5f-212b-449b-b570-c7dcd5f7e8fc",
-      "word": "aualacaya",
-      "meaning": "dispersar, esparcir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "31a70bb8-af8a-447e-8e56-7f647e57d89c",
-      "word": "aualainse",
-      "meaning": "mandíbula, quijada",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "395db35b-ca44-4f96-aa80-cebb4e1ebbc7",
-      "word": "aualaua",
-      "meaning": "aliviarse, mejorarse (fuego)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0fae4b02-41ae-4b3f-88d9-7ec9168de202",
-      "word": "auanayaua",
-      "meaning": "cambiar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "98c61c03-83ab-4c3c-9c26-35fc9d6271db",
-      "word": "auarala",
-      "meaning": "luz",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "65aece07-8156-4f49-8f1d-80e2da5276d6",
-      "word": "auareya",
-      "meaning": "barrer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "38c4ef07-4f2a-4e1e-b336-3aa1e41b2f18",
-      "word": "auata",
-      "meaning": "gritar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "73128536-bc5f-4448-99f4-3e98d322bde8",
-      "word": "auata-2",
-      "meaning": "ser pesado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "107ee8d6-f30c-4c7e-a203-f538966b5a6a",
-      "word": "auataua",
-      "meaning": "jactarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7268f243-fc81-42c2-9d25-a8ac432c2845",
-      "word": "auataua-2",
-      "meaning": "correr",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a4ba3be2-56df-49f0-99e6-e521bf0a10af",
-      "word": "auaya",
-      "meaning": "alabar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1d19d4c9-48de-4ba2-8bec-ecdae5913152",
-      "word": "auayaua",
-      "meaning": "rajarse, partirse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e4650514-bead-495a-a1c0-47aa211da2b4",
-      "word": "auayuuse",
-      "meaning": "esposo, -a",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fc6101e9-a3b2-4a73-a6ad-0302002397d4",
-      "word": "aui",
-      "meaning": "suegro (de mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "cf213061-f33f-43a6-8df9-8869366aec0d",
-      "word": "auiira",
-      "meaning": "lágrima",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "ef2cf1e8-4e21-47d0-82aa-c5bdf717f571",
@@ -4528,51 +2962,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "f388aa56-c484-41b6-a1e2-d0e5f8f41a03",
-      "word": "aulu",
-      "meaning": "suegra (de mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "899f9b2a-a450-49fe-8091-2a72f9436bf7",
-      "word": "auluya",
-      "meaning": "regañar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "146ecc6f-89dc-4ef9-b22f-3219e02b6620",
-      "word": "auluyiraua",
-      "meaning": "discutir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2dfa789d-1451-4030-abbf-b4ac085da24a",
-      "word": "aunu",
-      "meaning": "enemigo, -ga",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "596a31d7-1b43-43c6-a9fc-8d68026e6085",
-      "word": "aurula",
-      "meaning": "estar flaco, -ca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "9ab6fbb4-6eb6-48b7-8557-0810ad506704",
       "word": "aürülaa",
       "meaning": "estar flaco, -ca",
@@ -4582,33 +2971,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "f6ded428-b7d5-40c1-8c81-4cb362a82754",
-      "word": "aurulaua",
-      "meaning": "odiar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "03321004-343b-4d32-9ca1-3e185e671cf9",
-      "word": "autpaa",
-      "meaning": "al lado de, junto a",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1a5b8a14-153b-4e88-9c1b-1915484e296c",
-      "word": "auya",
-      "meaning": "cortar (el pelo), afeitar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a3a088fd-b635-455b-a1b1-3c2b2d0d3b58",
       "word": "auyama",
       "meaning": "auyama, calabaza (Cucurbita maxima)",
@@ -4616,15 +2978,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "0a96c505-5072-4855-bc37-2936b61d98db",
-      "word": "auyaua",
-      "meaning": "matar (ganado)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "6df37faa-ce00-454a-a4eb-9912873c336d",
@@ -4735,15 +3088,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "86d59c33-2c85-4988-b4d8-3a6b66c3acfd",
-      "word": "awothici",
-      "meaning": "encontrar, hallar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ab65ba58-e117-4fd4-b4b7-a265940379d3",
       "word": "awothiki",
       "meaning": "encontrar, hallar",
@@ -4751,33 +3095,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "365677aa-a22b-436c-b644-a2c016225361",
-      "word": "aya",
-      "meaning": "relámpago",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ca4d1716-35ec-4449-9c9f-fce056abe302",
-      "word": "aya-2",
-      "meaning": "aparecer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0ea6926f-df47-4f91-aed6-b599f301ff22",
-      "word": "aya-3",
-      "meaning": "ser barato, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "4a52a703-2abb-4488-888c-cdf00b446092",
@@ -4825,24 +3142,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "c5ce2850-43c7-484b-8380-3edf9dc98ec0",
-      "word": "ayabuluuua",
-      "meaning": "estar a cargo de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "65ec2977-17f7-4f7b-aca1-69b3231b2365",
-      "word": "ayabuya",
-      "meaning": "coser",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a1c9665d-91f1-4887-ab47-26f1d6a19f41",
       "word": "ayahaddin",
       "meaning": "caminar, andar",
@@ -4852,15 +3151,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "4002e0aa-00fb-435c-bf6b-31fa0c538e7d",
-      "word": "ayaita",
-      "meaning": "recoger agua",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "cf051abb-48ef-46d4-924d-5f6acb1f491b",
       "word": "ayalajaa",
       "meaning": "comprar",
@@ -4868,42 +3158,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "29387abd-ffff-49b4-b038-d67d78812509",
-      "word": "ayalaya",
-      "meaning": "llorar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7525ecff-e88b-4c0a-8367-ba19ad20435c",
-      "word": "ayalayaua",
-      "meaning": "terminarse, agotarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "40598d25-e06a-4982-bbdd-b4b26565e232",
-      "word": "ayalayeera",
-      "meaning": "agotar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2b04b8b5-062d-4560-a6b1-a7eee3edba3a",
-      "word": "ayalera",
-      "meaning": "levantar, alzar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "689dc5a5-1b9a-41dd-b4ca-f771acb51803",
@@ -4924,69 +3178,6 @@
       "source_ref": "jirajaroide-contacto"
     },
     {
-      "id": "fbea9a65-8b82-4db1-9786-687e02740266",
-      "word": "ayapcii",
-      "meaning": "muñeca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fd8e2e29-dc3b-4f36-bab7-ddf056edc405",
-      "word": "ayaraitta",
-      "meaning": "halar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f49d55f5-16a2-452b-ace2-c4afeb9d48b9",
-      "word": "ayata",
-      "meaning": "golpear, pegar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "b5605c59-a8c2-491c-b78c-e48d74de6565",
-      "word": "ayata-2",
-      "meaning": "pegar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4183a1df-dd07-47b1-b2ef-cdeabef5fea2",
-      "word": "ayatta",
-      "meaning": "terminarse, acabarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "202770de-de4e-4fd7-8823-8c3590ff3ca5",
-      "word": "ayauata",
-      "meaning": "reconocer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d11703f5-9be9-4027-b6cf-f1577e170050",
-      "word": "aye",
-      "meaning": "lengua",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "5792078b-4102-4b9d-bcfa-ff8d0ad24d37",
       "word": "ayee",
       "meaning": "lengua",
@@ -5005,15 +3196,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "a8fcf0e9-3d55-4e8c-abae-d2166be4ad7e",
-      "word": "ayounja",
-      "meaning": "azotar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b757d60a-10b3-4a00-b0ed-c9ccb3be5e42",
       "word": "ayounjaa",
       "meaning": "azotar",
@@ -5021,42 +3203,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "c0e90bab-1763-4f28-b452-e56a506b82b0",
-      "word": "ayouyiraua",
-      "meaning": "competir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f8df2eb1-d905-4c81-a371-8bf23f208b87",
-      "word": "ayuitta",
-      "meaning": "salir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c030e4fd-7376-4c62-9b37-cc24be1b537c",
-      "word": "ayuittira",
-      "meaning": "sacar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "05d050c1-ef37-48dc-acaf-cf93c2a5bbbb",
-      "word": "ayulain",
-      "meaning": "intestino, tripa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "8338ef78-8738-4042-90bc-9b3aa2ac0824",
@@ -5068,51 +3214,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "a6baf3e8-b630-47cc-8409-07c43c1edbe2",
-      "word": "ayumuu",
-      "meaning": "estar bien",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f1472ec0-9bc5-4ce4-86e8-dfcb718f6de0",
-      "word": "ayuna",
-      "meaning": "cubierta, techo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "45ac83d7-d2ed-4ad4-a851-b41e4201dfa5",
-      "word": "ayurulaya",
-      "meaning": "revolver",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f2c24fe0-c648-4aa2-ac1c-2d7c7ce511bf",
-      "word": "ayuta",
-      "meaning": "tirar, lanzar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "737ccdc0-35db-4293-a1dd-59dc21c37eef",
-      "word": "ayutuua",
-      "meaning": "caerse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "79b6cd89-9c17-45a1-b4d0-6211a5b9d653",
       "word": "ayüüjawaa",
       "meaning": "moler",
@@ -5120,24 +3221,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "f04170f7-cb3a-44d1-95b5-7ab40813f85d",
-      "word": "ayuyaua",
-      "meaning": "bostezar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "949e4713-291c-49fd-b5c1-ea8f2a3934fd",
-      "word": "ayuyaua-2",
-      "meaning": "moler",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "9fbd5dbf-cb1d-42e1-baec-014083cf95c3",
@@ -5167,33 +3250,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "f6b8fefe-ca5a-4174-81fb-b7827ff654aa",
-      "word": "balachi",
-      "meaning": "pelo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7506e428-4be7-48a5-81b6-7b778219f1d9",
-      "word": "balatchi",
-      "meaning": "calor atmosférico",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d1fa64ea-7aa0-45b3-b5ef-3d5c9abc6445",
-      "word": "balaua",
-      "meaning": "estar pagado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "419d76e0-65fc-4fe2-ac50-0e1a79ba2a26",
       "word": "baleta",
       "meaning": "querer sentarse, desear (verbo desiderativo)",
@@ -5219,24 +3275,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "9049d0b2-a0d9-4d92-a71c-5fba811ce05f",
-      "word": "banaua",
-      "meaning": "ser lo mismo, ser",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7c39a0e4-baa5-4370-b75b-bf1d7839dbfe",
-      "word": "baneereeya",
-      "meaning": "no hasta que",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "c448f06d-7862-4b39-a7c0-b78e5160b02a",
@@ -5336,24 +3374,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taíno"
-    },
-    {
-      "id": "dfe8e3d0-e19b-4767-b165-c2bb6d69e9f6",
-      "word": "bauai",
-      "meaning": "viento (de tempestad)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f9f0e024-f726-496c-a035-15a99c8b7294",
-      "word": "bauata",
-      "meaning": "soplar (el viento)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "552508f9-a32b-4b18-8afc-0fe38ec94eb5",
@@ -5545,15 +3565,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "b7276d09-7fb5-4ecb-b20a-2764769c193b",
-      "word": "boolu",
-      "meaning": "mochila para el cinturón bosque, monte",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "14dcaa10-0afb-41fc-8fd9-3876aabed0b1",
       "word": "boratyn",
       "meaning": "ayudar, salvar",
@@ -5597,33 +3608,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "01c636b1-1e08-4349-aff7-9b5ac209992a",
-      "word": "buin",
-      "meaning": "agua",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c3fe8361-e0a0-4849-81de-b04c16b15907",
-      "word": "buinsira",
-      "meaning": "ahogarse (en agua)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "22170459-5aee-40a7-968a-05d2deea72a7",
-      "word": "buitta",
-      "meaning": "ser azul, ser verde",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "779ad6e8-843a-4170-9160-b5cd377b587d",
@@ -5707,33 +3691,6 @@
       "source_ref": "kalinago"
     },
     {
-      "id": "b0bd4d71-5952-43d2-9be2-9ecb8399bee2",
-      "word": "cabu",
-      "meaning": "estar atado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ee294e1d-bb4a-4f59-b3b6-859431f20452",
-      "word": "cabyn",
-      "meaning": "tres (numeral)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4a11c2a9-e30a-4b9a-82e6-04b4145f1109",
-      "word": "cacheta",
-      "meaning": "estar colgado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7c515213-d47b-44a7-a7dc-5809db4291a7",
       "word": "cachicamo",
       "meaning": "armadillo (Dasypus novemcinctus)",
@@ -5759,15 +3716,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taíno"
-    },
-    {
-      "id": "a9d43ebb-fc5f-4d7c-86f4-cbc9c3488c8b",
-      "word": "cacua",
-      "meaning": "ser veloz (andando)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "859a2ee0-f5d5-4fcb-9423-d9a4c33ba059",
@@ -5797,69 +3745,6 @@
       "source_ref": "taino"
     },
     {
-      "id": "eea4204e-c90e-4872-9b98-3d2899c4c124",
-      "word": "cainjala",
-      "meaning": "causar daño, pecar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0b1ee802-e209-414c-b0fa-9d27f2e2d52c",
-      "word": "cairi",
-      "meaning": "isla, territorio insular",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "19b8d237-f735-47ed-b87b-a7c6c6dd5b0a",
-      "word": "cakythi",
-      "meaning": "hombre adulto arahuacano",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "54bac222-8b1a-470b-9fd8-b93626d6f32d",
-      "word": "cakythinon",
-      "meaning": "pueblo, gente arahuacana",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7e243807-1764-46db-a536-b08acc30d719",
-      "word": "calabuchou",
-      "meaning": "ave cucarachero",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6301be08-8d66-4f40-b875-129f5c2f036a",
-      "word": "calecale",
-      "meaning": "perico (cara sucia)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "12fdc572-434d-4c59-b9d7-740374cda9ee",
-      "word": "caluuua",
-      "meaning": "contener",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "cc173018-7150-42a3-b955-8f500b3d0378",
       "word": "caney",
       "meaning": "caney, bohío rectangular del cacique",
@@ -5876,33 +3761,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "1cef3eaf-336e-4e7d-8c6d-dab4f27cd11c",
-      "word": "canulia",
-      "meaning": "ser llamado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c3ac3a85-0e68-4031-b42a-bcd8485c8eaf",
-      "word": "capojan",
-      "meaning": "conuco, milpa, terreno de cultivo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "278bad4f-d140-4d4c-9fdc-864bbfbd74b3",
-      "word": "carai",
-      "meaning": "alcaraván (dara)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "d2ffb03d-9122-4b33-adba-65608ae7b6af",
@@ -5923,15 +3781,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "9b4820e1-9de1-4b7b-bbc9-09ff862877ad",
-      "word": "casa",
-      "meaning": "tener filo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "0449d73e-31be-4863-870a-7be9c7402272",
       "word": "casabe",
       "meaning": "casabe",
@@ -5939,42 +3788,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taino"
-    },
-    {
-      "id": "c1104476-9857-4676-8960-4dc8d8434376",
-      "word": "casiba",
-      "meaning": "ciempiés",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "dec871b3-485d-4e4d-a0a3-04da1f7e0396",
-      "word": "caspoluin",
-      "meaning": "arco iris",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "767ecaee-eda7-453f-b2ac-e077ff6e2505",
-      "word": "cassacu",
-      "meaning": "firmamento, bóveda celeste",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a1b170cf-6ae0-4197-a435-326daa0a9dac",
-      "word": "cassan",
-      "meaning": "estar embarazada",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "781c0211-0277-4cc5-89e2-eabb86c32dcc",
@@ -5986,33 +3799,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "a54aa065-61ed-4a13-9abe-dc5cb4fc41cf",
-      "word": "catchinba",
-      "meaning": "ser fuerte",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ef8ffa57-4256-4615-8290-81d56dd3d45e",
-      "word": "catcousu",
-      "meaning": "arma de fuego",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3a01c267-c069-4297-b688-86ed31802671",
-      "word": "catei",
-      "meaning": "¡oiga! ka'i",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "d94d47b7-4f33-448b-9c2e-533ae64ee3a3",
       "word": "cati",
       "meaning": "luna",
@@ -6020,24 +3806,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "b68da3a3-ebdc-4fd2-8530-5d9e543ae539",
-      "word": "cauayuuse",
-      "meaning": "tener esposo, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "9297b23b-8993-4bed-b06b-6d729a3ecd7a",
-      "word": "cayata",
-      "meaning": "estar un poco retirado",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "daf94d2b-2c6c-4d12-89c8-cb121c374bde",
@@ -6103,24 +3871,6 @@
       "source_ref": "taíno"
     },
     {
-      "id": "62dce2d0-863e-44d2-bbf6-16ecf9650430",
-      "word": "cen",
-      "meaning": "y (conjunción copulativa)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "9b36547b-f935-4dce-9af5-26a9d5ecc5e7",
-      "word": "cena",
-      "meaning": "derramarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "5b5483d2-01f2-4741-b4d8-cd7968028395",
       "word": "cha'aya",
       "meaning": "allá (lejos)",
@@ -6157,15 +3907,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "1b5ced49-069a-4f79-b9ac-d885b2b0f5c6",
-      "word": "chale",
-      "meaning": "último hijo, última hija",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "5827633b-4b16-47cd-b311-959bffb6e51c",
       "word": "che'esaa",
       "meaning": "arete",
@@ -6182,15 +3923,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "0803536e-996b-4520-8812-76fab87a4c91",
-      "word": "chiale",
-      "meaning": "o ella",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "3ba1ab50-01f6-46a0-bcca-74465351ba12",
@@ -6220,15 +3952,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "bb72e2fe-7ec3-4268-aa3f-df0aa05c3d4b",
-      "word": "chocota",
-      "meaning": "ser curvo, -va",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "46db2d74-ac18-440f-bf52-0c7f9066e1bf",
       "word": "chogogo",
       "meaning": "flamingo rosado (Phoenicopterus ruber)",
@@ -6236,15 +3959,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "0974aab3-9b6c-4fac-b594-61af560f5671",
-      "word": "chotta",
-      "meaning": "gotear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "84f1d200-2a01-489f-ba47-f8fe0dce91cb",
@@ -6283,24 +3997,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "847ffd8f-293a-4b94-af84-b961ca5bdccb",
-      "word": "cijadoma",
-      "meaning": "por eso, por tanto, por esa razón",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "59a3a71d-1ba7-4982-8e2a-235b62869d6e",
-      "word": "cisaua",
-      "meaning": "estar guisado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "6f320ff9-97d0-4d65-92d7-afffd1e3c891",
       "word": "cobo",
       "meaning": "cobo, caracol marino gigante (Strombus gigas), trompeta ritual",
@@ -6319,24 +4015,6 @@
       "source_ref": "taino"
     },
     {
-      "id": "5504b4c8-9d11-49ce-b303-0bf22bdb3e65",
-      "word": "coïa",
-      "meaning": "tierra, suelo (forma lokono)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7bcb5c97-a929-45db-934e-e4f1f44063ce",
-      "word": "colocon",
-      "meaning": "en el fuego, en la luz (postposición)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "6d4612e5-c886-4514-a8e5-46de3b206870",
       "word": "conuco",
       "meaning": "huerto familiar, parcela cultivada",
@@ -6344,15 +4022,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "d91f30eb-bf3b-423e-8fd6-982bca65163e",
-      "word": "cooyoua",
-      "meaning": "ser redondo, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "e3e8f9a0-4731-4349-86e4-c60dd5c2c1a1",
@@ -6373,33 +4042,6 @@
       "source_ref": "caquetío/topónimo"
     },
     {
-      "id": "f55c517c-946c-49fc-bee9-4b2507853f60",
-      "word": "couta",
-      "meaning": "estar callado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "50f73ad7-6d79-4576-a3bc-633a9771874a",
-      "word": "coya",
-      "meaning": "pincharse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7ef9cfb2-a592-429a-a9d9-d623700bd52b",
-      "word": "coyuta",
-      "meaning": "ser caro, -ra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "13a56513-6e39-4408-bd72-8794867aacb4",
       "word": "cudan",
       "meaning": "servir, estar al servicio de",
@@ -6418,15 +4060,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "31fec7d7-a013-4535-9813-c846bd066c89",
-      "word": "culala",
-      "meaning": "corral",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "28ce0f12-18a8-46b0-8323-e86649e9a3bd",
       "word": "cumaragua",
       "meaning": "ciruela, espuma rosada (Spondias mombin)",
@@ -6434,15 +4067,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "33436145-c4c4-4c99-8dc9-60ddd914f04c",
-      "word": "cupacanan",
-      "meaning": "antepasados, ancestros",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "094d2fa6-d2f8-4c0b-9418-fb36509d5f72",
@@ -6886,87 +4510,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "5fc80e81-814e-4f9f-bdb3-f5e042c09c8c",
-      "word": "ebee",
-      "meaning": "mano izquierda",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c5fc996a-b2c2-4abb-9754-60b7aa00c865",
-      "word": "ebetta",
-      "meaning": "tocar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "86d44448-97c5-4218-9750-c66885e077e7",
-      "word": "ebeyaua",
-      "meaning": "prender, encender",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3444a7de-76c5-4dee-bffa-8c46b6d2b169",
-      "word": "ebiraya",
-      "meaning": "llenar, inflar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "55dff05b-5c4a-4da4-a6a9-29ac5f2e9f54",
-      "word": "eceroyira",
-      "meaning": "meter",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2d718f36-ae76-4276-9d5c-5b7b5ff6a095",
-      "word": "ecia",
-      "meaning": "mano derecha",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "87620eb6-5d32-4826-9c3f-abc2f2a256e0",
-      "word": "ecii",
-      "meaning": "dolerle la cabeza",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7015e404-d112-469c-a306-c31bddaf71e1",
-      "word": "eciicholoin",
-      "meaning": "cerebro, seso",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "19b3dd4a-4956-4b78-8f11-f873d84c87a7",
-      "word": "eciraya",
-      "meaning": "enseñar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ae82faa1-4b1c-45e4-8c77-ed8ef210af09",
       "word": "ee'irain",
       "meaning": "canción",
@@ -7039,15 +4582,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "d47541c3-53ab-499f-9ebc-6840c9b136b6",
-      "word": "eeru",
-      "meaning": "cuñada (de mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "788f858e-45e0-4f57-b3e6-8275d661cbb4",
       "word": "eerüin",
       "meaning": "esposa",
@@ -7093,114 +4627,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "90fdac8b-d106-47de-9e0f-cfcd2d0ba210",
-      "word": "eibaye",
-      "meaning": "en respuesta a",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2e93ff3a-2ed0-4ebd-857a-424e82aa0308",
-      "word": "eibira",
-      "meaning": "perseguir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fff13ae4-86a7-439f-9936-399aca641662",
-      "word": "eibunaua",
-      "meaning": "llevar y dejar de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "91215126-0112-41ec-9330-cc1c3da108d7",
-      "word": "eibuse",
-      "meaning": "hueso",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4f8f0866-931e-4456-b231-4c79d6ca8f83",
-      "word": "eica",
-      "meaning": "enseñar, instruir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "8d83834a-a018-418e-a605-6b425f6a9da1",
-      "word": "eicaua",
-      "meaning": "estar herido, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f7254a78-f9fc-445e-b6f8-347585d4ca9a",
-      "word": "eicayaua",
-      "meaning": "llevar y dejar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "08f1b7ea-4560-4473-8746-24fde639f57b",
-      "word": "eichi",
-      "meaning": "nariz",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ea670596-d7e8-4cd4-9211-2ac75ded9504",
-      "word": "eiima",
-      "meaning": "barba",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ccb38dd8-140a-45d0-b511-ee15e9fb2bf5",
-      "word": "eiita",
-      "meaning": "defecar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "853b4597-af01-403d-a905-8c71a2725a85",
-      "word": "eiiya",
-      "meaning": "tener diarrea",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "12d3500c-09f5-4f37-a9c8-eec99bca0468",
-      "word": "eimalaua",
-      "meaning": "ekiipala n",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "c6cec94e-c58a-438d-ab83-3f02034670aa",
       "word": "eimalawaa",
       "meaning": "ekiipala n",
@@ -7210,15 +4636,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "2f58370b-c5bc-4c37-b2eb-d007af084b9d",
-      "word": "eina",
-      "meaning": "tejer con aguja",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "3a774f75-5e2e-4d18-b48e-bfc01e69decf",
       "word": "einalu'u",
       "meaning": "en el fondo de, en el ekiisa",
@@ -7226,15 +4643,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "2e0da736-952a-498e-a326-4cc5e8a22cb6",
-      "word": "einaluu",
-      "meaning": "en el fondo de, en el ekiisa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "5dfed64e-ebc9-4d98-8345-76aa869cedb4",
@@ -7273,33 +4681,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "5a88ce91-9b3a-4753-8c92-e065041ab81a",
-      "word": "eirataua",
-      "meaning": "cambiar de esposo, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0335efae-eba1-462f-bf1a-19487a1e359e",
-      "word": "eiruma",
-      "meaning": "primogénito, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "eb9eabf5-c259-43db-9cdd-e0038e899a2a",
-      "word": "eiruu",
-      "meaning": "punta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "3c6c5388-4372-460a-bedc-1a393cc2e6e7",
       "word": "eisalajaa",
       "meaning": "cuidar, asear",
@@ -7307,15 +4688,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "40a328e3-dc81-4302-9ff5-f31317494bee",
-      "word": "eisalaua",
-      "meaning": "acostarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "04b48749-8091-4bb3-8f06-f9ec839ec76f",
@@ -7327,15 +4699,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "2eb696ee-7146-4fdd-b255-2195cc860276",
-      "word": "eita",
-      "meaning": "aportar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "59c3f5c7-dbbc-494a-8214-eed70875d7d5",
       "word": "eitajaa",
       "meaning": "repartir",
@@ -7345,24 +4708,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "f30db11e-d7c9-494f-b216-060c92d43a05",
-      "word": "eitaua",
-      "meaning": "poner, meter",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "1b43d458-5c42-46e8-a2d9-a41bb3c65bbe",
-      "word": "eitaya",
-      "meaning": "repartir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "fc373679-df1d-41ee-8f52-d131647c024d",
       "word": "eite'eraa",
       "meaning": "devolver",
@@ -7370,15 +4715,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "5835662d-c7c9-4712-9b36-14cc88b0fadf",
-      "word": "eiteera",
-      "meaning": "devolver",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "fbada71f-c80a-4036-b634-58d1e968ea6c",
@@ -7397,33 +4733,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "dbc35ba8-5d07-4e79-b2f6-5f52d650805c",
-      "word": "eiyasu",
-      "meaning": "madrastra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2d697708-1f26-4af0-9670-2a773bb6b72a",
-      "word": "eiyaya",
-      "meaning": "curar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "aa4721dd-cea3-4039-92b2-dca028baa4e1",
-      "word": "eiyeise",
-      "meaning": "barbilla",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "bede2952-8269-42c5-9aaa-8ec5121d8a5f",
@@ -7534,24 +4843,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "98e93c42-e547-4b58-b58c-95b746fd6b39",
-      "word": "emechi",
-      "meaning": "suegra (de varón)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "7e477d8f-1706-4e99-ab79-dee2f3484b9e",
-      "word": "emeerayaua",
-      "meaning": "bromear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "75ec88c4-2734-4f90-9d58-e0666bc7fbf5",
       "word": "emeshi",
       "meaning": "suegra (de varón)",
@@ -7559,15 +4850,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "515464dd-36f1-4a3d-affb-7fb2eaa6dfc7",
-      "word": "emiouchi",
-      "meaning": "sombra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "3603f9c2-b46b-405b-9c23-af842bf2a3e6",
@@ -7651,24 +4933,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "44dd4812-2ba8-4b6f-8ada-46b4f4ce8b04",
-      "word": "eraya",
-      "meaning": "conocer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ff18c8fb-9c2e-4f32-84f1-0a8f259eb1ad",
-      "word": "eraya-2",
-      "meaning": "mirar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "cbe81278-c63c-407b-9fd3-b5b8aacb0d30",
       "word": "eretho",
       "meaning": "esposa (término inalienable)",
@@ -7694,15 +4958,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "6a40f606-348a-4e8c-826e-ff27ba4ee67d",
-      "word": "erocu",
-      "meaning": "en (un líquido)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "08b747ee-190a-469e-af86-73e17f4be354",
@@ -7732,60 +4987,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "c15c9e1f-c018-4f2a-867a-d7722650e1b5",
-      "word": "eruin",
-      "meaning": "esposa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d2f33679-162e-4142-8ca7-2048a3bb5405",
-      "word": "eua",
-      "meaning": "haber, existir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fb902f26-1c4f-40cf-b990-d89df526f7aa",
-      "word": "euaua",
-      "meaning": "accidentarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "afbfe335-26d9-41ad-a87b-149ae3bfa9c5",
-      "word": "euein",
-      "meaning": "lunar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fb1159e5-8802-45a2-880f-1552afc84fc4",
-      "word": "eueta",
-      "meaning": "salir a la vista, aparecer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "06facf37-fc1a-46f6-988f-ae53e436b7e5",
-      "word": "euiiya",
-      "meaning": "silbar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "4a61a5ba-a555-488c-97f8-08e78622dd3f",
       "word": "eweetaa",
       "meaning": "salir a la vista, aparecer",
@@ -7813,15 +5014,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "e32031e2-1f1e-464b-ba45-d6ee90202755",
-      "word": "eyemplo",
-      "meaning": "estar cerrado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7ded4bee-efd4-4029-8b39-d60be3270bed",
       "word": "eyeri",
       "meaning": "hombres arahuacanos isleños (etnónimo caribeño)",
@@ -7829,51 +5021,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "67293917-eb04-4c22-a354-073f21c66143",
-      "word": "eyeta",
-      "meaning": "escupir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ec5067e7-31cb-4e22-a997-59e938e0856f",
-      "word": "eyeyeraua",
-      "meaning": "cuchichear, secretear",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "134b90c8-39e5-476f-8d87-417714f3bb95",
-      "word": "eyita",
-      "meaning": "verter (polvos o granos)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "facdf572-5a0b-46ee-907a-6803c53d703f",
-      "word": "eyittaua",
-      "meaning": "atar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a6034c8f-03f7-4df5-8e67-3962e6c958ff",
-      "word": "eyuu",
-      "meaning": "olor",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "36c8462a-9cfa-435c-abf1-4caacba253c6",
@@ -8245,15 +5392,6 @@
       "source_ref": "taíno"
     },
     {
-      "id": "f5c07bea-dbc4-4f73-93b3-dce31f8bb8bd",
-      "word": "iba",
-      "meaning": "piedra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "1e744ab9-9bbf-48db-a653-daf45fe17847",
       "word": "ibili",
       "meaning": "niño, infante (sin distinción de género)",
@@ -8261,24 +5399,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "62de4d84-d33b-47a8-9549-dd78e60d0657",
-      "word": "icha",
-      "meaning": "sufrir una quemadura",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e0d06cfc-7f74-46ac-8b6c-fb46dd4db53f",
-      "word": "iche",
-      "meaning": "estar tenso, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "c73e2b3f-cbab-4eca-bcc6-c7c45f7844c4",
@@ -8380,24 +5500,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "a876aaba-7325-4c49-9c38-c08ec2109220",
-      "word": "ipili",
-      "meaning": "niño, infante (sin distinción de género)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f2b5b822-053c-40e7-9990-1c8e62763f6c",
-      "word": "ipin",
-      "meaning": "ya, de ya (aspecto completivo)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "288fa968-0f99-47d3-9cd4-9d121a97ce8a",
       "word": "iraa",
       "meaning": "ser insípido, -da; tener poco unaquemadura",
@@ -8443,15 +5545,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "cfc94162-14a4-44bb-b726-7f861c3f08fe",
-      "word": "ita",
-      "meaning": "secarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7e22ed13-b37d-492e-acb1-acc2c27408c0",
       "word": "itaa",
       "meaning": "secarse",
@@ -8477,15 +5570,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "11786259-d6a7-4150-ac50-a45895426bba",
-      "word": "iua",
-      "meaning": "ser prostituta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "a75ad599-6553-40a4-8c09-41f3fd0aa0f1",
@@ -10144,15 +7228,6 @@
       "source_ref": "caquetío-reconstruido"
     },
     {
-      "id": "04553401-9bc4-452a-8555-1488871521c9",
-      "word": "la",
-      "meaning": "jagüey",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "2a7a3075-c108-46fc-9254-cbde8997edbc",
       "word": "la'walawaa",
       "meaning": "ser flexible",
@@ -10216,15 +7291,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "73a91208-0f00-4cc8-bd47-3bff562969f1",
-      "word": "laualaua",
-      "meaning": "ser flexible",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "90e58a2b-346f-45db-962b-c465dbafd9e3",
       "word": "laüktaa",
       "meaning": "ser grueso, -sa (de luma",
@@ -10241,15 +7307,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "ff592b18-7ff0-46f7-b557-5c991f0f2f7c",
-      "word": "lemta",
-      "meaning": "arrastrarse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "4d0458cb-5043-4754-a1e0-1850489eb9ba",
@@ -10279,15 +7336,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "0d2ac624-4e2d-4c3d-abfe-864bf9a06135",
-      "word": "lico",
-      "meaning": "nuestro (posesivo 1pl, poseído)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "66e99b0b-6902-4295-929d-b73737a5302f",
       "word": "liko",
       "meaning": "nuestro (posesivo 1pl, poseído)",
@@ -10315,15 +7363,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "8ef6059c-888a-4466-a4c7-94024ff0e044",
-      "word": "lota",
-      "meaning": "ser recto, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "53e642ef-c397-4c90-94a5-c3470a7c2937",
       "word": "lotaa",
       "meaning": "ser recto, -ta",
@@ -10331,15 +7370,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "e979acf4-201e-40a1-97a1-3e9fabdf6b07",
-      "word": "lucunu",
-      "meaning": "el pueblo lokono (autónimo colectivo)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "6bbd3647-c9ee-4eda-8894-4dc484259de9",
@@ -10367,15 +7397,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "51fdf512-5128-4a7b-bfa2-985308fc2b32",
-      "word": "luuobu",
-      "meaning": "arroyo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "56cc3ec0-b862-42c3-a37e-12ecf9103ca1",
@@ -10495,24 +7516,6 @@
       "source_ref": "taíno"
     },
     {
-      "id": "cab18695-8b46-4c95-9653-f2c852a62e1a",
-      "word": "mabui",
-      "meaning": "piojo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ad5e87cf-abba-47c4-8712-8c2662ccd2b4",
-      "word": "mabuleua",
-      "meaning": "ser fácil",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "0be1f9cf-5787-4565-b80f-2dc7cd0682f0",
       "word": "macana",
       "meaning": "macana, garrote de madera dura, arma de combate",
@@ -10529,24 +7532,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "33370619-6ae1-4a27-8e1c-583fad8c9a79",
-      "word": "macheeua",
-      "meaning": "ser sordo, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6b5b8864-8bb0-4de0-8b25-af9daae03c2a",
-      "word": "machon",
-      "meaning": "mamá, abuela",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "b8656813-f6f7-4084-9ac2-5c87d3f2b806",
@@ -10567,15 +7552,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "65612cca-a508-4c94-94aa-80a37e67845b",
-      "word": "mainba",
-      "meaning": "ser necio, -cia",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "478bfd79-30b0-494a-b81b-94b0f3b8360a",
       "word": "maisi",
       "meaning": "maíz (Zea mays)",
@@ -10583,15 +7559,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taíno"
-    },
-    {
-      "id": "c91ddb09-49c1-4744-8a0a-4c74f5218df6",
-      "word": "maitta",
-      "meaning": "estar en calma el tiempo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "695f22bf-6dce-483a-a218-f392316993c9",
@@ -10664,15 +7631,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "bb9c2abc-8a68-4c68-9a1d-4ec8230dd672",
-      "word": "mamainna",
-      "meaning": "ser loco, -ca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "26c62a20-3c51-49a7-bec3-644ba06a7d40",
@@ -10792,15 +7750,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "43c15237-a520-488f-9374-f1a7cfabed1d",
-      "word": "maralu",
-      "meaning": "ser estéril",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "d817af64-af12-4ae9-a99a-00cde3c8b57b",
       "word": "maralüü",
       "meaning": "ser estéril",
@@ -10826,24 +7775,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono/garifuna"
-    },
-    {
-      "id": "c6436e1e-68f7-46cd-b932-d818df6c7423",
-      "word": "maraya",
-      "meaning": "vidrio",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "160cb5cc-f7cb-4985-a3b7-f4d77d99f7d5",
-      "word": "mariiya",
-      "meaning": "ser amarillo, -lla",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "3997548f-e2ce-4f34-a9fb-c91245eca02c",
@@ -10900,15 +7831,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "7e506e45-6b0a-4544-8008-56a1f613fa47",
-      "word": "matsuinba",
-      "meaning": "estar sin fuerza",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b6bd2cc6-5999-41d7-b703-a39e7bf6c4a8",
       "word": "matsüinwaa",
       "meaning": "estar sin fuerza",
@@ -10952,15 +7874,6 @@
       "source_language": "taíno",
       "attested": false,
       "source_ref": "taino"
-    },
-    {
-      "id": "b6b83375-b171-4edf-86e3-d47ff293a592",
-      "word": "mayayulu",
-      "meaning": "señorita, joven (mujer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "49a8e3ee-c100-4664-b493-38aed790d795",
@@ -11062,15 +7975,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "2e797d56-586b-49e0-9701-2f5c0e5f8af8",
-      "word": "miirocu",
-      "meaning": "sitio donde hay",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "a94a364e-3b5c-455f-8a48-fb6a9d6eca2f",
       "word": "miiroku",
       "meaning": "sitio donde hay",
@@ -11096,15 +8000,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "31104afa-c179-459a-b313-98251f6736a6",
-      "word": "miyasu",
-      "meaning": "tener sed",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "74ab0a80-0540-482f-ae13-212e514759f3",
@@ -11161,15 +8056,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "6b6a8009-d07d-49a2-8402-5e926e598c79",
-      "word": "moluu",
-      "meaning": "tener 2",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "e0f61699-41fc-4db3-b02c-c138dafdcfb3",
       "word": "monku",
       "meaning": "mango (fruta)",
@@ -11215,24 +8101,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "15b0c501-72be-4d54-8a7e-08005a28148d",
-      "word": "mouu",
-      "meaning": "ser ciego, -ga",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3fe6b6f5-5286-415b-bac8-b134903fbc66",
-      "word": "moyuui",
-      "meaning": "monte (vegetación)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "51ce2eca-f18e-4666-93a8-1963f162ce0a",
       "word": "mülia",
       "meaning": "miedo, temor, espanto",
@@ -11267,15 +8135,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki-cogn"
-    },
-    {
-      "id": "608b9a6d-ebfd-47c8-bc47-fd812effb869",
-      "word": "mutsiiya",
-      "meaning": "ser negro, -gra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "95855927-120a-4bc3-9541-9dbc1a040720",
@@ -11384,15 +8243,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "7e2d28da-114d-4aaa-8c54-0729562ce1ee",
-      "word": "namuna",
-      "meaning": "loma, cerro",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "9bc596dc-dca0-4a23-9ed0-1c29148443aa",
@@ -11719,60 +8569,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "1f4d4362-804c-4c86-8698-a8fab5c6d81e",
-      "word": "oboloyo",
-      "meaning": "hervir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "24c97fd5-802c-494d-8d45-41279056eb61",
-      "word": "ochoyo",
-      "meaning": "desollar, pelar, curandero, -ra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c9e52249-99aa-42ac-8c15-4195a5a09433",
-      "word": "ocithi",
-      "meaning": "hermano menor (visto por el mayor)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3b67e977-f8a3-4126-86ab-092b39bf8e7a",
-      "word": "ocitho",
-      "meaning": "hermana menor (vista por la mayor)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "8f73b6bd-5084-4800-8361-9065377b3674",
-      "word": "ocoloyo",
-      "meaning": "llevar regalo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "730e9184-3cac-4bd4-9b62-8cff5ef6ee28",
-      "word": "ocoolo",
-      "meaning": "envolver",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b2449a55-23d6-4d37-9093-b2e83cd4fa1f",
       "word": "oi",
       "meaning": "vello",
@@ -11890,24 +8686,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "48a873ef-861f-41ba-a8f0-e2d0a51432b7",
-      "word": "oloto",
-      "meaning": "tener ampolla",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2575eb0a-4c59-444c-b9b9-b152d471bf4e",
-      "word": "olotsu",
-      "meaning": "estrella",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "bd1210b3-7317-4c23-b28c-1bee0d1daa70",
       "word": "olu",
       "meaning": "borde",
@@ -11924,15 +8702,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "a688d5df-2e91-4077-b49b-8a684daa3943",
-      "word": "omocoin",
-      "meaning": "espuma",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "18efb20f-7e57-4638-af26-649b868ca105",
@@ -11960,24 +8729,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "86182a66-a06a-483d-9632-3c95cdac24c3",
-      "word": "oniapo",
-      "meaning": "agua, cuerpo de agua",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "337c0185-3638-4cc0-a88a-6845d58ee280",
-      "word": "onoyo",
-      "meaning": "toser",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "bc74b84c-bc10-462c-b12c-dbe3cae44ed5",
@@ -12088,24 +8839,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ad1cd138-c9be-48c7-9acb-73f95aebb409",
-      "word": "ootoua",
-      "meaning": "montar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "dc4c3d7d-3983-4d31-a630-2501235e2ed7",
-      "word": "ootoyoua",
-      "meaning": "sacudir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ea1d8d80-da04-4b2b-8d98-97fae5ba7408",
       "word": "opoolojoo",
       "meaning": "hervir",
@@ -12142,15 +8875,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "577c856c-dd4d-4dc2-87ab-eafefa07ca1b",
-      "word": "oso",
-      "meaning": "estar seco, -ca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "f404316e-9f7f-4383-aa0b-a5bb2a7fd872",
       "word": "osyn",
       "meaning": "ir, caminar, desplazarse",
@@ -12160,24 +8884,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "4b132429-c446-4d6d-ae04-10d7eb9a54d7",
-      "word": "ota",
-      "meaning": "arder",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "b77c6808-d841-4245-a211-708678265e1c",
-      "word": "otoyo",
-      "meaning": "perforar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "c6e4c421-f639-41c4-aa55-9f5470bc5ac7",
       "word": "otse",
       "meaning": "olla",
@@ -12185,60 +8891,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "156e7ea6-862f-4b1d-9e1e-d2b9eb71f67a",
-      "word": "otta",
-      "meaning": "aterrizar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ec8c7ceb-496f-45c8-a0fa-74f78f710692",
-      "word": "otteera",
-      "meaning": "hacer pasar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "ea228a17-f8cc-49ff-8b1d-bb1870a1d853",
-      "word": "oubuna",
-      "meaning": "cara, rostro",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "fb4e9f1d-d372-4e41-912f-b007f3f6a587",
-      "word": "oubuna-2",
-      "meaning": "debajo de",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c5621bf5-c4f2-475d-85d6-702774ac3ec1",
-      "word": "ouchuua",
-      "meaning": "tener fiebre",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "13a2444d-5697-44bb-abfd-301e7791a760",
-      "word": "oui",
-      "meaning": "tropezar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "738c3b37-7c55-4914-bbbe-b9e6adaa5925",
@@ -12259,33 +8911,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "709a871c-c556-4f83-81ed-07cc03f09d48",
-      "word": "ouliuou",
-      "meaning": "descendiente",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "24e5dee5-5192-45d8-bddf-5c2bc975d0b5",
-      "word": "ouliya",
-      "meaning": "cargar (a un niño)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a926ddb0-bc7b-4094-91fc-320abaf5d996",
-      "word": "oulucu",
-      "meaning": "miembro",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "6303cc49-622e-4de9-abb0-592fb6abc014",
       "word": "ounekaa",
       "meaning": "recobrar el conocimiento, ounekaa",
@@ -12295,24 +8920,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ea08e1ec-cf27-4000-9d10-8b424abf8292",
-      "word": "ounira",
-      "meaning": "llevar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "acd71ccf-7667-4703-8e7b-cb8b3fa21c63",
-      "word": "ounjula",
-      "meaning": "esconder",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "22237147-89df-476e-ae0e-7b0c7a933268",
       "word": "ounjulaa",
       "meaning": "esconder",
@@ -12320,15 +8927,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "2044db39-fedf-44c2-8a10-16c8ef155fed",
-      "word": "ounjulaua",
-      "meaning": "esconderse",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "a54c2641-0aea-4e55-a6ca-b84cc512eb9f",
@@ -12367,15 +8965,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "e37a545d-5447-4131-bc64-99f0bb600bde",
-      "word": "ourula",
-      "meaning": "estar hinchado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "c1d587f7-4d68-4b6c-896d-f72f43b61712",
       "word": "ourulaa",
       "meaning": "estar hinchado, -da",
@@ -12412,15 +9001,6 @@
       "source_ref": "wayunaiki-cogn"
     },
     {
-      "id": "1c146016-21fc-4aa3-af45-fc623d15021a",
-      "word": "outala",
-      "meaning": "cáscara",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "2c39ca47-622f-4928-84f2-b9fa0e543c0b",
       "word": "outkajaa",
       "meaning": "reunir, juntar",
@@ -12439,33 +9019,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "9bc0953c-a3a7-4eac-b4a7-fe8c52521d4a",
-      "word": "outpuna",
-      "meaning": "durante",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "31d0cddb-4013-444c-987f-75baf10d90ef",
-      "word": "ouya",
-      "meaning": "vámonos",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c7044ecd-5ca3-4b0d-bf2f-515e907d490b",
-      "word": "ouyanta",
-      "meaning": "volver",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b076a282-40b3-47e6-9bb4-dd11452d65df",
       "word": "ouyantaa",
       "meaning": "volver",
@@ -12482,96 +9035,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "fc01a592-177e-4332-afe6-33b69cde1782",
-      "word": "oyo",
-      "meaning": "raspar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "f179c0c7-71be-47e9-b240-dbaccda108b4",
-      "word": "oyoita",
-      "meaning": "enterrar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "127795e1-ec58-4fd5-87e7-48d93889ad22",
-      "word": "oyoto",
-      "meaning": "estar sentado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "cd7ceb50-fc5c-424a-8a00-e50d76d55854",
-      "word": "oyoto-2",
-      "meaning": "verter (un líquido)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "4747b73a-1082-4bad-ba04-784e9f507d0c",
-      "word": "oyotoua",
-      "meaning": "cortar (con cuchillo, abdomen)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "3b16120f-5bca-4d64-8a8b-34c969951069",
-      "word": "oyotta",
-      "meaning": "morder",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "00f02a3b-fcf6-405b-bd1e-5e19b7badcc5",
-      "word": "oyununtaua",
-      "meaning": "o'ktaa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "6c8bfa40-c59d-4dc6-af73-803e729f2f81",
-      "word": "oyutta",
-      "meaning": "caer",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "696785f5-b212-4dcf-999e-c4915c7ab40c",
-      "word": "oyuttira",
-      "meaning": "derribar, 2",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "2d4c8c96-5d2a-4a29-8d56-84e31488263f",
-      "word": "oyuuna",
-      "meaning": "a escondidas",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "15d2acf1-609e-4dd4-83ee-0c7d67fcc773",
@@ -12610,15 +9073,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "e72d4443-29d9-4e5a-9b45-cf713cd009bd",
-      "word": "painba",
-      "meaning": "estar de acuerdo",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "fcfadc2c-2eec-49ed-a640-4872ebf6af39",
       "word": "palaapünaa",
       "meaning": "por el norte",
@@ -12646,15 +9100,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "9022be2e-056f-4746-9a92-abe943119e71",
-      "word": "palaua",
-      "meaning": "ser salado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "768ad7ec-123b-4e33-b838-fd797849e8b4",
       "word": "palawaa",
       "meaning": "ser salado, -da",
@@ -12671,24 +9116,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "6902f9cc-d88b-43c6-850c-0fdaeadc8e63",
-      "word": "palii",
-      "meaning": "ceniza",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "c0cb30ed-6bb7-41ae-8cf5-7610950379fb",
-      "word": "paliraua",
-      "meaning": "estar mezclado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "c447742a-01ff-4028-9784-d673c2adedb3",
@@ -12718,15 +9145,6 @@
       "source_ref": "caquetío-reconstruido"
     },
     {
-      "id": "bc8caa9b-b866-453d-9a02-0e8a0cdda75e",
-      "word": "pansaua",
-      "meaning": "estar derecho, -cha",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "65103684-8262-4472-a8d5-853ffb84dfb4",
       "word": "pansawaa",
       "meaning": "estar derecho, -cha",
@@ -12752,15 +9170,6 @@
       "source_language": "proto-arahuaco",
       "attested": false,
       "source_ref": "proto-arahuaco"
-    },
-    {
-      "id": "4d2b3ae1-57e3-48f8-bd16-2f89d8e60ca1",
-      "word": "paraca",
-      "meaning": "mar, agua extensa (forma lokono)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "eae8f6bb-93c3-4240-b4ed-9c05f8a33b81",
@@ -12808,15 +9217,6 @@
       "source_ref": "caquetío"
     },
     {
-      "id": "be1c5b7f-3bd2-4272-b817-29bca9dd2964",
-      "word": "pe",
-      "meaning": "sufijo plural general (-be)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "7e2d3959-6523-4ddf-9530-2af2e9b4a187",
       "word": "peerü",
       "meaning": "perdiz",
@@ -12844,15 +9244,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "973c8831-3973-4542-a382-09b90e1a74c2",
-      "word": "pera",
-      "meaning": "ser mocho, -cha",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "d909367e-7081-4f65-b446-8559f2b4dfc1",
       "word": "peraa",
       "meaning": "ser mocho, -cha",
@@ -12869,33 +9260,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "eff1d4d6-c53a-4524-aa9a-e5e08929b021",
-      "word": "peye",
-      "meaning": "estar cerca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "dd11cad0-ca04-4cd4-b479-7233ac199f02",
-      "word": "peyiche",
-      "meaning": "bejique, chamán taíno, mediador ritual",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "10ccb605-e0e0-4e47-820f-f4c4788ecbbe",
-      "word": "pi",
-      "meaning": "tú (pronombre libre 2sg)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "438f6cff-1428-4168-9936-8cd4ad859d76",
@@ -12923,15 +9287,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "73c8f96b-63c5-4b40-895c-d18625e0574c",
-      "word": "pian",
-      "meaning": "dos (numeral)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "2f0b69f6-cff0-4123-b41f-aaa6bf9ee8ab",
@@ -12979,15 +9334,6 @@
       "source_ref": "caquetío-reconstruido"
     },
     {
-      "id": "420d1416-b56a-4629-8027-11d14eea36b1",
-      "word": "piinasufix",
-      "meaning": "sufijo de pasado próximo (-biina: ayer)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "b75931af-8d32-494a-9384-e047aac30dd0",
       "word": "pilplii",
       "meaning": "padre (forma arcaica, De Laet 1598)",
@@ -13033,24 +9379,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "d707ea6f-4806-4658-83e4-b1f6f6eb0efe",
-      "word": "pisufix",
-      "meaning": "sufijo de pasado reciente (-bi: hoy)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "bc642d43-e826-4346-97aa-90eb4c805a76",
-      "word": "pithi",
-      "meaning": "cuatro (numeral)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "999d9ae3-809b-4171-81dd-72eacb40b1d0",
       "word": "piuuna",
       "meaning": "sirviente, -ta",
@@ -13069,15 +9397,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "ef97f543-699a-49de-ac8a-2478fb6f9aa2",
-      "word": "piyuuchi",
-      "meaning": "oscuridad",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "0f9d45a4-605e-4123-baa8-4b32a0743c6e",
       "word": "piyuushi",
       "meaning": "oscuridad",
@@ -13085,24 +9404,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "a79b3cba-6b3d-45d0-8113-287d0582301c",
-      "word": "pocithi",
-      "meaning": "hermano mayor (visto por el menor)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "79f554e3-ab6c-4933-824f-e4903d465f67",
-      "word": "pocon",
-      "meaning": "cocinar, hervir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "1adb84d9-a08c-4c8b-9368-cb57085313a1",
@@ -13141,24 +9442,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "34c3c000-227c-412a-868a-46b397d70ba0",
-      "word": "poratyn",
-      "meaning": "ayudar, salvar",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "e4219e46-5973-4776-b07e-8dd27f4b04e0",
-      "word": "poro",
-      "meaning": "aldea, pueblo, asentamiento",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "af2fc052-6bf6-4ed1-beb7-64703522eab8",
       "word": "potshonoi",
       "meaning": "libélula",
@@ -13175,24 +9458,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "368b8710-3703-4793-a6de-cd5b97919de9",
-      "word": "puattou",
-      "meaning": "puerta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "0359ab2e-7d3a-4688-a0ee-297a74d47429",
-      "word": "pula",
-      "meaning": "ser poderoso, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "468c995c-f884-4d96-afda-559335beb2fb",
@@ -13240,24 +9505,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "c34b4901-83be-4228-8539-78dc940e58ff",
-      "word": "puresa",
-      "meaning": "estar preso, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "d93ebd06-e84a-4ced-97de-da0c9aca061b",
-      "word": "puru",
-      "meaning": "cielo, firmamento",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "9f5731b4-574d-478f-805c-d64df1cb3400",
       "word": "puruna",
       "meaning": "mercado, lugar de trueque y reunión",
@@ -13283,15 +9530,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "a4accf84-d8de-48c4-ac9e-744c2bb35b15",
-      "word": "pute",
-      "meaning": "ahora (marcador de presente inmediato)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "94809a82-50f6-49bc-a2d7-d19990d1947d",
@@ -13445,15 +9683,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono/proto-arawakan"
-    },
-    {
-      "id": "9b7395a1-5df6-42e2-901b-97d5ab853299",
-      "word": "salapan",
-      "meaning": "sabana, llanura (terreno plano y liso)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "2d77dd8e-8ec9-40d8-a167-6c24da972ebd",
@@ -13672,15 +9901,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "b742031f-046a-41de-bdb4-6295d4264186",
-      "word": "sicin",
-      "meaning": "dar, poner",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "232f56cf-7751-4f2e-8a4d-7298544b535c",
       "word": "siimaraalü",
       "meaning": "marca",
@@ -13717,15 +9937,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "57fffd6d-b348-4043-a463-241a2b415536",
-      "word": "sipa",
-      "meaning": "piedra, roca",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "39621de2-7a77-4018-950d-033f16dfb112",
       "word": "sipara",
       "meaning": "flecha, dardo arrojadizo",
@@ -13742,15 +9953,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "2918fce6-6558-4bfa-9e11-0b55af6a43c0",
-      "word": "sirasira",
-      "meaning": "ser liso, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "826052a9-f517-46b9-85ed-87074d42ccf2",
@@ -13796,15 +9998,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "e2ef8db7-1271-4fe7-a893-c98e67fd857f",
-      "word": "socon",
-      "meaning": "cortar (con machete o hacha)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "177e66c6-5616-4f4f-a0df-1e2208af487f",
@@ -13933,15 +10126,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "88fb4a9b-1d8a-4720-a01f-92cd22c15453",
-      "word": "tacuty",
-      "meaning": "pies, patas",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "5a903e00-f0aa-4e47-8c31-db5ad313c1f7",
       "word": "taita",
       "meaning": "padre",
@@ -13969,15 +10153,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "61cbabef-2444-443d-bed6-d643d23dc066",
-      "word": "tali",
-      "meaning": "padre (mi padre, forma poseída)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "376c4c27-fcd3-4b6d-8b97-e6eece75f298",
       "word": "taneka",
       "meaning": "deuda, lo que se debe devolver (raíz taa-)",
@@ -13994,15 +10169,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "15f5e0f8-dcea-4550-b96d-9098d3730f01",
-      "word": "tari",
-      "meaning": "dientes",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "2186a6f1-114e-4a8b-9fb0-e7bf37a6cc95",
@@ -14030,15 +10196,6 @@
       "source_language": "caquetío",
       "attested": false,
       "source_ref": "caquetío-reconstruido"
-    },
-    {
-      "id": "8f82a7ba-c4f7-4efa-8a8e-a838b3e43bd2",
-      "word": "te",
-      "meaning": "yo (pronombre libre 1sg)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "82c2c868-906b-45f2-8a11-fc6ba63eeed5",
@@ -14095,15 +10252,6 @@
       "source_ref": "lokono"
     },
     {
-      "id": "b95caf34-3969-44b0-b16c-9e1f1ec393c3",
-      "word": "tian",
-      "meaning": "hablar, decir",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "824abc32-5ad3-4122-b930-b8eef215fe02",
       "word": "to",
       "meaning": "artículo no-masculino / no-humano (3sg NM/NH)",
@@ -14129,15 +10277,6 @@
       "source_language": "wayunaiki",
       "attested": false,
       "source_ref": "wayunaiki"
-    },
-    {
-      "id": "a53d0e09-ed26-409a-95c7-49ebd2b3f7e7",
-      "word": "toma",
-      "meaning": "porque, a causa de (postposición causal)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "b87bf2cc-cd22-4700-84fb-0f7eb46ca957",
@@ -14302,33 +10441,6 @@
       "source_ref": "caquetío-atestiguado"
     },
     {
-      "id": "0edb10d2-e3eb-4c3d-bbf5-54a8f10370cb",
-      "word": "ucu",
-      "meaning": "corazón, centro vital",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "883c835d-8c0b-44da-8a75-49850587513f",
-      "word": "ucurahu",
-      "meaning": "familia, tribu, grupo de origen común",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "52e130b6-d1cc-49ec-a248-dc018eb40150",
-      "word": "ucurahu2",
-      "meaning": "pus (secreción del cuerpo enfermo)",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "ca5037cb-bb83-480a-9907-5e9baf60d17e",
       "word": "uju",
       "meaning": "madre",
@@ -14444,15 +10556,6 @@
       "source_language": "caquetío",
       "attested": true,
       "source_ref": "caquetío-atestiguado"
-    },
-    {
-      "id": "630013d5-7b35-475f-a36e-14d6970b28f0",
-      "word": "utata",
-      "meaning": "estar abierto, -ta",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "3e165acd-f7e1-4efe-ac72-7774d2ac275f",
@@ -15103,15 +11206,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b064e82f-5ac1-4349-983b-db23755c943c",
-      "word": "yalayala",
-      "meaning": "ser áspero, -ra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "2826c49b-4ec1-4478-a246-908f27ab9593",
       "word": "yalayalaa",
       "meaning": "ser áspero, -ra",
@@ -15148,15 +11242,6 @@
       "source_ref": "wayunaiki"
     },
     {
-      "id": "b99c6332-5d53-47a1-b10c-b0174c70ffd0",
-      "word": "yarutta",
-      "meaning": "estar sucio",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
       "id": "3ae3d18a-bd0b-4c35-8d62-7a323692a6aa",
       "word": "yarüttaa",
       "meaning": "estar sucio",
@@ -15173,60 +11258,6 @@
       "source_language": "lokono",
       "attested": false,
       "source_ref": "lokono"
-    },
-    {
-      "id": "57e30482-135f-4721-8ab8-c7a1f570fce2",
-      "word": "yemeta",
-      "meaning": "ser sabroso, -sa",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "54b106b2-f19f-474c-957b-d8279ee25c7e",
-      "word": "yera",
-      "meaning": "cuánto ser",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "a2044352-2704-40c8-b848-43a1bc2b57c9",
-      "word": "yerula",
-      "meaning": "ser ancho, -cha",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "45569247-94e5-4474-a26a-b2580ad25580",
-      "word": "yeue",
-      "meaning": "estar maduro, -ra",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "9a854b28-0afc-4fa4-9121-2de77dad94b1",
-      "word": "yocuta",
-      "meaning": "estar apagado, -da",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
-    },
-    {
-      "id": "972122cc-b895-4659-88b7-a7582b12ad2e",
-      "word": "yoi",
-      "meaning": "llaga, infección",
-      "category": "sust",
-      "source_language": "hipotético-no-verificado",
-      "attested": false,
-      "source_ref": "hipotético-no-verificado"
     },
     {
       "id": "5c5ea8b6-6e67-45b3-b7da-818c4c9e3722",


### PR DESCRIPTION
## Resumen

El seed estático `content/simulador/lexicon.json` (que alimenta `/simulador/lexicon`) se exportó el 2026-06-23, **antes** de que las 441 palabras `hipotético-no-verificado` fueran aisladas del léxico activo (2026-06-28, movidas a `curiana_sim/lexicon_candidatos.py` y fuera de Supabase). El seed seguía mostrando 1703 palabras con una categoría que ya no existe en el léxico activo.

- Re-exportado con `export_lexicon_seed.py` contra Supabase local: **1703 → 1262 palabras, 0 hipotéticas**.
- La tabla `lexicon` local ya estaba limpia (1262 filas), no hizo falta re-sembrar.
- Distribución final: wayunaiki 781, lokono 228, caquetío 157, taíno 57, kalinago 19, proto-arahuaco 9, jirajaroide-contacto 7, kalinago-caribe-overlay 4.
- Extra: `autoPort: true` en `.claude/launch.json` para evitar colisiones de puerto entre sesiones de dev.

## Verificación

- `/simulador/lexicon` renderiza con el nuevo seed: encabezado "1262 palabras", 8 chips de lenguas (el chip de hipotéticas desaparece solo porque `LexiconFilter` descarta categorías con conteo 0).
- Filtro por chip verificado: caquetío → "Mostrando 157 de 157 resultados".
- Sin errores ni warnings en consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)