### PR TITLE
chore(lint): resolver los 22 problemas destapados (cleanup en 4 olas)

### DIFF
--- a/LINT_CLEANUP_ROADMAP.md
+++ b/LINT_CLEANUP_ROADMAP.md
@@ -27,24 +27,24 @@
 
 ### Ola 1 — Bugs reales (no es cosmética; arreglar primero)
 
-- [ ] **`app/not-found.tsx:65` — `react-hooks/immutability`**
+- [x] **`app/not-found.tsx:65` — `react-hooks/immutability`**
       `seleccionarSabiduria` se invoca dentro de un `useEffect` (línea 65) **antes** de
       declararse (línea 68). La captura temprana no se actualiza. Fix: mover la
       declaración de la función arriba del `useEffect`, o envolverla en `useCallback` y
       declararla antes. Verificar que el mensaje aleatorio siga apareceindo al montar.
-- [ ] **`components/simulador/LexiconDiccionario.tsx:220` — `react-hooks/static-components`**
+- [x] **`components/simulador/LexiconDiccionario.tsx:220` — `react-hooks/static-components`**
       Se crea un componente durante el render (se redefine en cada render → remonta el
       subárbol, pierde estado/foco). Fix: extraer ese componente fuera del componente
       padre (a nivel de módulo) y pasarle props.
 
 ### Ola 2 — Correctness / UX (reglas de Next y React)
 
-- [ ] **`app/[edition]/page.tsx:149` — `@next/next/no-html-link-for-pages`**
+- [x] **`app/[edition]/page.tsx:149` — `@next/next/no-html-link-for-pages`**
       `<a href="/archivo/">` → usar `<Link href="/archivo/">` de `next/link` (navegación
       client-side, prefetch).
-- [ ] **`app/not-found.tsx:100` — `react/jsx-no-comment-textnodes`**
+- [x] **`app/not-found.tsx:100` — `react/jsx-no-comment-textnodes`**
       Comentario suelto que se renderiza como texto. Envolver en `{/* ... */}` o eliminar.
-- [ ] **`react/no-unescaped-entities` (4)** — comillas sin escapar en JSX:
+- [x] **`react/no-unescaped-entities` (4)** — comillas sin escapar en JSX:
   - `app/not-found.tsx:119` (x2)
   - `app/simulador/personajes/page.tsx:40` (x2)
       Fix: usar `&ldquo;`/`&rdquo;`/`&quot;` o mover el texto a una constante/expresión.
@@ -53,20 +53,20 @@
 
 Empezar por el tipo raíz; probablemente cascada al resto.
 
-- [ ] **`types/edition.ts:68`, `:69`** — definir los tipos reales que hoy son `any`.
+- [x] **`types/edition.ts:68`, `:69`** — definir los tipos reales que hoy son `any`.
       Es el archivo de tipos de "edition"; tiparlo bien seguramente arregla varios de los
       `any` de `app/[edition]/page.tsx`.
-- [ ] **`app/[edition]/page.tsx:10-15`** (6 `any`) — reemplazar por los tipos de
+- [x] **`app/[edition]/page.tsx:10-15`** (6 `any`) — reemplazar por los tipos de
       `types/edition.ts` una vez definidos.
-- [ ] **`lib/content.ts:65`** — tipar el retorno/parámetro que hoy es `any`.
+- [x] **`lib/content.ts:65`** — tipar el retorno/parámetro que hoy es `any`.
 
 ### Ola 4 — Limpieza (warnings, `no-unused-vars`, 5)
 
-- [ ] `app/[edition]/page.tsx:4` — import `Navigation` sin usar → eliminar.
-- [ ] `app/[edition]/page.tsx:5` — import `Caption` sin usar → eliminar.
-- [ ] `app/not-found.tsx:19` — const `BURRO_ASCII` sin usar → eliminar o usar.
-- [ ] `app/not-found.tsx:29` — const `BURRO_PERFIL` sin usar → eliminar o usar.
-- [ ] `app/simulador/lexicon/page.tsx:15` — param `_id` sin usar.
+- [x] `app/[edition]/page.tsx:4` — import `Navigation` sin usar → eliminar.
+- [x] `app/[edition]/page.tsx:5` — import `Caption` sin usar → eliminar.
+- [x] `app/not-found.tsx:19` — const `BURRO_ASCII` sin usar → eliminar o usar.
+- [x] `app/not-found.tsx:29` — const `BURRO_PERFIL` sin usar → eliminar o usar.
+- [x] `app/simulador/lexicon/page.tsx:15` — param `_id` sin usar.
       **Decisión de config:** el prefijo `_` sugiere intención de "ignorado". Si es un
       patrón que se repetirá, considerar añadir al flat config
       `argsIgnorePattern: "^_"` / `varsIgnorePattern: "^_"` en las rules de
