### PR TITLE
fix(lint): reparar setup roto por Next 16 (ESLint 9 flat config)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,20 @@
+import coreWebVitals from "eslint-config-next/core-web-vitals";
+import typescript from "eslint-config-next/typescript";
+
+/** @type {import('eslint').Linter.Config[]} */
+const config = [
+  {
+    ignores: [
+      "**/.next/**",
+      "**/node_modules/**",
+      "out/**",
+      "build/**",
+      ".claude/**",
+      "proyecto-linguistico-caquetío/**",
+    ],
+  },
+  ...coreWebVitals,
+  ...typescript,
+];
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Qué

Repara el setup de lint, roto desde la subida a Next 16. `next lint` fue eliminado en Next 16, así que `npm run lint` fallaba en seco:

```
> next lint
Invalid project directory provided, no such directory: ...\Curiana Radio\lint
```

## Cambios

- **`eslint.config.mjs`** (nuevo): flat config nativo de ESLint 9 con spread de `eslint-config-next/core-web-vitals` + `/typescript`. `ignores` acotados a `.next`, `node_modules`, `.claude/` (worktrees) y el sub-proyecto `proyecto-linguistico-caquetío/` (que tiene su propio lint).
- **`package.json`**: script `"lint"` pasa de `next lint` a `eslint .`.
- **`.eslintrc.json`**: eliminado (formato legacy que ESLint 9 ya no lee por defecto).

## Nota

Al volver a correr, el lint destapa 22 problemas preexistentes en el código del app que estaban invisibles mientras `next lint` estaba roto. Se resuelven aparte en la rama `chore/lint-cleanup` (PR stackeado sobre este), documentados en `LINT_CLEANUP_ROADMAP.md`.

## Verificación

- `npm run lint` vuelve a correr (antes fallaba en seco).
- `tsc --noEmit` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
