### PR TITLE
feat(koine): métrica de convergencia corregida + experimento normal vs ablación

### DIFF
--- a/proyecto-linguistico-caquetío/BITACORA_RUNS.md
+++ b/proyecto-linguistico-caquetío/BITACORA_RUNS.md
@@ -23,6 +23,7 @@ detallados por run en archivos `ANALISIS_RUN_*.md` enlazados.
 
 | Fecha | Run (id8) | Turnos/Días | Agentes | Score | Caquetío | Estado / hito |
 |---|---|---|---|---|---|---|
+| 07-06 | `038d7b9d` + `bdc54134` | 60 / 30 c/u | 38 / 34 | 7.3 | **99%** | **Experimento normal vs. ablación** — emergente −17.9% vs −6.6%: la koiné sobrevive parcialmente sin andamiaje |
 | 07-04 | `b0cbb3b8` + `2d4e67ad` | 4 / 2 c/u | 15-16 | ~7.5 | 99% | smokes de la métrica corregida (normal + `--ablacion`, descartables) |
 | 06-29 | `20091e1f` | 57 / 29 | 30 | 7.4 | **99%** | **Fijación por competencia** — diccionario koiné de 7 conceptos |
 | 06-29 | `9bb920eb` | 60 / 30 | 32 | 7.5 | **99%** | Run largo — población constante, métrica persistida, convergencia −44% |
@@ -33,7 +34,56 @@ detallados por run en archivos `ANALISIS_RUN_*.md` enlazados.
 
 ---
 