@@ -117,3 +117,23 @@ types/edition.ts
 ```bash
 npm run lint          # objetivo: 0 errores
 ```
+
+## Cierre — COMPLETADO
+
+Estado final: `npm run lint` → **0 errores, 0 warnings**; `tsc --noEmit` limpio.
+Ejecutado en 4 commits (uno por ola) sobre `chore/lint-cleanup`.
+
+Verificación en runtime (dev server): paginación del léxico cambia de página,
+`GlobalNotFound` puebla la cita aleatoria con comillas tipográficas, y la edición
+`/01` renderiza el MDX (34 párrafos) con el enlace de archivo como `<Link>`.
+
+Dos decisiones fuera del plan original:
+
+1. **Ola 1 destapó un error latente nuevo** (`react-hooks/set-state-in-effect` en
+   not-found.tsx): antes el linter no lo veía porque bailaba en el error de orden.
+   El setState de montaje es randomización client-only (hydration-safe), no estado
+   derivable, así que se resolvió con `eslint-disable-next-line` justificado.
+2. **`_id` (Ola 4) se resolvió a nivel de config**, no de código: se añadió a
+   `eslint.config.mjs` `no-unused-vars` con `ignoreRestSiblings: true` y
+   `varsIgnorePattern/argsIgnorePattern: "^_"`, honrando el patrón deliberado
+   `{ id: _id, ...rest }`. `app/simulador/lexicon/page.tsx` no se tocó.

--- a/LINT_CLEANUP_ROADMAP.md
+++ b/LINT_CLEANUP_ROADMAP.md
@@ -1,0 +1,119 @@
+# Hoja de ruta — limpieza de lint
+
+> **Contexto.** Al reparar el setup de lint (Next 16 eliminó `next lint` → migración a
+> ESLint 9 flat config, ver commit `fix(lint): reparar setup roto por Next 16`), el linter
+> volvió a correr y afloraron **22 problemas preexistentes** que estuvieron invisibles
+> mientras `next lint` estaba roto. Este documento los registra y prioriza.
+>
+> **Rama:** `chore/lint-cleanup` (apilada sobre `fix/eslint-flat-config`, que trae el config
+> funcionando; hacer merge del fix primero, luego rebasar esta rama sobre `main`).
+>
+> **Estado inicial:** `npm run lint` → **17 errores, 5 warnings** en 7 archivos.
+> Meta: `npm run lint` sin errores (warnings a criterio).
+
+## Resumen por regla
+
+| Regla | Cantidad | Sev | Naturaleza |
+|---|---|---|---|
+| `@typescript-eslint/no-explicit-any` | 9 | error | Tipado |
+| `@typescript-eslint/no-unused-vars` | 5 | warn | Limpieza |
+| `react/no-unescaped-entities` | 4 | error | JSX / cosmético |
+| `@next/next/no-html-link-for-pages` | 1 | error | Navegación (UX real) |
+| `react-hooks/immutability` | 1 | error | **Bug real** |
+| `react/jsx-no-comment-textnodes` | 1 | error | JSX |
+| `react-hooks/static-components` | 1 | error | **Bug real (perf/remount)** |
+
+## Plan por olas (orden sugerido)
+
+### Ola 1 — Bugs reales (no es cosmética; arreglar primero)
+
+- [ ] **`app/not-found.tsx:65` — `react-hooks/immutability`**
+      `seleccionarSabiduria` se invoca dentro de un `useEffect` (línea 65) **antes** de
+      declararse (línea 68). La captura temprana no se actualiza. Fix: mover la
+      declaración de la función arriba del `useEffect`, o envolverla en `useCallback` y
+      declararla antes. Verificar que el mensaje aleatorio siga apareceindo al montar.
+- [ ] **`components/simulador/LexiconDiccionario.tsx:220` — `react-hooks/static-components`**
+      Se crea un componente durante el render (se redefine en cada render → remonta el
+      subárbol, pierde estado/foco). Fix: extraer ese componente fuera del componente
+      padre (a nivel de módulo) y pasarle props.
+
+### Ola 2 — Correctness / UX (reglas de Next y React)
+
+- [ ] **`app/[edition]/page.tsx:149` — `@next/next/no-html-link-for-pages`**
+      `<a href="/archivo/">` → usar `<Link href="/archivo/">` de `next/link` (navegación
+      client-side, prefetch).
+- [ ] **`app/not-found.tsx:100` — `react/jsx-no-comment-textnodes`**
+      Comentario suelto que se renderiza como texto. Envolver en `{/* ... */}` o eliminar.
+- [ ] **`react/no-unescaped-entities` (4)** — comillas sin escapar en JSX:
+  - `app/not-found.tsx:119` (x2)
+  - `app/simulador/personajes/page.tsx:40` (x2)
+      Fix: usar `&ldquo;`/`&rdquo;`/`&quot;` o mover el texto a una constante/expresión.
+
+### Ola 3 — Tipado (`no-explicit-any`, 9)
+
+Empezar por el tipo raíz; probablemente cascada al resto.
+
+- [ ] **`types/edition.ts:68`, `:69`** — definir los tipos reales que hoy son `any`.
+      Es el archivo de tipos de "edition"; tiparlo bien seguramente arregla varios de los
+      `any` de `app/[edition]/page.tsx`.
+- [ ] **`app/[edition]/page.tsx:10-15`** (6 `any`) — reemplazar por los tipos de
+      `types/edition.ts` una vez definidos.
+- [ ] **`lib/content.ts:65`** — tipar el retorno/parámetro que hoy es `any`.
+
+### Ola 4 — Limpieza (warnings, `no-unused-vars`, 5)
+
+- [ ] `app/[edition]/page.tsx:4` — import `Navigation` sin usar → eliminar.
+- [ ] `app/[edition]/page.tsx:5` — import `Caption` sin usar → eliminar.
+- [ ] `app/not-found.tsx:19` — const `BURRO_ASCII` sin usar → eliminar o usar.
+- [ ] `app/not-found.tsx:29` — const `BURRO_PERFIL` sin usar → eliminar o usar.
+- [ ] `app/simulador/lexicon/page.tsx:15` — param `_id` sin usar.
+      **Decisión de config:** el prefijo `_` sugiere intención de "ignorado". Si es un
+      patrón que se repetirá, considerar añadir al flat config
+      `argsIgnorePattern: "^_"` / `varsIgnorePattern: "^_"` en las rules de
+      `@typescript-eslint/no-unused-vars`, en vez de tocar cada caso.
+
+## Detalle crudo (referencia)
+
+```
+app/[edition]/page.tsx
+  warn 4:8    no-unused-vars           'Navigation' sin usar
+  warn 5:36   no-unused-vars           'Caption' sin usar
+  ERR  10:15  no-explicit-any
+  ERR  11:15  no-explicit-any
+  ERR  12:15  no-explicit-any
+  ERR  13:15  no-explicit-any
+  ERR  14:14  no-explicit-any
+  ERR  15:23  no-explicit-any
+  ERR  149:13 no-html-link-for-pages   <a href="/archivo/"> → <Link>
+
+app/not-found.tsx
+  warn 19:7   no-unused-vars           'BURRO_ASCII' sin usar
+  warn 29:7   no-unused-vars           'BURRO_PERFIL' sin usar
+  ERR  65:5   react-hooks/immutability variable usada antes de declararse
+  ERR  100:75 jsx-no-comment-textnodes
+  ERR  119:13 no-unescaped-entities
+  ERR  119:23 no-unescaped-entities
+
+app/simulador/lexicon/page.tsx
+  warn 15:44  no-unused-vars           '_id' sin usar
+
+app/simulador/personajes/page.tsx
+  ERR  40:15  no-unescaped-entities
+  ERR  40:29  no-unescaped-entities
+
+components/simulador/LexiconDiccionario.tsx
+  ERR  220:12 react-hooks/static-components  componente creado en render
+
+lib/content.ts
+  ERR  65:28  no-explicit-any
+
+types/edition.ts
+  ERR  68:14  no-explicit-any
+  ERR  69:32  no-explicit-any
+```
+
+## Verificación al cerrar
+
+```bash
+npm run lint          # objetivo: 0 errores
+```