-## 2026-06-29 · Run `20091e1f` — Fijación por competencia
+## 2026-07-06 · Runs `038d7b9d` (normal) + `bdc54134` (ablación) — El experimento de control
+
+**Comandos:** `python curiana_orchestrator_v2.py --auto 60` y `--auto 60 --ablacion`,
+misma configuración, corridos el mismo día en secuencia. Runs bien apareados:
+300 vs 294 respuestas, score 7.31 vs 7.30, caquetío 99.1% vs 99.7%, 0 fallos de DB.
+
+**Pregunta:** ¿cuánta convergencia sobrevive sin las tres inyecciones de prompt
+(sugerencias de contagio, competencias abiertas, muestreo ponderado)? Si la
+ablación converge igual, la koineización era andamiaje, no emergencia.
+
+### Resultado (distancia idiolectal, día 1 → día 30)
+
+| Lectura | Normal `038d7b9d` | Ablación `bdc54134` | Diferencia |
+|---|---|---|---|
+| **emergente** (la exigente) | 0.6997 → 0.5746 (**−17.9%**) | 0.6957 → 0.6499 (**−6.6%**) | **2.7×** más convergencia con andamiaje |
+| ventana | 0.5631 → 0.4243 (−24.6%) | 0.5704 → 0.4573 (−19.8%) | moderada |
+| acumulada | 0.6331 → 0.3536 (−44.1%) | 0.6317 → 0.3751 (−40.6%) | **casi nula** — confirma el artefacto |
+| fijación (conceptos) | **6/10** fijados | 4/10 fijados | |
+| neologismos adoptados | 63 | 39 | |
+
+### Lectura
+
+- **La evidencia de koineización emergente existe y es la diferencia:** en la
+  lectura emergente el run normal converge 2.7× más que su control. La
+  acumulada, en cambio, es casi idéntica en ambos (−44% vs −41%) — converge
+  por acumulación del léxico base compartido sin importar el mecanismo, tal
+  como diagnosticó la corrección metodológica del 07-04.
+- **Forma de las curvas:** la ablación cae los primeros ~7 días (esa parte es
+  intrínseca al mundo compartido, no al andamiaje) y luego se **aplana en
+  ~0.64–0.65 desde el día ~16**, con leve subida al final. La normal muestra
+  un rebote (días 12–17, entrada de formas nuevas) y **sigue convergiendo**
+  hasta 0.575. El andamiaje no solo acelera: sostiene la convergencia después
+  del equilibrio inicial.
+- ⚠️ **El veredicto impreso de la ablación dice "CONVERGE ✓"** porque compara
+  inicio vs fin de forma naive (−6.6% es negativo). Es correcto pero engañoso
+  leído solo: la trayectoria es plateau, no convergencia sostenida. El
+  veredicto binario debería considerar la pendiente reciente, no solo los
+  extremos — anotado como ajuste pendiente.
+- **La ablación aún fija conceptos (4/10):** los eventos de nombramiento
+  siguen ocurriendo (solo se apagan las inyecciones de prompt), así que hay
+  fijación residual genuina — los agentes reusan variantes que oyeron en el
+  diálogo mismo. Eso es la señal emergente "pura" más interesante del run.
+
+### Implicaciones para calibración (punto 3 del plan)
+
+Con −17.9% en 30 días y 4/10 conceptos aún en disputa en el run normal, la
+cadencia de nombramientos y los umbrales de fijación se ven razonables — la
+competencia no resuelve trivialmente. Si se quiere más señal por run: más días
+antes que más presión (la pendiente emergente del normal seguía negativa al
+día 30).
 
 **Comando:** `python curiana_orchestrator_v2.py --auto 60 --perfiles` (el proceso
 se cortó en el turno 57/60 por teardown de sesión; analíticamente completo —

--- a/proyecto-linguistico-caquetío/BITACORA_RUNS.md
+++ b/proyecto-linguistico-caquetío/BITACORA_RUNS.md
@@ -9,10 +9,21 @@ detallados por run en archivos `ANALISIS_RUN_*.md` enlazados.
 > psql -U postgres -d postgres`. La distancia idiolectal se recomputa desde
 > `word_uses` (join con `turns` para el día — `word_uses.day` quedó sin poblar).
 
+> ⚠️ **Corrección metodológica (2026-07-04):** la "convergencia" reportada en
+> runs previos usa la distancia idiolectal ACUMULADA, que converge en parte
+> por mera acumulación del vocabulario base compartido (artefacto matemático).
+> Desde 07-04 `koine_metrics` guarda además `distance_ventana` (habla reciente
+> real) y `distance_emergente` (solo formas emergentes), y existe `--ablacion`
+> para runs de control sin las inyecciones de prompt que empujan la
+> convergencia. En los smokes de verificación (`b0cbb3b8`), la acumulada
+> "convergía" mientras ventana y emergente divergían — las cifras de
+> convergencia históricas deben releerse con esa reserva. Ver DISENO_KOINE.md §7.
+
 ## Registro
 
 | Fecha | Run (id8) | Turnos/Días | Agentes | Score | Caquetío | Estado / hito |
 |---|---|---|---|---|---|---|
+| 07-04 | `b0cbb3b8` + `2d4e67ad` | 4 / 2 c/u | 15-16 | ~7.5 | 99% | smokes de la métrica corregida (normal + `--ablacion`, descartables) |
 | 06-29 | `20091e1f` | 57 / 29 | 30 | 7.4 | **99%** | **Fijación por competencia** — diccionario koiné de 7 conceptos |
 | 06-29 | `9bb920eb` | 60 / 30 | 32 | 7.5 | **99%** | Run largo — población constante, métrica persistida, convergencia −44% |
 | 06-29 | `f8ef263d` | 30 / 15 | 28 | 7.5 | **99%** | Primer run koiné — convergencia confirmada |

--- a/proyecto-linguistico-caquetío/CLAUDE.md
+++ b/proyecto-linguistico-caquetío/CLAUDE.md
@@ -89,6 +89,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=...     # anon key local (ver `supabase status`)
 cd curiana_sim
 pip install -r requirements.txt
 python test_quick.py          # verifica el stack sin API keys (debe dar 8/8 OK)
+python -m pytest tests/ -q    # suite unitaria (koiné, léxico, observer, social; sin API keys)
 supabase start                 # levanta Supabase local (ver nota de egress arriba)
 python curiana_database.py seed  # siembra las 1262 palabras activas en Supabase
 
@@ -100,6 +101,11 @@ python curiana_orchestrator_v2.py --auto 30 --perfiles --reporte
   # --perfiles: genera perfiles curados por agente al cerrar el run
   #             (rol, arco narrativo, frases célebres → agent_profiles/agent_quotes)
   # --reporte:  reporte anual LLM al completar cada año simulado
+  # --ablacion: run de CONTROL — apaga las inyecciones de prompt que empujan la
+  #             convergencia (contagio, competencias abiertas, muestreo ponderado).
+  #             La evidencia de koineización es la DIFERENCIA normal vs. ablación.
+  #             La convergencia se mide en 3 lecturas/día (acumulada/ventana/emergente,
+  #             ver DISENO_KOINE.md §7); el veredicto usa la más exigente con datos.
 
 # Dashboard
 cd curiana_dashboard

--- a/proyecto-linguistico-caquetío/DISENO_KOINE.md
+++ b/proyecto-linguistico-caquetío/DISENO_KOINE.md
@@ -163,6 +163,20 @@ Esto vuelve el resultado defendible en vez de anecdótico. Tabla nueva
 - **Distancia idiolectal media** entre agentes (coseno/Jaccard sobre vectores
   de frecuencia de formas). **Debe contraerse** en el tiempo → firma de la
   koineización. Si no se contrae, no hubo koiné.
+  - ⚠️ **Corrección metodológica (2026-07-04):** la versión acumulada de esta
+    métrica converge por mera acumulación del vocabulario base compartido
+    (artefacto matemático), no por koineización. Desde entonces se miden TRES
+    lecturas por día (`koine_metrics.distance / distance_ventana /
+    distance_emergente`): acumulada (histórica), **ventana** (últimos
+    `VENTANA_TURNOS` de habla real, sin formas-semilla) y **emergente**
+    (ventana excluyendo el vocabulario base: solo neologismos/adopciones).
+    El veredicto de convergencia se emite sobre la más exigente con datos.
+    Verificado en un run corto: la acumulada "convergía" mientras ventana y
+    emergente divergían — el artefacto era real.
+  - ⚗ **Run de control (`--ablacion`):** apaga las tres inyecciones de prompt
+    que empujan la convergencia (sugerencias de contagio, competencias
+    abiertas, muestreo ponderado). La evidencia de koineización emergente es
+    la DIFERENCIA entre un run normal y su ablación, no el run normal solo.
 - **Variantes por significado → 1** (tasa de fijación).
 - **Curvas de frecuencia** de las formas ganadoras (forma de S esperada).
 - **Supervivencia de neologismos** (nace → vive → muere / se fija).

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
@@ -233,7 +233,9 @@ class CurianaDB:
         """Crea un nuevo simulation run y retorna su UUID."""
         row = {
             "model": model,
-            "config": json.dumps(config or {}),
+            # dict directo → jsonb OBJETO consultable con config->>'clave'.
+            # (json.dumps lo guardaba como string JSON, inconsultable en SQL.)
+            "config": config or {},
         }
         result = self.client.table("simulation_runs").insert(row).execute()
         run_id: str = result.data[0]["id"]
@@ -395,13 +397,29 @@ class CurianaDB:
 
     # ── Koiné metrics ─────────────────────────────────────────────────
 
-    def save_koine_metric(self, run_id: str, day: int, distance: float, n_agents: int):
+    def save_koine_metric(self, run_id: str, day: int, distance: float, n_agents: int,
+                          distance_ventana: Optional[float] = None,
+                          distance_emergente: Optional[float] = None):
         """Persiste la distancia idiolectal media de un día (métrica de
-        convergencia). Upsert por (run_id, day) para ser idempotente."""
-        self.client.table("koine_metrics").upsert(
-            {"run_id": run_id, "day": day, "distance": distance, "n_agents": n_agents},
-            on_conflict="run_id,day",
-        ).execute()
+        convergencia). Upsert por (run_id, day) para ser idempotente.
+
+        distance = acumulada (histórica); distance_ventana = sobre los últimos
+        turnos de habla real; distance_emergente = ventana sin vocabulario base
+        (solo formas emergentes — la señal de koineización menos sesgada).
+        Si el esquema no tiene las columnas nuevas (sin migración), reintenta
+        con las básicas para no perder la métrica principal."""
+        row = {"run_id": run_id, "day": day, "distance": distance, "n_agents": n_agents,
+               "distance_ventana": distance_ventana,
+               "distance_emergente": distance_emergente}
+        try:
+            self.client.table("koine_metrics").upsert(
+                row, on_conflict="run_id,day").execute()
+        except Exception:
+            self.client.table("koine_metrics").upsert(
+                {"run_id": run_id, "day": day, "distance": distance,
+                 "n_agents": n_agents},
+                on_conflict="run_id,day",
+            ).execute()
 
     def save_koine_lexicon(self, run_id: str, concepto_id: str, descripcion: str,
                            form: str, fijada_dia: int,

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
@@ -20,7 +20,7 @@ No hace llamadas LLM: se alimenta de lo que el Observer ya extrae cada turno.
 from __future__ import annotations
 
 import math
-from collections import Counter
+from collections import Counter, deque
 from typing import Optional
 
 
@@ -179,32 +179,53 @@ def formas_semilla(agente: str, emo: dict) -> list[str]:
 class IdiolectoAgente:
     """Perfil de frecuencia de formas de un agente. No expira en el run."""
 
+    # Turnos de habla que abarca la ventana reciente (~5 días si el agente
+    # habla cada turno; más días reales con la rotación de roster).
+    VENTANA_TURNOS = 10
+
     def __init__(self, agente: str, emocionar: Optional[dict] = None, peso_semilla: int = 2):
         self.agente = agente
         self.emocionar = emocionar or {}
         self.frecuencias: Counter[str] = Counter()
         self.acunaciones: set[str] = set()
         self.adopciones: set[str] = set()
+        # Ventana de USO REAL (solo lo que el agente dijo, sin semillas):
+        # base de la métrica de convergencia por ventana, inmune tanto al
+        # sesgo acumulativo como al artefacto de las formas-semilla.
+        self.recientes: deque[list[str]] = deque(maxlen=self.VENTANA_TURNOS)
         # Pre-carga: las formas-semilla entran con peso, para que el día 1 ya
         # haya divergencia entre agentes (precondición de la convergencia).
         for f in formas_semilla(agente, self.emocionar):
             self.frecuencias[f] += peso_semilla
 
     def registrar(self, formas, neologismos=None, adoptadas=None):
+        turno_formas: list[str] = []
         for f in formas or []:
             self.frecuencias[f] += 1
+            turno_formas.append(f)
         for neo in neologismos or []:
             forma = getattr(neo, "forma", neo)
             self.acunaciones.add(forma)
             self.frecuencias[forma] += 1
+            turno_formas.append(forma)
         for f in adoptadas or []:
             self.adopciones.add(f)
+        if turno_formas:
+            self.recientes.append(turno_formas)
 
     def top_formas(self, n: int = 6) -> list[str]:
         return [f for f, _ in self.frecuencias.most_common(n)]
 
     def vector(self) -> Counter:
         return self.frecuencias
+
+    def vector_reciente(self) -> Counter:
+        """Frecuencias SOLO de la ventana de turnos recientes (uso real,
+        sin las formas-semilla pre-cargadas)."""
+        c: Counter[str] = Counter()
+        for turno in self.recientes:
+            c.update(turno)
+        return c
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -252,7 +273,8 @@ def _coseno(a: Counter, b: Counter) -> float:
 
 
 def distancia_idiolectal(idiolectos: dict[str, "IdiolectoAgente"], min_formas: int = 5,
-                         solo: Optional[set] = None) -> float:
+                         solo: Optional[set] = None, ventana: bool = False,
+                         excluir: Optional[set] = None) -> Optional[float]:
     """Distancia idiolectal media (1 - coseno) entre pares de agentes activos.
 
     Es la firma de la koineización: DEBE CONTRAERSE en el tiempo. Solo se
@@ -262,18 +284,35 @@ def distancia_idiolectal(idiolectos: dict[str, "IdiolectoAgente"], min_formas: i
     agentes (los que REALMENTE hablaron) — clave porque los idiolectos se
     pre-cargan con formas-semilla para los 60 agentes, y medir sobre todos
     diluiría la señal con vectores estáticos de quienes nunca participaron.
+
+    `ventana`: mide sobre los últimos VENTANA_TURNOS de habla real (sin
+    semillas) en vez del acumulado. El acumulado converge en coseno por mera
+    acumulación del vocabulario base compartido (artefacto matemático); la
+    ventana mide si el habla ACTUAL de los agentes se parece.
+
+    `excluir`: formas a ignorar en los vectores (típicamente el vocabulario
+    base heredado). Con ventana+excluir la métrica queda solo sobre formas
+    EMERGENTES (neologismos y adopciones), que es donde la koiné se juega.
+
+    Retorna None si menos de 2 agentes tienen vocabulario suficiente bajo
+    estos filtros (sin datos ≠ convergencia perfecta).
     """
-    vectores = [
-        idio.vector() for nombre, idio in idiolectos.items()
-        if (solo is None or nombre in solo) and len(idio.vector()) >= min_formas
-    ]
+    vectores = []
+    for nombre, idio in idiolectos.items():
+        if solo is not None and nombre not in solo:
+            continue
+        vec = idio.vector_reciente() if ventana else idio.vector()
+        if excluir:
+            vec = Counter({f: n for f, n in vec.items() if f not in excluir})
+        if len(vec) >= min_formas:
+            vectores.append(vec)
     if len(vectores) < 2:
-        return 0.0
+        return None
     distancias = []
     for i in range(len(vectores)):
         for j in range(i + 1, len(vectores)):
             distancias.append(1.0 - _coseno(vectores[i], vectores[j]))
-    return round(sum(distancias) / len(distancias), 4) if distancias else 0.0
+    return round(sum(distancias) / len(distancias), 4) if distancias else None
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_lexicon.py
@@ -6556,6 +6556,7 @@ class Neologismo:
     adoptado_por: list = field(default_factory=list)
     rechazado_por: list = field(default_factory=list)
     turno_resolucion: Optional[int] = None
+    dia_resolucion: Optional[int] = None   # día en que se adoptó/rechazó (dia = día de PROPUESTA)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -6610,7 +6611,8 @@ class LexicoComunitario:
                 "dia": neo.dia,
             }
 
-    def adoptar(self, forma: str, agente: str, turno: int) -> Optional["Neologismo"]:
+    def adoptar(self, forma: str, agente: str, turno: int,
+                dia: Optional[int] = None) -> Optional["Neologismo"]:
         """
         Un agente adopta una palabra propuesta. Retorna el Neologismo si la
         adopción se OFICIALIZA recién en esta llamada (2do adoptante distinto),
@@ -6624,6 +6626,7 @@ class LexicoComunitario:
                 if len(neo.adoptado_por) >= 2:
                     neo.estado = "adoptado"
                     neo.turno_resolucion = turno
+                    neo.dia_resolucion = dia
                     self._lexico[forma] = {
                         "significado": neo.significado,
                         "autor": neo.autor,

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_observer.py
@@ -216,18 +216,27 @@ Responde en JSON:
 
     # ── Detección de adopciones/rechazos ─────────────────────────────
 
-    def procesar_adopciones(self, texto: str, agente: str, turno: int) -> list:
+    def procesar_adopciones(self, texto: str, agente: str, turno: int,
+                            dia: Optional[int] = None) -> list:
         """
         Detecta si un agente usó palabras propuestas por otros,
         registrándolo como adopción. Retorna los Neologismo que se
         OFICIALIZARON recién (2do adoptante distinto) en esta llamada, para
         que el caller pueda sincronizar su estado con Supabase.
+
+        El match exige frontera de palabra: 'kali-ni' NO cuenta dentro de
+        'kali-nima' (con substring, las formas cortas generaban adopciones
+        falsas). Guion y letras (incl. ü/acentos) son parte de la palabra.
         """
+        import re
         texto_lower = texto.lower()
         oficializados = []
         for neo in self.lexico.neologismos_pendientes():
-            if neo.forma in texto_lower and neo.autor != agente:
-                resultado = self.lexico.adoptar(neo.forma, agente, turno)
+            if neo.autor == agente:
+                continue
+            patron = r"(?<![\w\-])" + re.escape(neo.forma) + r"(?![\w\-])"
+            if re.search(patron, texto_lower):
+                resultado = self.lexico.adoptar(neo.forma, agente, turno, dia=dia)
                 if resultado is not None:
                     oficializados.append(resultado)
         return oficializados
@@ -316,7 +325,7 @@ Responde en JSON:
                 lines.append(f"    [{neo.forma}] = {neo.significado}  (por {neo.autor})")
 
         adoptadas_hoy = [n for n in self.lexico.neologismos_adoptados()
-                         if n.dia == dia]
+                         if (n.dia_resolucion or n.dia) == dia]
         if adoptadas_hoy:
             lines.append(f"\n  ✓ Adoptadas hoy ({len(adoptadas_hoy)}):")
             for neo in adoptadas_hoy:
@@ -347,8 +356,11 @@ Responde en JSON:
         )
 
         neos_estacion = [n for r in registros for n in r.neologismos_extraidos]
+        # Adoptadas DURANTE esta estación: por día de adopción (dia_resolucion),
+        # no de propuesta — antes se atribuían a la estación equivocada.
+        dias_estacion = {r.dia for r in registros}
         adoptadas = [n for n in self.lexico.neologismos_adoptados()
-                     if any(r.dia == n.dia and r.estacion == estacion for r in registros)]
+                     if (n.dia_resolucion or n.dia) in dias_estacion]
 
         nombre_est = "Seca (viento + pesca)" if estacion == "seca" else "Lluvias (siembra + ritual)"
 

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -16,6 +16,7 @@ import sys
 import json
 import random
 import argparse
+from collections import Counter
 from typing import Optional
 
 import anthropic
@@ -69,6 +70,10 @@ from curiana_koine import (
 MODEL = "claude-haiku-4-5-20251001"
 MAX_TOKENS_AGENT = 500      # Espacio para frases en caquetío + glosa + neologismos
 MAX_TOKENS_DIRECTOR = 600
+
+# Vocabulario heredado: se excluye de la métrica de convergencia "emergente"
+# (la koiné se juega en las formas nuevas, no en el léxico base compartido).
+_FORMAS_BASE = frozenset(VOCABULARIO_BASE)
 
 # Koiné: roster FIJO de participantes (población constante desde el día 1). Se
 # rota una ventana sobre este roster cada turno, de modo que todos hablan en los
@@ -180,6 +185,7 @@ def call_agent(
     idiolectos: Optional[dict] = None,
     competencia: Optional["CompetenciaLexica"] = None,
     campo: Optional[CampoLexico] = None,
+    ablacion: bool = False,
 ) -> str:
     agent = ALL_AGENTS.get(agent_name)
     if not agent:
@@ -208,8 +214,14 @@ def call_agent(
     # Léxico + reglas apropiadas para el tier (priorizado por el contexto
     # del turno: evento del mundo + ubicación + mensaje — ver chunking en
     # curiana_lexicon.categorias_relevantes)
+    # Ablación (run de control): se apagan las tres inyecciones que EMPUJAN
+    # la convergencia desde el prompt — muestreo rich-get-richer (pesos),
+    # sugerencias de contagio y competencias abiertas. La medición (observer,
+    # difusión, competencia como registro) sigue intacta: la diferencia entre
+    # un run normal y uno --ablacion es cuánta convergencia es emergente vs.
+    # inducida por el andamiaje.
     contexto_turno = f"{world_context} {ubicacion} {user_message}"
-    pesos_campo = campo.pesos if campo is not None else None
+    pesos_campo = campo.pesos if (campo is not None and not ablacion) else None
     bloque_lexico = vocabulario_para_agente(
         tier, lexico, contexto=contexto_turno, pesos=pesos_campo
     )
@@ -222,7 +234,7 @@ def call_agent(
 
     # Contagio: palabras que el agente "ha oído" de gente que respeta
     sugerencia_contagio = ""
-    if difusion is not None:
+    if difusion is not None and not ablacion:
         sugs = difusion.sugerencias_para(agent_name, lexico=lexico)
         if sugs:
             txt = "; ".join(f"{f} = {s}" if s else f for f, s in sugs)
@@ -246,7 +258,7 @@ def call_agent(
         system_parts.append(sugerencia_contagio)
     # Competencias léxicas abiertas: empuja a reusar una forma rival que ya
     # circula (en vez de inventar otra) → una se impone y se fija en la koiné.
-    if competencia is not None:
+    if competencia is not None and not ablacion:
         bloque_comp = competencia.prompt_competencias()
         if bloque_comp:
             system_parts.append(bloque_comp)
@@ -320,10 +332,7 @@ Escribe el cierre narrativo del turno (2-3 oraciones)."""
     return resp.content[0].text.strip()
 
 
-def director_select_event(
-    client: anthropic.Anthropic,
-    state: ComunidadState,
-) -> Optional[dict]:
+def director_select_event(state: ComunidadState) -> Optional[dict]:
     prob = 0.3
     if state.nivel_tension == "alto":
         prob += 0.2
@@ -367,8 +376,12 @@ def run_turn(
     campo: Optional[CampoLexico] = None,
     competencia: Optional[CompetenciaLexica] = None,
     naming_referente: Optional[dict] = None,
+    ablacion: bool = False,
+    db_fallos: Optional[Counter] = None,
 ) -> list[dict]:
     interactions = []
+    if db_fallos is None:
+        db_fallos = Counter()  # descartable si el caller no lo pidió
 
     # Evento de nombramiento: aparece un referente sin palabra caquetía y se
     # presenta a TODOS los agentes activos este turno → acuñan formas rivales
@@ -391,11 +404,12 @@ def run_turn(
                 event_description=state.evento_del_turno or None,
             )
         except Exception as e:
+            db_fallos["turns"] += 1
             if verbose:
                 print(f"  ⚠ DB turn error: {e}")
 
     # 1. Director: ¿hay evento?
-    evento = director_select_event(client, state)
+    evento = director_select_event(state)
     if evento:
         state.evento_del_turno = evento["descripcion"]
         state.eventos_activos = [evento["id"]]
@@ -451,7 +465,7 @@ def run_turn(
         response = call_agent(
             client, agent_name, state, lexico, observer, stimulus, mem,
             difusion=difusion, idiolectos=idiolectos, competencia=competencia,
-            campo=campo,
+            campo=campo, ablacion=ablacion,
         )
 
         interactions.append({
@@ -474,7 +488,8 @@ def run_turn(
         )
 
         # Detectar adopciones de palabras propuestas por otros
-        neos_oficializados = observer.procesar_adopciones(response, agent_name, state.turno)
+        neos_oficializados = observer.procesar_adopciones(
+            response, agent_name, state.turno, dia=state.dia)
 
         # Contagio: propagar exposición de las palabras emergentes que usó este
         # agente (no las del vocabulario base) a sus vecinos sociales.
@@ -547,7 +562,9 @@ def run_turn(
                             morphological_rule=getattr(neo, "regla_aplicada", "desconocida"),
                         )
                     except Exception:
-                        pass  # No interrumpir por neologismo fallido
+                        # No interrumpir por neologismo fallido, pero contarlo:
+                        # perder escrituras en silencio corrompe el análisis.
+                        db_fallos["neologisms"] += 1
 
                 # Sincronizar adopciones oficializadas este turno (antes solo
                 # se actualizaba el LexicoComunitario en memoria; Supabase
@@ -562,9 +579,10 @@ def run_turn(
                             adopted_turn_id=turn_id,
                         )
                     except Exception:
-                        pass
+                        db_fallos["neologism_status"] += 1
 
             except Exception as e:
+                db_fallos["agent_responses"] += 1
                 if verbose:
                     print(f"  ⚠ DB agent error ({agent_name}): {e}")
 
@@ -635,6 +653,7 @@ def interactive_mode(client: anthropic.Anthropic):
     }
     campo = CampoLexico()
     competencia = CompetenciaLexica()
+    db_fallos: Counter = Counter()
 
     # Inicializar DB (gracefully degraded si no hay Supabase)
     db = get_db()
@@ -654,7 +673,7 @@ def interactive_mode(client: anthropic.Anthropic):
         if not user_input:
             run_turn(client, state, memory, lexico, observer, db=db, run_id=run_id,
                      difusion=difusion, idiolectos=idiolectos, campo=campo,
-                     competencia=competencia)
+                     competencia=competencia, db_fallos=db_fallos)
         elif user_input.lower() == "salir":
             break
         elif user_input.lower() == "estado":
@@ -709,7 +728,7 @@ def interactive_mode(client: anthropic.Anthropic):
                 client, state, memory, lexico, observer,
                 user_input=user_input, db=db, run_id=run_id,
                 difusion=difusion, idiolectos=idiolectos, campo=campo,
-                competencia=competencia,
+                competencia=competencia, db_fallos=db_fallos,
             )
 
     # Guardar todo
@@ -722,6 +741,9 @@ def interactive_mode(client: anthropic.Anthropic):
 
     # Cerrar run
     db.end_run(run_id, total_turns=state.turno, total_days=state.dia)
+    if db_fallos:
+        print(f"  ⚠ {sum(db_fallos.values())} escritura(s) a DB fallaron: "
+              + ", ".join(f"{t}×{n}" for t, n in db_fallos.most_common()))
     print("  Guardado. ¡Hasta la próxima jornada en la Curiana!")
 
 
@@ -735,10 +757,16 @@ def auto_mode(
     reporte_anual: bool = False,
     verbose: bool = True,
     perfiles: bool = False,
+    ablacion: bool = False,
 ):
     """
     Corre N turnos automáticamente.
     Genera reportes al final de cada día, estación y año simulado.
+
+    ablacion=True → run de CONTROL: se apagan las inyecciones de prompt que
+    empujan la convergencia (contagio, competencias abiertas, muestreo
+    ponderado). Comparar un run normal contra su ablación separa la
+    convergencia emergente de la inducida por el andamiaje.
 
     Mapeo temporal:
         1 turno = media jornada
@@ -761,8 +789,12 @@ def auto_mode(
         for nm, a in ALL_AGENTS.items()
     }
     campo = CampoLexico()
-    serie_distancia: list[tuple[int, float]] = []
+    # (dia, acumulada, ventana, emergente) — la acumulada se conserva por
+    # compatibilidad histórica; la señal científica es ventana/emergente
+    # (la acumulada converge por mera acumulación del vocabulario base).
+    serie_distancia: list[tuple[int, Optional[float], Optional[float], Optional[float]]] = []
     participantes: set[str] = set()   # agentes que REALMENTE hablaron (para la métrica)
+    db_fallos: Counter = Counter()    # escrituras a Supabase que fallaron, por tabla
 
     # Koiné: competencia léxica (fijación por significado). Cada ~4 turnos se
     # introduce un referente novedoso sin nombre → varios agentes acuñan formas
@@ -775,7 +807,7 @@ def auto_mode(
     db = get_db()
     run_id = db.create_run(
         model=MODEL,
-        config={"max_turns": turnos, "mode": "auto"},
+        config={"max_turns": turnos, "mode": "auto", "ablacion": ablacion},
     )
     # Re-crear cliente con run_id para que LangSmith use el proyecto correcto
     client = get_client(run_id)
@@ -788,6 +820,8 @@ def auto_mode(
     print(f"  CURIANA — Modo Automático: {turnos} turnos")
     print(f"  ({turnos // 2} días simulados · {turnos // 240} año(s) aprox.)")
     print(f"  Run ID: {run_id[:8]}...")
+    if ablacion:
+        print("  ⚗ ABLACIÓN: sin contagio, sin competencias en prompt, sin muestreo ponderado")
     print(f"{'='*60}\n")
 
     for t in range(turnos):
@@ -801,30 +835,43 @@ def auto_mode(
             verbose=verbose, db=db, run_id=run_id,
             difusion=difusion, idiolectos=idiolectos, campo=campo,
             competencia=competencia, naming_referente=naming_referente,
+            ablacion=ablacion, db_fallos=db_fallos,
         )
         participantes.update(i["agent"] for i in interactions)
 
         # Reporte al final de cada día
         if state.turno == 1 and state.dia > 1:  # acaba de cambiar de día
             dia_terminado = state.dia - 1
-            # Distancia medida SOLO sobre quienes hablaron (población real)
+            # Distancia medida SOLO sobre quienes hablaron (población real).
+            # Tres lecturas: acumulada (histórica, sesgada a converger por
+            # acumulación del vocabulario base), ventana (habla reciente real)
+            # y emergente (ventana sin vocabulario base: solo neologismos).
             dist = distancia_idiolectal(idiolectos, solo=participantes)
-            serie_distancia.append((dia_terminado, dist))
+            dist_vent = distancia_idiolectal(idiolectos, solo=participantes, ventana=True)
+            dist_emer = distancia_idiolectal(idiolectos, solo=participantes,
+                                             ventana=True, excluir=_FORMAS_BASE,
+                                             min_formas=3)
+            serie_distancia.append((dia_terminado, dist, dist_vent, dist_emer))
             # Evaluar fijación de competencias léxicas del día
             fijadas = competencia.evaluar_fijacion(dia_terminado)
             if db and run_id:
                 try:
-                    db.save_koine_metric(run_id, dia_terminado, dist, len(participantes))
+                    db.save_koine_metric(run_id, dia_terminado, dist or 0.0,
+                                         len(participantes),
+                                         distance_ventana=dist_vent,
+                                         distance_emergente=dist_emer)
                     for cid, forma in fijadas:
                         d = competencia.diccionario_koine().get(cid, {})
                         db.save_koine_lexicon(run_id, cid, d.get("desc", ""), forma,
                                               dia_terminado, d.get("soporte"), d.get("n_variantes"))
                 except Exception:
-                    pass
+                    db_fallos["koine_metrics"] += 1
             if verbose:
                 print(observer.reporte_dia(dia_terminado))
+                fmt = lambda v: "s/d" if v is None else v
                 print(f"  ◇ Koiné — distancia idiolectal ({len(participantes)} agentes): "
-                      f"{dist}  (↓ = converge hacia koiné)")
+                      f"acumulada={fmt(dist)} · ventana={fmt(dist_vent)} · "
+                      f"emergente={fmt(dist_emer)}  (↓ = converge)")
                 for cid, forma in fijadas:
                     print(f"  ◆ Koiné fija: '{cid}' → {forma}")
 
@@ -865,21 +912,41 @@ def auto_mode(
     # ── Resumen koiné: ¿convergió la lengua? ──
     print(f"\n{'─'*60}")
     print("  KOINÉ — convergencia (distancia idiolectal media por día)")
+    if ablacion:
+        print("  ⚗ RUN DE ABLACIÓN (control sin inyecciones de convergencia)")
     print(f"{'─'*60}")
     if serie_distancia:
-        traj = " → ".join(f"D{d}:{v}" for d, v in serie_distancia)
-        print(f"  {traj}")
-        d_ini = serie_distancia[0][1]
-        d_fin = serie_distancia[-1][1]
-        veredicto = ("CONVERGE ✓ (la koiné se forma)" if d_fin < d_ini
-                     else "NO converge ✗ (sin koineización)")
-        print(f"  Inicio {d_ini} → Fin {d_fin}  →  {veredicto}")
+        fmt = lambda v: "s/d" if v is None else v
+        for etiqueta, idx in (("acumulada", 1), ("ventana  ", 2), ("emergente", 3)):
+            traj = " → ".join(f"D{p[0]}:{fmt(p[idx])}" for p in serie_distancia)
+            print(f"  {etiqueta}: {traj}")
+        # Veredicto sobre la métrica MÁS EXIGENTE con datos suficientes:
+        # emergente > ventana > acumulada (la acumulada converge casi siempre
+        # por acumulación del vocabulario base — no es evidencia por sí sola).
+        for etiqueta, idx in (("emergente", 3), ("ventana", 2), ("acumulada", 1)):
+            puntos = [(p[0], p[idx]) for p in serie_distancia if p[idx] is not None]
+            if len(puntos) >= 2:
+                d_ini, d_fin = puntos[0][1], puntos[-1][1]
+                veredicto = ("CONVERGE ✓ (la koiné se forma)" if d_fin < d_ini
+                             else "NO converge ✗ (sin koineización)")
+                print(f"  Veredicto [{etiqueta}]: inicio {d_ini} → fin {d_fin}  →  {veredicto}")
+                break
+        else:
+            print("  Veredicto: datos insuficientes (ningún par de días comparable)")
     print("\n  Diccionario koiné emergente (formas más extendidas):")
     for forma, peso in campo.top(15):
         print(f"    {forma:18} {peso:.1f}")
 
     # ── Fijación por competencia: el diccionario koiné de conceptos nuevos ──
     print(competencia.reporte())
+
+    # ── Integridad de datos: escrituras a Supabase que fallaron ──
+    if db_fallos:
+        total_fallos = sum(db_fallos.values())
+        print(f"\n  ⚠ PERSISTENCIA INCOMPLETA: {total_fallos} escritura(s) a DB fallaron")
+        for tabla, n in db_fallos.most_common():
+            print(f"      {tabla}: {n}")
+        print("    Los análisis sobre Supabase de este run pueden estar incompletos.")
 
     if reporte_anual:
         print(observer.reporte_anual_llm(anio_simulado))
@@ -921,19 +988,27 @@ if __name__ == "__main__":
         help="Al terminar, generar perfiles curados por agente (rol, arco, "
              "frases célebres) vía el Observer y guardarlos en Supabase."
     )
+    parser.add_argument(
+        "--ablacion", action="store_true",
+        help="Run de CONTROL: apaga las inyecciones de prompt que empujan la "
+             "convergencia (sugerencias de contagio, competencias abiertas, "
+             "muestreo ponderado por frecuencia). Comparar contra un run normal "
+             "separa la convergencia emergente de la inducida por el andamiaje."
+    )
     args = parser.parse_args()
 
     client = get_client()
 
     if args.anio:
         auto_mode(client, 240, reporte_anual=True, verbose=not args.silencioso,
-                   perfiles=args.perfiles)
+                   perfiles=args.perfiles, ablacion=args.ablacion)
     elif args.auto > 0:
         auto_mode(
             client, args.auto,
             reporte_anual=args.reporte,
             verbose=not args.silencioso,
             perfiles=args.perfiles,
+            ablacion=args.ablacion,
         )
     else:
         interactive_mode(client)

--- a/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260704000000_koine_metrics_ventana.sql
+++ b/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260704000000_koine_metrics_ventana.sql
@@ -1,0 +1,11 @@
+-- Métricas de convergencia adicionales por día (ver curiana_koine.py):
+--   distance          → acumulada (histórica; converge por acumulación del
+--                       vocabulario base compartido — sesgada a converger)
+--   distance_ventana  → sobre los últimos turnos de habla real (sin semillas)
+--   distance_emergente→ ventana excluyendo el vocabulario base: solo formas
+--                       emergentes (neologismos/adopciones) — la señal de
+--                       koineización menos sesgada.
+-- NULL = datos insuficientes ese día (< 2 agentes con vocabulario suficiente).
+
+alter table koine_metrics add column if not exists distance_ventana numeric;
+alter table koine_metrics add column if not exists distance_emergente numeric;

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/conftest.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Configuración pytest: los módulos de curiana_sim viven en el directorio
+padre (no es un paquete instalable), así que se agrega al sys.path."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
@@ -1,0 +1,142 @@
+"""Tests del motor de koiné: idiolectos, métricas de convergencia,
+competencia léxica y campo léxico (curiana_koine.py)."""
+
+from curiana_koine import (
+    IdiolectoAgente,
+    CampoLexico,
+    CompetenciaLexica,
+    distancia_idiolectal,
+    emocionar_de,
+)
+
+
+def _idios(nombres):
+    return {nm: IdiolectoAgente(nm, emocionar_de(nm)) for nm in nombres}
+
+
+# ── Métrica acumulada (compatibilidad histórica) ──────────────────────
+
+def test_distancia_acumulada_converge_con_uso_comun():
+    idios = _idios(["Manaure", "Shaboro", "Dara-ko"])
+    d0 = distancia_idiolectal(idios)
+    comunes = ["taya", "wana-ka", "biro", "kali", "naa-da"]
+    for _ in range(30):
+        for idio in idios.values():
+            idio.registrar(comunes)
+    d1 = distancia_idiolectal(idios)
+    assert d0 is not None and d1 is not None
+    assert d1 < d0
+
+
+def test_distancia_none_con_datos_insuficientes():
+    idios = _idios(["Manaure"])  # un solo agente: no hay pares
+    assert distancia_idiolectal(idios) is None
+    # ventana sin habla registrada: nadie tiene vector reciente
+    idios2 = _idios(["Manaure", "Shaboro"])
+    assert distancia_idiolectal(idios2, ventana=True) is None
+
+
+# ── Métrica por ventana: mide el habla RECIENTE, no el acumulado ─────
+
+def test_ventana_ignora_semillas():
+    """Las formas-semilla pre-cargadas no cuentan en el vector reciente."""
+    idio = IdiolectoAgente("Manaure", emocionar_de("Manaure"))
+    assert len(idio.vector()) > 0          # semillas presentes en acumulado
+    assert len(idio.vector_reciente()) == 0  # pero no en la ventana
+
+
+def test_ventana_refleja_habla_actual_no_historia():
+    """Dos agentes con historia distinta pero habla reciente idéntica deben
+    verse CERCA en ventana aunque el acumulado los separe."""
+    a = IdiolectoAgente("A", peso_semilla=0)
+    b = IdiolectoAgente("B", peso_semilla=0)
+    # Historia divergente (más larga que la ventana)
+    for _ in range(IdiolectoAgente.VENTANA_TURNOS + 5):
+        a.registrar(["kali", "kasha", "urari", "piache", "barsure"])
+        b.registrar(["biro", "habo", "canoa", "arima", "bara"])
+    # Habla reciente idéntica (llena la ventana completa)
+    comunes = ["taya", "naa-ka", "wana-ni", "duna", "kuru"]
+    for _ in range(IdiolectoAgente.VENTANA_TURNOS):
+        a.registrar(comunes)
+        b.registrar(comunes)
+    idios = {"A": a, "B": b}
+    d_ventana = distancia_idiolectal(idios, ventana=True)
+    d_acum = distancia_idiolectal(idios)
+    assert d_ventana == 0.0                 # habla actual idéntica
+    assert d_acum > d_ventana               # el acumulado aún arrastra la historia
+
+
+def test_excluir_deja_solo_formas_emergentes():
+    base = {"taya", "naa-ka", "wana-ni", "duna", "kuru"}
+    a = IdiolectoAgente("A", peso_semilla=0)
+    b = IdiolectoAgente("B", peso_semilla=0)
+    for _ in range(5):
+        # comparten TODO el vocabulario base, difieren solo en neologismos
+        a.registrar(list(base) + ["kali-dusha", "sima-bana", "buco-rua"])
+        b.registrar(list(base) + ["suka-wana", "habo-kata", "dali-nu"])
+    idios = {"A": a, "B": b}
+    d_total = distancia_idiolectal(idios, ventana=True)
+    d_emergente = distancia_idiolectal(idios, ventana=True, excluir=base, min_formas=3)
+    # sobre formas emergentes los agentes son totalmente disjuntos;
+    # el vocabulario base compartido enmascara esa divergencia en la total
+    assert d_emergente == 1.0
+    assert d_total < d_emergente
+
+
+def test_ventana_expira_formas_viejas():
+    idio = IdiolectoAgente("A", peso_semilla=0)
+    idio.registrar(["forma-vieja"])
+    for _ in range(IdiolectoAgente.VENTANA_TURNOS):
+        idio.registrar(["forma-nueva"])
+    reciente = idio.vector_reciente()
+    assert "forma-vieja" not in reciente
+    assert reciente["forma-nueva"] == IdiolectoAgente.VENTANA_TURNOS
+    # el acumulado sí la conserva (entrenchment no expira)
+    assert idio.vector()["forma-vieja"] == 1
+
+
+# ── Competencia léxica (fijación por concepto) ────────────────────────
+
+def test_competencia_fija_la_variante_dominante():
+    comp = CompetenciaLexica(soporte_minimo=2.0)
+    comp.activar("cometa", "estrella con cola")
+    comp.proponer("cometa", "kali-dusha", "Manaure")
+    comp.proponer("cometa", "suka-wana", "Tariwa")
+    for _ in range(4):
+        comp.registrar_uso("kali-dusha", "Shaboro")
+    fijadas = comp.evaluar_fijacion(dia=5)
+    assert ("cometa", "kali-dusha") in fijadas
+    assert comp.diccionario_koine()["cometa"]["forma"] == "kali-dusha"
+
+
+def test_competencia_no_fija_sin_rivales():
+    """Con una sola variante no hay competencia que resolver."""
+    comp = CompetenciaLexica(soporte_minimo=1.0)
+    comp.activar("eclipse", "el sol se oscurece")
+    comp.proponer("eclipse", "kali-suka", "Manaure")
+    for _ in range(10):
+        comp.registrar_uso("kali-suka", "Shaboro")
+    assert comp.evaluar_fijacion(dia=3) == []
+
+
+def test_competencia_ignora_uso_tras_fijacion():
+    comp = CompetenciaLexica(soporte_minimo=1.0, umbral_fijacion=0.5)
+    comp.activar("c", "algo")
+    comp.proponer("c", "forma-a", "Manaure")
+    comp.proponer("c", "forma-b", "Tariwa")
+    comp.registrar_uso("forma-a", "Shaboro")
+    assert comp.evaluar_fijacion(dia=1)
+    soporte_antes = comp.referentes["c"]["variantes"]["forma-b"]
+    comp.registrar_uso("forma-b", "Shaboro")   # ya fijada: no debe sumar
+    assert comp.referentes["c"]["variantes"]["forma-b"] == soporte_antes
+
+
+# ── Campo léxico (rich-get-richer + decaimiento) ──────────────────────
+
+def test_campo_decae_y_descarta():
+    campo = CampoLexico(decaimiento=0.5)
+    campo.registrar(["biro"], incremento=1.0)
+    campo.registrar(["kali"], incremento=0.08)
+    campo.decaer()
+    assert campo.peso("biro") == 0.5
+    assert campo.peso("kali") == 0.0   # 0.04 < umbral 0.05: la forma muere

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_lexicon.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_lexicon.py
@@ -1,0 +1,100 @@
+"""Tests del motor léxico: scoring, compuerta de neologismos, extracción
+y ciclo de adopción (curiana_lexicon.py)."""
+
+from curiana_lexicon import (
+    LexicoComunitario,
+    score_linguistico,
+    neologismo_valido,
+    extraer_neologismos_del_texto,
+)
+
+
+def _lexico():
+    return LexicoComunitario()
+
+
+# ── score_linguistico ─────────────────────────────────────────────────
+
+def test_score_caquetio_supera_espanol():
+    lex = _lexico()
+    caq = ("Taya wana-ka arima wara bara-bana. Ta-barsure naba-ni. "
+           "Ka biro escaso, mara waya naa-da salinar.")
+    esp = ("Hoy fui al río muy temprano por la mañana y vi muchos peces. "
+           "Mi alma está pensando, pero debemos ir por sal.")
+    assert score_linguistico(caq, lex)["score"] > score_linguistico(esp, lex)["score"]
+
+
+def test_score_glosas_no_penalizan():
+    """Lo que va entre paréntesis es glosa: no puntúa ni penaliza."""
+    lex = _lexico()
+    con_glosa = "Taya wana-ka arima bara-bana. (Vi peces en la orilla del río.)"
+    sin_glosa = "Taya wana-ka arima bara-bana."
+    assert (score_linguistico(con_glosa, lex)["espanol_funcional"]
+            == score_linguistico(sin_glosa, lex)["espanol_funcional"] == 0)
+
+
+def test_homografo_para_segun_contexto():
+    lex = _lexico()
+    # rodeada de caquetío → "para" es el mar (léxico caquetío)
+    r_caq = score_linguistico("Taya naa-ni para-bana, wana-ka para wara arima.", lex)
+    assert "para" in r_caq["palabras_caquetias"]
+    # rodeada de español → es la preposición
+    r_esp = score_linguistico("Esto es para que vayas mañana temprano.", lex)
+    assert "para" not in r_esp["palabras_caquetias"]
+    assert r_esp["espanol_funcional"] > 0
+
+
+# ── neologismo_valido (compuerta anti-español) ────────────────────────
+
+def test_bloquea_ofensores_observados_en_runs():
+    for forma in ("suave-bana-ni", "tension-bana-chi", "boca-pana",
+                  "carrera-kata", "guardia-bana", "lanza-sara", "temblor-bana"):
+        assert not neologismo_valido(forma), forma
+
+
+def test_acepta_composiciones_caquetias():
+    for forma in ("sima-bana", "kali-dusha", "kuru-bana", "arima-ana", "wa-buco"):
+        assert neologismo_valido(forma), forma
+
+
+# ── extraer_neologismos_del_texto ─────────────────────────────────────
+
+def test_extraccion_y_regla_de_afijo_mas_largo():
+    texto = "Taya wana-ka [sima-bana: sima+-bana = orilla del cerro]."
+    neos = extraer_neologismos_del_texto(texto, "Shaboro", dia=1, turno=1)
+    assert len(neos) == 1
+    assert neos[0].forma == "sima-bana"
+    # "-bana" debe ganar sobre "-ana" (afijo más largo)
+    assert neos[0].regla_aplicada == "-bana"
+
+
+def test_extraccion_descarta_neologismo_espanol():
+    texto = "Naba-ni [guardia-bana: guardia+-bana = puesto de vigilancia]."
+    assert extraer_neologismos_del_texto(texto, "Tawaka", dia=1, turno=1) == []
+
+
+# ── ciclo de adopción en LexicoComunitario ────────────────────────────
+
+def _neo(lex, forma="kali-dusha"):
+    neos = extraer_neologismos_del_texto(
+        f"[{forma}: kali+dusha = estrella con cola]", "Manaure", dia=3, turno=1)
+    lex.registrar_neologismo(neos[0])
+    return neos[0]
+
+
+def test_adopcion_requiere_dos_agentes_y_registra_dia():
+    lex = _lexico()
+    _neo(lex)
+    assert lex.adoptar("kali-dusha", "Shaboro", turno=2, dia=4) is None  # 1er adoptante
+    oficial = lex.adoptar("kali-dusha", "Tawaka", turno=1, dia=5)        # 2do → oficializa
+    assert oficial is not None and oficial.estado == "adoptado"
+    assert oficial.dia_resolucion == 5      # día de ADOPCIÓN, no de propuesta
+    assert oficial.dia == 3
+    assert "kali-dusha" in lex.palabras_activas()
+
+
+def test_adopcion_repetida_mismo_agente_no_oficializa():
+    lex = _lexico()
+    _neo(lex)
+    assert lex.adoptar("kali-dusha", "Shaboro", turno=1, dia=4) is None
+    assert lex.adoptar("kali-dusha", "Shaboro", turno=2, dia=4) is None

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_observer.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_observer.py
@@ -1,0 +1,61 @@
+"""Tests del Observer: análisis local y detección de adopciones con
+frontera de palabra (curiana_observer.py). Sin llamadas LLM."""
+
+from curiana_lexicon import LexicoComunitario, extraer_neologismos_del_texto
+from curiana_observer import ObserverAgent
+
+
+def _observer():
+    """ObserverAgent sin cliente Anthropic (solo análisis local)."""
+    lex = LexicoComunitario()
+    obs = ObserverAgent.__new__(ObserverAgent)
+    obs.client = None
+    obs.lexico = lex
+    obs._historial = []
+    obs._scores_por_agente = {}
+    return obs, lex
+
+
+def _proponer(lex, forma, autor="Manaure"):
+    neos = extraer_neologismos_del_texto(
+        f"[{forma}: kali+ni = luz continua]", autor, dia=1, turno=1)
+    assert neos, f"el neologismo de test '{forma}' no pasó la compuerta"
+    lex.registrar_neologismo(neos[0])
+
+
+def test_adopcion_exige_frontera_de_palabra():
+    """'kali-ni' NO debe adoptarse desde 'kali-nima' (bug de substring)."""
+    obs, lex = _observer()
+    _proponer(lex, "kali-ni")
+    obs.procesar_adopciones("Taya wana-ka kali-nima wara.", "Shaboro", turno=1, dia=2)
+    obs.procesar_adopciones("Nüma maa-ni kali-nima.", "Tawaka", turno=2, dia=2)
+    assert lex.neologismos_adoptados() == []
+
+
+def test_adopcion_con_uso_exacto():
+    obs, lex = _observer()
+    _proponer(lex, "kali-ni")
+    assert obs.procesar_adopciones("Taya wana-ka kali-ni.", "Shaboro", turno=1, dia=2) == []
+    oficializados = obs.procesar_adopciones(
+        "Kali-ni wara, naa-da yama.", "Tawaka", turno=2, dia=3)
+    assert len(oficializados) == 1
+    assert oficializados[0].forma == "kali-ni"
+    assert oficializados[0].dia_resolucion == 3
+
+
+def test_autor_no_se_adopta_a_si_mismo():
+    obs, lex = _observer()
+    _proponer(lex, "kali-ni", autor="Manaure")
+    obs.procesar_adopciones("Kali-ni wara.", "Manaure", turno=1, dia=2)
+    neo = lex.neologismos_pendientes()[0]
+    assert neo.adoptado_por == []
+
+
+def test_analizar_alimenta_historial_y_scores():
+    obs, _ = _observer()
+    r = obs.analizar("Shaboro", "caquetío", 1,
+                     "Taya wana-ka arima wara bara-bana. Ta-barsure naba-ni.",
+                     dia=1, turno=1, momento="amanecer", estacion="seca")
+    assert r.score > 0
+    assert obs.score_promedio("Shaboro") == r.score
+    assert len(obs._historial) == 1

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_social.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_social.py
@@ -1,0 +1,37 @@
+"""Tests de difusión léxica y variación dialectal (curiana_social.py)."""
+
+from curiana_social import (
+    DifusionLexica,
+    normalizar_por_dialecto,
+    prestigio_de,
+)
+
+
+def test_prestigio_explicito_y_derivado():
+    assert prestigio_de("Manaure") == 1.0
+    assert 0.0 < prestigio_de("Marokoto-ni") < prestigio_de("Manaure")
+
+
+def test_contagio_prestigioso_cruza_umbral_en_un_uso():
+    d = DifusionLexica()
+    d.propagar_uso("sima-bana", "Shaboro")   # prestigio 1.0, vínculo 0.95 con Buio-sha
+    assert d.exposicion_de("Buio-sha", "sima-bana") >= d.umbral
+    assert any(f == "sima-bana" for f, _ in d.sugerencias_para("Buio-sha"))
+
+
+def test_no_se_sugiere_lo_ya_usado():
+    d = DifusionLexica()
+    d.propagar_uso("sima-bana", "Shaboro")
+    d.propagar_uso("sima-bana", "Buio-sha")  # Buio-sha ya la usó
+    assert d.sugerencias_para("Buio-sha") == []
+
+
+def test_periferico_sin_vinculo_no_adopta():
+    d = DifusionLexica()
+    d.propagar_uso("sima-bana", "Shaboro")
+    assert d.sugerencias_para("Marokoto-ni") == []
+
+
+def test_normalizacion_dialectal_favorece_l2():
+    assert normalizar_por_dialecto(4.5, "caribe") > normalizar_por_dialecto(4.5, "caquetío")
+    assert normalizar_por_dialecto(9.9, "caribe") <= 10.0   # acotado


### PR DESCRIPTION
## Qué hace

**Corrección metodológica de la medición de koineización + el experimento de control que la valida.**

### Métrica corregida
- `distancia_idiolectal()` gana modos `ventana` (últimos N turnos de habla real) y `excluir` (solo formas emergentes). La acumulada converge por mera acumulación del léxico base compartido — artefacto matemático, verificado.
- `koine_metrics` persiste las tres lecturas (`distance` / `distance_ventana` / `distance_emergente`, migración `20260704000000`). El veredicto usa la más exigente con datos.
- `--ablacion`: run de CONTROL que apaga las 3 inyecciones de prompt que empujan la convergencia (contagio, competencias abiertas, muestreo ponderado).

### Resultado del experimento (runs `038d7b9d` normal + `bdc54134` ablación, 60T/30d c/u)

| Lectura | Normal | Ablación |
|---|---|---|
| emergente | **−17.9%** | −6.6% (plateau desde d16) |
| acumulada | −44.1% | −40.6% (≈ idénticas → artefacto confirmado) |
| fijación | 6/10 | 4/10 |

La evidencia de koineización emergente es la **diferencia** (2.7× en la lectura emergente), no el run normal solo. Detalle en `BITACORA_RUNS.md`.

### Integridad de datos
- `procesar_adopciones()` exige frontera de palabra (`kali-ni` ya no se adopta desde `kali-nima`).
- `Neologismo.dia_resolucion`: día de adopción real, no de propuesta.
- Contador `db_fallos` reportado al cierre (ambos runs del experimento: 0).
- `create_run` guarda config como jsonb consultable.

### Tests
Suite pytest nueva: 28 tests (koiné, léxico, observer, social) sin API keys — todos verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)