--- a/app/[edition]/page.tsx
+++ b/app/[edition]/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getEditionBySlug, getAllEditionSlugs } from '@/lib/content';
@@ -146,12 +147,12 @@ export default async function EditionPage({ params }: EditionPageProps) {
 
           {/* Navigation to Archive */}
           <div className="text-center pt-16 border-t border-earth-200">
-            <a
+            <Link
               href="/archivo"
               className="inline-block text-deep-700 hover:text-frequency transition-colors font-sans text-sm tracking-wide uppercase"
             >
               ← Ver todas las ediciones
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/app/[edition]/page.tsx
+++ b/app/[edition]/page.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getEditionBySlug, getAllEditionSlugs } from '@/lib/content';
-import Navigation from '@/components/layout/Navigation';
-import { Heading, BodyText, Quote, Caption, SectionTitle } from '@/components/ui/Typography';
+import { Heading, BodyText, Quote, SectionTitle } from '@/components/ui/Typography';
 import type { Metadata } from 'next';
 import type { ComponentProps } from 'react';
 

--- a/app/[edition]/page.tsx
+++ b/app/[edition]/page.tsx
@@ -5,15 +5,16 @@ import { getEditionBySlug, getAllEditionSlugs } from '@/lib/content';
 import Navigation from '@/components/layout/Navigation';
 import { Heading, BodyText, Quote, Caption, SectionTitle } from '@/components/ui/Typography';
 import type { Metadata } from 'next';
+import type { ComponentProps } from 'react';
 
 // MDX components mapping
 const components = {
-  h1: (props: any) => <Heading level={1} {...props} />,
-  h2: (props: any) => <Heading level={2} {...props} />,
-  h3: (props: any) => <Heading level={3} {...props} />,
-  h4: (props: any) => <Heading level={4} {...props} />,
-  p: (props: any) => <BodyText {...props} />,
-  blockquote: (props: any) => <Quote {...props} />,
+  h1: (props: ComponentProps<'h1'>) => <Heading level={1} className={props.className}>{props.children}</Heading>,
+  h2: (props: ComponentProps<'h2'>) => <Heading level={2} className={props.className}>{props.children}</Heading>,
+  h3: (props: ComponentProps<'h3'>) => <Heading level={3} className={props.className}>{props.children}</Heading>,
+  h4: (props: ComponentProps<'h4'>) => <Heading level={4} className={props.className}>{props.children}</Heading>,
+  p: (props: ComponentProps<'p'>) => <BodyText className={props.className}>{props.children}</BodyText>,
+  blockquote: (props: ComponentProps<'blockquote'>) => <Quote className={props.className}>{props.children}</Quote>,
 };
 
 interface EditionPageProps {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -16,28 +16,6 @@ const SABIDURIA_ANCESTRAL = [
   "Has llegado al borde del mapa. Aquí comienzan los dragones (y los burros)."
 ];
 
-const BURRO_ASCII = `
-      /\_/\
-     ( o.o )
-      > ^ <
-     /     \
-    (       )
-    (___)___)
-`;
-
-// O una versión más "de perfil" mirando al usuario
-const BURRO_PERFIL = `
-        _  _ 
-       ( \/ ) 
-        \  / 
-        /  \    //
-       /    \__//
-      /      \ /
-     /   _    |
-    (   / \   |
-     \_/   \_/
-`;
-
 // Versión Minimalista Desierto
 const PAISAJE_ASCII = `
            ,

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -102,7 +102,7 @@ export default function GlobalNotFound() {
             404
           </h1>
           <p className="text-frequency text-sm tracking-widest uppercase">
-            // Ruta del Extravío
+            {'// Ruta del Extravío'}
           </p>
         </header>
 
@@ -120,7 +120,7 @@ export default function GlobalNotFound() {
         <div className="space-y-6 text-left min-h-[120px]">
           <div className="h-px w-12 bg-frequency mb-6"></div>
           <p className="text-xl md:text-2xl text-earth-50 font-serif italic leading-relaxed">
-            "{mensaje}"
+            &ldquo;{mensaje}&rdquo;
           </p>
         </div>
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const SABIDURIA_ANCESTRAL = [
   "El viento no borra, reescribe. Tu error es un nuevo borrador.",
@@ -60,15 +60,19 @@ export default function GlobalNotFound() {
   const [mensaje, setMensaje] = useState<string>("");
   const [mounted, setMounted] = useState(false);
 
-  useEffect(() => {
-    setMounted(true);
-    seleccionarSabiduria();
-  }, []);
-
-  const seleccionarSabiduria = () => {
+  const seleccionarSabiduria = useCallback(() => {
     const indice = Math.floor(Math.random() * SABIDURIA_ANCESTRAL.length);
     setMensaje(SABIDURIA_ANCESTRAL[indice]);
-  };
+  }, []);
+
+  useEffect(() => {
+    // Randomización client-only: el mensaje sale de Math.random(), que no puede
+    // correr en SSR sin provocar hydration mismatch. Fijar el estado tras el
+    // montaje es intencional aquí (no es estado derivable en render).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+    seleccionarSabiduria();
+  }, [seleccionarSabiduria]);
 
   const handleSeguirPerdido = () => {
     // Pequeña animación de recarga "mental"

--- a/app/simulador/personajes/page.tsx
+++ b/app/simulador/personajes/page.tsx
@@ -37,7 +37,7 @@ function EntradaPersonaje({ p }: { p: Personaje }) {
           </p>
           {quote && (
             <p className="mt-2 line-clamp-2 font-serif text-[0.95rem] italic text-(--sim-ink)">
-              "{quote.quote}"
+              &ldquo;{quote.quote}&rdquo;
             </p>
           )}
         </div>

--- a/components/simulador/LexiconDiccionario.tsx
+++ b/components/simulador/LexiconDiccionario.tsx
@@ -37,6 +37,39 @@ function inicial(word: string): string {
   return ch ? ch[0].toUpperCase() : "·";
 }
 
+function Paginacion({
+  paginaActual,
+  totalPaginas,
+  setPagina,
+}: {
+  paginaActual: number;
+  totalPaginas: number;
+  setPagina: (n: number) => void;
+}) {
+  if (totalPaginas <= 1) return null;
+  return (
+    <div className="flex items-center justify-between border-t border-(--sim-rule) py-3 font-sans text-sm">
+      <button
+        onClick={() => setPagina(Math.max(0, paginaActual - 1))}
+        disabled={paginaActual === 0}
+        className="text-(--sim-ink-soft) transition-colors hover:text-(--sim-fuego) disabled:cursor-default disabled:text-(--sim-rule)"
+      >
+        ← anterior
+      </button>
+      <span className="font-sans text-xs tabular-nums text-(--sim-ink-faint)">
+        página {paginaActual + 1} de {totalPaginas}
+      </span>
+      <button
+        onClick={() => setPagina(Math.min(totalPaginas - 1, paginaActual + 1))}
+        disabled={paginaActual >= totalPaginas - 1}
+        className="text-(--sim-ink-soft) transition-colors hover:text-(--sim-fuego) disabled:cursor-default disabled:text-(--sim-rule)"
+      >
+        siguiente →
+      </button>
+    </div>
+  );
+}
+
 export default function LexiconDiccionario({ palabras }: { palabras: EntradaDiccionario[] }) {
   const [search, setSearch] = useState("");
   const [langFilter, setLangFilter] = useState("todos");
@@ -83,29 +116,6 @@ export default function LexiconDiccionario({ palabras }: { palabras: EntradaDicc
     fn();
     setPagina(0);
   };
-
-  const Paginacion = () =>
-    totalPaginas > 1 ? (
-      <div className="flex items-center justify-between border-t border-(--sim-rule) py-3 font-sans text-sm">
-        <button
-          onClick={() => setPagina(Math.max(0, paginaActual - 1))}
-          disabled={paginaActual === 0}
-          className="text-(--sim-ink-soft) transition-colors hover:text-(--sim-fuego) disabled:cursor-default disabled:text-(--sim-rule)"
-        >
-          ← anterior
-        </button>
-        <span className="font-sans text-xs tabular-nums text-(--sim-ink-faint)">
-          página {paginaActual + 1} de {totalPaginas}
-        </span>
-        <button
-          onClick={() => setPagina(Math.min(totalPaginas - 1, paginaActual + 1))}
-          disabled={paginaActual >= totalPaginas - 1}
-          className="text-(--sim-ink-soft) transition-colors hover:text-(--sim-fuego) disabled:cursor-default disabled:text-(--sim-rule)"
-        >
-          siguiente →
-        </button>
-      </div>
-    ) : null;
 
   return (
     <div>
@@ -217,7 +227,11 @@ export default function LexiconDiccionario({ palabras }: { palabras: EntradaDicc
               </dl>
             </section>
           ))}
-          <Paginacion />
+          <Paginacion
+            paginaActual={paginaActual}
+            totalPaginas={totalPaginas}
+            setPagina={setPagina}
+          />
         </>
       )}
     </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,16 @@ const config = [
   },
   ...coreWebVitals,
   ...typescript,
+  {
+    // Honrar el prefijo `_` y el patrón omit-via-rest ({ id: _id, ...rest }):
+    // variables deliberadamente descartadas no deben marcarse como sin usar.
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", ignoreRestSiblings: true },
+      ],
+    },
+  },
 ];
 
 export default config;

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import type { EditionMetadata, SectionContent, Edition, ArchiveItem } from '@/types';
+import type { EditionMetadata, SectionType, SectionContent, Edition, ArchiveItem } from '@/types';
 
 const CONTENT_DIR = path.join(process.cwd(), 'content', 'editions');
 
@@ -62,7 +62,7 @@ async function loadSection(
 
     // Return raw MDX content for RSC rendering
     return {
-      type: sectionName as any,
+      type: sectionName as SectionType,
       mdxSource: content, // Raw MDX string for next-mdx-remote/rsc
       frontmatter: data,
     };

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -65,8 +65,8 @@ export interface RabbitHole {
  */
 export interface SectionContent {
   type: SectionType;
-  mdxSource: any; // MDX compiled source from next-mdx-remote
-  frontmatter?: Record<string, any>;
+  mdxSource: string; // Raw MDX string; next-mdx-remote/rsc lo compila al renderizar
+  frontmatter?: Record<string, unknown>;
   rabbitHole?: RabbitHole;
 }
 


### PR DESCRIPTION
> Reemplaza al #19, que GitHub cerró automáticamente al borrarse su rama base (`fix/eslint-flat-config`) tras mergear #18. Mismo contenido, ahora directo a `main`. El setup de lint (#18) ya está en `main`.

## Qué

Resuelve los 22 problemas (17 errores, 5 warnings) que afloraron al reparar el setup de lint (#18). Organizado en 4 olas (una por commit), documentado en `LINT_CLEANUP_ROADMAP.md`.

## Olas

- **Ola 1 — bugs reales** (`fix`): use-before-declare de `seleccionarSabiduria` en `not-found.tsx` (→ `useCallback`); subcomponente `Paginacion` creado en render en `LexiconDiccionario.tsx` (→ hoisteado a nivel módulo con props).
- **Ola 2 — correctness/UX** (`fix`): `<a>`→`<Link>` al archivo; comment-textnode y comillas sin escapar (→ tipográficas).
- **Ola 3 — tipado** (`refactor`): 9 `any` eliminados del pipeline de ediciones (`mdxSource: string`, `Record<string, unknown>`, `as SectionType`, mapa MDX con `ComponentProps`).
- **Ola 4 — limpieza** (`chore`): imports/consts muertos; `no-unused-vars` en config honra `^_` + `ignoreRestSiblings` para el patrón deliberado `{ id: _id, ...rest }`.

## Dos decisiones fuera del plan

1. La Ola 1 destapó un error latente nuevo (`react-hooks/set-state-in-effect` en `not-found.tsx`): antes el linter no lo veía por el error de orden. Es randomización client-only hydration-safe (no estado derivable), así que queda con `eslint-disable-next-line` justificado.
2. `_id` se resolvió a nivel de config (no de código): honra el patrón omit-via-rest que recorta el UUID del payload al cliente.

## Verificación

- `npm run lint` → **0 errores, 0 warnings**; `tsc --noEmit` limpio.
- Runtime (dev server): paginación del léxico cambia de página; `GlobalNotFound` puebla la cita aleatoria con comillas tipográficas; la edición `/01` renderiza el MDX (34 párrafos) con el enlace de archivo como `<Link>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
