### PR TITLE
feat(simulador): evolución entre simulaciones + diccionario koiné (MVP)

### DIFF
--- a/app/simulador/page.tsx
+++ b/app/simulador/page.tsx
@@ -4,6 +4,8 @@ import { getRunActivo, getRunsPublicados } from "@/lib/editorial";
 import { getManaureFragment } from "@/lib/manaure";
 import { getResumen } from "@/lib/resumen";
 import { getAllPersonajes } from "@/lib/personajes";
+import { getRunsIndex } from "@/lib/runs";
+import { EvolucionTimeline, DiccionarioKoine } from "@/components/simulador/evolucion";
 import ManaureVoice from "@/components/simulador/ManaureVoice";
 import LanguageDriftChart from "@/components/simulador/LanguageDriftChart";
 import { Epoca, EventoItem, DataAside, Asterismo } from "@/components/simulador/prose";
@@ -27,6 +29,7 @@ export default function SimuladorPage() {
   const runs = getRunsPublicados();
   const run = getRunActivo();
   const resumen = getResumen();
+  const runsIndex = getRunsIndex();
   const nombrePorSlug = new Map(getAllPersonajes().map((p) => [p.slug, p.nombre]));
 
   const hero = run.manaure_hero ? getManaureFragment(run.manaure_hero) : null;
@@ -150,6 +153,39 @@ export default function SimuladorPage() {
           <p aria-hidden="true" className="mt-6">
             <span className="sim-caret" />
           </p>
+        </>
+      )}
+
+      {/* El meta-relato: qué pasó ENTRE las simulaciones */}
+      {runsIndex && runsIndex.runs.length > 1 && (
+        <>
+          <Asterismo />
+          <section id="evolucion" className="scroll-mt-24">
+            <Overline>Bitácora de expediciones</Overline>
+            <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+              La evolución, simulación a simulación
+            </h2>
+            <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+              Cada corrida es una expedición: mismo golfete, misma gente, y un instrumento que cada
+              vez mide mejor. Lo que empezó como una comunidad que apenas sostenía su lengua terminó
+              formando una koiné — y la última expedición salió con un grupo de control para probar
+              que la convergencia no era un truco del andamiaje.
+            </p>
+            <EvolucionTimeline runs={runsIndex.runs} />
+          </section>
+
+          <Asterismo />
+          <section id="diccionario-koine" className="scroll-mt-24">
+            <Overline>Lo que la comunidad nombró</Overline>
+            <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+              El diccionario koiné
+            </h2>
+            <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+              Cuando algo nuevo llegó al golfete — un cometa, una fiebre, un metal amarillo — la
+              comunidad necesitó nombrarlo. Varias formas compitieron; estas ganaron.
+            </p>
+            <DiccionarioKoine runs={runsIndex.runs} />
+          </section>
         </>
       )}
 

--- a/components/simulador/evolucion.tsx
+++ b/components/simulador/evolucion.tsx
@@ -1,0 +1,197 @@
+// La evolución entre simulaciones: el meta-relato del proyecto.
+// Cada run es una expedición del cronista; esta capa las junta y deja leer
+// el arco (deriva plana → koiné con diccionario → experimento de control).
+// Datos: content/simulador/runs/index.json vía lib/runs.ts — medido, no
+// narrativa; por eso habla casi todo en monospace (registro del instrumento).
+import type { RunIndexEntry, FormaFijada } from "@/lib/runs";
+import { RUN_CATEGORIAS } from "@/lib/sim-theme";
+
+const fmtFecha = (iso: string) =>
+  new Date(iso).toLocaleDateString("es-VE", { day: "numeric", month: "short", year: "numeric" });
+
+// ── Sparkline: el trazo del instrumento ───────────────────────────────
+// Distancia idiolectal media por día; baja = las voces se acercan.
+function Sparkline({ serie, color }: { serie: number[]; color: string }) {
+  if (serie.length < 2) return null;
+  const w = 112;
+  const h = 26;
+  const pad = 2;
+  const min = Math.min(...serie);
+  const max = Math.max(...serie);
+  const span = max - min || 1;
+  const pts = serie.map((v, i) => {
+    const x = pad + (i / (serie.length - 1)) * (w - pad * 2);
+    const y = pad + ((max - v) / span) * (h - pad * 2);
+    return [x, y] as const;
+  });
+  const d = pts.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  const [ex, ey] = pts[pts.length - 1];
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      width={w}
+      height={h}
+      aria-hidden="true"
+      className="shrink-0 overflow-visible"
+    >
+      <path d={d} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" opacity="0.85" />
+      <circle cx={ex} cy={ey} r="2.4" fill={color} />
+    </svg>
+  );
+}
+
+// ── Una expedición del cronista ───────────────────────────────────────
+function RunEntry({ run }: { run: RunIndexEntry }) {
+  const cat = RUN_CATEGORIAS[run.categoria] ?? RUN_CATEGORIAS.koine;
+  const conv = run.convergencia;
+  const pctCaq = run.pct_caquetio != null ? Math.round(run.pct_caquetio * 100) : null;
+
+  return (
+    <li className="relative border-l border-(--sim-rule) pl-5 pb-10 last:pb-0">
+      <span
+        aria-hidden="true"
+        className="absolute -left-[4.5px] top-1.5 h-2 w-2 rounded-full"
+        style={{ background: cat.color }}
+      />
+
+      {/* Registro del instrumento: id, fecha, tamaño */}
+      <div className="flex flex-wrap items-center gap-2 font-sans text-xs text-(--sim-ink-faint)">
+        <code className="sim-mono rounded bg-(--sim-paper-deep) px-1.5 py-0.5 text-(--sim-ink-soft)">
+          {run.id8}
+        </code>
+        <span>{fmtFecha(run.started_at)}</span>
+        {run.total_turnos != null && (
+          <span className="tabular-nums">
+            {run.total_turnos} turnos · {run.total_dias} días
+          </span>
+        )}
+        <span
+          className="inline-flex items-center rounded-full px-2 py-0.5 font-medium"
+          style={{ background: `${cat.color}1a`, color: cat.color, border: `1px solid ${cat.color}33` }}
+        >
+          {run.rol === "ablacion" ? "⚗ ablación" : run.rol === "normal" ? "⚗ experimento · normal" : cat.label}
+        </span>
+      </div>
+
+      {/* La voz editorial: qué significó este run */}
+      <p className="mt-1.5 max-w-reading font-serif text-lg leading-snug text-(--sim-ink)">{run.hito}</p>
+
+      {/* La medición */}
+      <div className="mt-3 flex flex-wrap items-end gap-x-8 gap-y-3">
+        {pctCaq != null && (
+          <div>
+            <span className="sim-mono block text-[0.65rem] font-medium uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+              Caquetío
+            </span>
+            <span className="sim-mono mt-0.5 block text-xl font-semibold leading-none tabular-nums text-(--sim-ink)">
+              {pctCaq}%
+            </span>
+          </div>
+        )}
+        {conv?.delta_pct != null && (
+          <div>
+            <span className="sim-mono block text-[0.65rem] font-medium uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+              Convergencia · {conv.lectura}
+              {conv.lectura === "acumulada" && " †"}
+            </span>
+            <span className="mt-0.5 flex items-end gap-3">
+              <span className="sim-mono text-xl font-semibold leading-none tabular-nums text-(--sim-ink)">
+                {conv.delta_pct > 0 ? "+" : "−"}
+                {Math.abs(conv.delta_pct).toFixed(1)}%
+              </span>
+              <Sparkline serie={conv.serie} color={cat.color} />
+            </span>
+          </div>
+        )}
+        {run.neologismos_adoptados > 0 && (
+          <div>
+            <span className="sim-mono block text-[0.65rem] font-medium uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+              Adoptadas
+            </span>
+            <span className="sim-mono mt-0.5 block text-xl font-semibold leading-none tabular-nums text-(--sim-ink)">
+              {run.neologismos_adoptados}
+            </span>
+          </div>
+        )}
+        {run.fijacion && (
+          <div>
+            <span className="sim-mono block text-[0.65rem] font-medium uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+              Fijadas
+            </span>
+            <span className="sim-mono mt-0.5 block text-xl font-semibold leading-none tabular-nums text-(--sim-ink)">
+              {run.fijacion.conceptos_fijados}
+            </span>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ── La línea de tiempo completa ───────────────────────────────────────
+export function EvolucionTimeline({ runs }: { runs: RunIndexEntry[] }) {
+  const hayAcumulada = runs.some((r) => r.convergencia?.lectura === "acumulada");
+  return (
+    <div>
+      <ol className="mt-8">
+        {runs.map((run) => (
+          <RunEntry key={run.id8} run={run} />
+        ))}
+      </ol>
+      {hayAcumulada && (
+        <p className="mt-6 max-w-reading font-sans text-xs leading-relaxed text-(--sim-ink-faint)">
+          † Runs anteriores a la corrección metodológica del 4 de julio: solo midieron la distancia
+          acumulada, que converge en parte por acumulación del vocabulario compartido. Los runs
+          posteriores usan la lectura <em>emergente</em> (solo formas nuevas), más exigente y honesta.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── El diccionario koiné: las palabras que la comunidad fijó ──────────
+// Entradas de diccionario real: lema en display, glosa en serif, la
+// trazabilidad (variantes rivales, día, run) en el registro del instrumento.
+function EntradaDiccionario({ forma, id8 }: { forma: FormaFijada; id8: string }) {
+  return (
+    <div className="border-t border-(--sim-rule) py-4">
+      <dt className="sim-display text-xl font-semibold text-(--sim-fuego)">{forma.form}</dt>
+      <dd className="mt-1">
+        {forma.descripcion && (
+          <p className="max-w-reading font-serif italic leading-snug text-(--sim-ink-soft)">
+            «{forma.descripcion}»
+          </p>
+        )}
+        <p className="sim-mono mt-1.5 text-[0.65rem] uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+          {forma.n_variantes != null && `venció a ${forma.n_variantes - 1} rival${forma.n_variantes - 1 === 1 ? "" : "es"}`}
+          {forma.fijada_dia != null && ` · fijada el día ${forma.fijada_dia}`}
+          {" · "}
+          <code>{id8}</code>
+        </p>
+      </dd>
+    </div>
+  );
+}
+
+export function DiccionarioKoine({ runs }: { runs: RunIndexEntry[] }) {
+  const entradas = runs
+    .filter((r) => r.fijacion)
+    .flatMap((r) => r.fijacion!.formas.map((forma) => ({ forma, id8: r.id8 })));
+  if (entradas.length === 0) return null;
+
+  return (
+    <div>
+      <dl className="mt-8 grid grid-cols-1 gap-x-10 sm:grid-cols-2">
+        {entradas.map(({ forma, id8 }) => (
+          <EntradaDiccionario key={`${id8}-${forma.concepto}`} forma={forma} id8={id8} />
+        ))}
+      </dl>
+      <p className="mt-8 max-w-reading font-sans text-xs leading-relaxed text-(--sim-ink-faint)">
+        Sobre estas palabras: ningún diccionario colonial las registra — nacieron dentro de la
+        simulación, cuando la comunidad necesitó nombrar algo nuevo y varias formas rivales
+        compitieron hasta que una se fijó. Usan la morfología caquetía documentada del proyecto,
+        pero son lengua simulada, no reconstrucción histórica.
+      </p>
+    </div>
+  );
+}

--- a/content/simulador/runs/index.json
+++ b/content/simulador/runs/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generado": "2026-07-06T21:18:28.092208+00:00",
+  "generado": "2026-07-07T20:20:58.655418+00:00",
   "runs": [
     {
       "id8": "2e729f3f",
@@ -151,42 +151,49 @@
         "formas": [
           {
             "concepto": "cometa",
+            "descripcion": "una estrella con cola que cruza el cielo varias noches seguidas",
             "form": "kali-subo",
             "fijada_dia": 5,
             "n_variantes": 3
           },
           {
             "concepto": "fiebre_manchas",
+            "descripcion": "una fiebre nueva que llena la piel de manchas, que ningún piache había visto",
             "form": "ka-bari-tüshi-kali",
             "fijada_dia": 9,
             "n_variantes": 2
           },
           {
             "concepto": "eclipse",
+            "descripcion": "el sol se oscurece en pleno día y luego vuelve, como si algo lo cubriera",
             "form": "ma-kali-bana",
             "fijada_dia": 10,
             "n_variantes": 4
           },
           {
             "concepto": "metal_amarillo",
+            "descripcion": "un trozo de metal amarillo y pesado, distinto del oro conocido, llegado por trueque",
             "form": "sulu-pana",
             "fijada_dia": 14,
             "n_variantes": 3
           },
           {
             "concepto": "tambor_caribe",
+            "descripcion": "un tambor de los caribe con un sonido grave y distinto a los nuestros",
             "form": "mana-koto",
             "fijada_dia": 17,
             "n_variantes": 2
           },
           {
             "concepto": "marea_roja",
+            "descripcion": "el agua del golfete se tiñe de rojo durante días y mata a los peces",
             "form": "duna-kali-biji",
             "fijada_dia": 18,
             "n_variantes": 2
           },
           {
             "concepto": "planta_quema",
+            "descripcion": "una planta nueva que cura la herida pero quema la boca al probarla",
             "form": "tüshi-mana-bana",
             "fijada_dia": 20,
             "n_variantes": 2
@@ -253,36 +260,42 @@
         "formas": [
           {
             "concepto": "cuentas_vidrio",
+            "descripcion": "unas cuentas brillantes y duras que un mercader trajo de tierras lejanas, nunca vistas aquí",
             "form": "kali-taro",
             "fijada_dia": 3,
             "n_variantes": 2
           },
           {
             "concepto": "fiebre_manchas",
+            "descripcion": "una fiebre nueva que llena la piel de manchas, que ningún piache había visto",
             "form": "bana-kali-taro-sulu",
             "fijada_dia": 9,
             "n_variantes": 3
           },
           {
             "concepto": "metal_amarillo",
+            "descripcion": "un trozo de metal amarillo y pesado, distinto del oro conocido, llegado por trueque",
             "form": "kali-pama",
             "fijada_dia": 11,
             "n_variantes": 2
           },
           {
             "concepto": "marea_roja",
+            "descripcion": "el agua del golfete se tiñe de rojo durante días y mata a los peces",
             "form": "duna-bana-kali-taro",
             "fijada_dia": 15,
             "n_variantes": 2
           },
           {
             "concepto": "tambor_caribe",
+            "descripcion": "un tambor de los caribe con un sonido grave y distinto a los nuestros",
             "form": "bani-taro-sulu",
             "fijada_dia": 17,
             "n_variantes": 3
           },
           {
             "concepto": "cometa",
+            "descripcion": "una estrella con cola que cruza el cielo varias noches seguidas",
             "form": "kali-rua-bana",
             "fijada_dia": 30,
             "n_variantes": 3
@@ -349,24 +362,28 @@
         "formas": [
           {
             "concepto": "eclipse",
+            "descripcion": "el sol se oscurece en pleno día y luego vuelve, como si algo lo cubriera",
             "form": "kali-ma-bana",
             "fijada_dia": 9,
             "n_variantes": 2
           },
           {
             "concepto": "metal_amarillo",
+            "descripcion": "un trozo de metal amarillo y pesado, distinto del oro conocido, llegado por trueque",
             "form": "kali-dunawe",
             "fijada_dia": 11,
             "n_variantes": 2
           },
           {
             "concepto": "fiebre_manchas",
+            "descripcion": "una fiebre nueva que llena la piel de manchas, que ningún piache había visto",
             "form": "kali-wara-bana",
             "fijada_dia": 12,
             "n_variantes": 3
           },
           {
             "concepto": "marea_roja",
+            "descripcion": "el agua del golfete se tiñe de rojo durante días y mata a los peces",
             "form": "**duna-karu-amana**",
             "fijada_dia": 15,
             "n_variantes": 2

--- a/content/simulador/runs/index.json
+++ b/content/simulador/runs/index.json
@@ -1,0 +1,378 @@
+{
+  "version": 1,
+  "generado": "2026-07-06T21:18:28.092208+00:00",
+  "runs": [
+    {
+      "id8": "2e729f3f",
+      "seed_run_id": "2e729f3f-ebf4-4d23-8142-c4c65b06e27b",
+      "categoria": "baseline",
+      "rol": null,
+      "pareja": null,
+      "hito": "Primer run largo calibrado — caquetío al 92%, deriva plana",
+      "started_at": "2026-06-22T06:08:56.493656+00:00",
+      "total_dias": 15,
+      "total_turnos": 30,
+      "agentes": 20,
+      "respuestas": 155,
+      "avg_score": 7.21,
+      "pct_caquetio": 0.922,
+      "neologismos_adoptados": 20,
+      "convergencia": null,
+      "fijacion": null
+    },
+    {
+      "id8": "f8ef263d",
+      "seed_run_id": "f8ef263d-43e1-4bdd-b0cb-647ff45d8824",
+      "categoria": "koine",
+      "rol": null,
+      "pareja": null,
+      "hito": "Primer run koiné — convergencia confirmada",
+      "started_at": "2026-06-29T16:26:39.812391+00:00",
+      "total_dias": 15,
+      "total_turnos": 30,
+      "agentes": 28,
+      "respuestas": 155,
+      "avg_score": 7.53,
+      "pct_caquetio": 0.992,
+      "neologismos_adoptados": 28,
+      "convergencia": null,
+      "fijacion": null
+    },
+    {
+      "id8": "9bb920eb",
+      "seed_run_id": "9bb920eb-fb3e-45c6-82ad-9d614d9a5b97",
+      "categoria": "koine",
+      "rol": null,
+      "pareja": null,
+      "hito": "Run largo (60T) — población constante, métrica persistida",
+      "started_at": "2026-06-29T17:40:20.53362+00:00",
+      "total_dias": 30,
+      "total_turnos": 60,
+      "agentes": 32,
+      "respuestas": 295,
+      "avg_score": 7.45,
+      "pct_caquetio": 0.99,
+      "neologismos_adoptados": 40,
+      "convergencia": {
+        "lectura": "acumulada",
+        "inicio": 0.6465,
+        "fin": 0.3898,
+        "delta_pct": -39.7,
+        "dias": 30,
+        "serie": [
+          0.6465,
+          0.6123,
+          0.5837,
+          0.5561,
+          0.4934,
+          0.4797,
+          0.4697,
+          0.4526,
+          0.4426,
+          0.4246,
+          0.4044,
+          0.4025,
+          0.397,
+          0.3818,
+          0.3965,
+          0.4323,
+          0.4252,
+          0.4199,
+          0.4174,
+          0.4145,
+          0.414,
+          0.4124,
+          0.4103,
+          0.409,
+          0.4057,
+          0.3977,
+          0.3973,
+          0.3954,
+          0.3942,
+          0.3898
+        ]
+      },
+      "fijacion": null
+    },
+    {
+      "id8": "20091e1f",
+      "seed_run_id": "20091e1f-a06b-4aa3-bad6-486cf1ee3abd",
+      "categoria": "koine",
+      "rol": null,
+      "pareja": null,
+      "hito": "Fijación por competencia — diccionario koiné de 7 conceptos",
+      "started_at": "2026-06-29T21:44:30.07376+00:00",
+      "total_dias": 0,
+      "total_turnos": 0,
+      "agentes": 30,
+      "respuestas": 290,
+      "avg_score": 7.42,
+      "pct_caquetio": 0.99,
+      "neologismos_adoptados": 41,
+      "convergencia": {
+        "lectura": "acumulada",
+        "inicio": 0.6325,
+        "fin": 0.3509,
+        "delta_pct": -44.5,
+        "dias": 28,
+        "serie": [
+          0.6325,
+          0.6416,
+          0.593,
+          0.4983,
+          0.4459,
+          0.4217,
+          0.4451,
+          0.4299,
+          0.4193,
+          0.4034,
+          0.3946,
+          0.3721,
+          0.3661,
+          0.363,
+          0.3551,
+          0.3676,
+          0.3653,
+          0.3557,
+          0.3538,
+          0.3531,
+          0.3508,
+          0.3408,
+          0.3396,
+          0.3712,
+          0.3694,
+          0.3674,
+          0.3586,
+          0.3509
+        ]
+      },
+      "fijacion": {
+        "conceptos_fijados": 7,
+        "formas": [
+          {
+            "concepto": "cometa",
+            "form": "kali-subo",
+            "fijada_dia": 5,
+            "n_variantes": 3
+          },
+          {
+            "concepto": "fiebre_manchas",
+            "form": "ka-bari-tüshi-kali",
+            "fijada_dia": 9,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "eclipse",
+            "form": "ma-kali-bana",
+            "fijada_dia": 10,
+            "n_variantes": 4
+          },
+          {
+            "concepto": "metal_amarillo",
+            "form": "sulu-pana",
+            "fijada_dia": 14,
+            "n_variantes": 3
+          },
+          {
+            "concepto": "tambor_caribe",
+            "form": "mana-koto",
+            "fijada_dia": 17,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "marea_roja",
+            "form": "duna-kali-biji",
+            "fijada_dia": 18,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "planta_quema",
+            "form": "tüshi-mana-bana",
+            "fijada_dia": 20,
+            "n_variantes": 2
+          }
+        ]
+      }
+    },
+    {
+      "id8": "038d7b9d",
+      "seed_run_id": "038d7b9d-3335-4b96-971d-8a3132c0319d",
+      "categoria": "experimento",
+      "rol": "normal",
+      "pareja": "bdc54134",
+      "hito": "Experimento de control (normal) — koiné con andamiaje",
+      "started_at": "2026-07-06T14:46:00.692018+00:00",
+      "total_dias": 30,
+      "total_turnos": 60,
+      "agentes": 38,
+      "respuestas": 300,
+      "avg_score": 7.31,
+      "pct_caquetio": 0.991,
+      "neologismos_adoptados": 63,
+      "convergencia": {
+        "lectura": "emergente",
+        "inicio": 0.6997,
+        "fin": 0.5746,
+        "delta_pct": -17.9,
+        "dias": 30,
+        "serie": [
+          0.6997,
+          0.6253,
+          0.6069,
+          0.5634,
+          0.533,
+          0.5161,
+          0.509,
+          0.5047,
+          0.5413,
+          0.5363,
+          0.5346,
+          0.5721,
+          0.5682,
+          0.5858,
+          0.6321,
+          0.6392,
+          0.6404,
+          0.6216,
+          0.6195,
+          0.5934,
+          0.5907,
+          0.5917,
+          0.5835,
+          0.5791,
+          0.5763,
+          0.5792,
+          0.5842,
+          0.5823,
+          0.5714,
+          0.5746
+        ]
+      },
+      "fijacion": {
+        "conceptos_fijados": 6,
+        "formas": [
+          {
+            "concepto": "cuentas_vidrio",
+            "form": "kali-taro",
+            "fijada_dia": 3,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "fiebre_manchas",
+            "form": "bana-kali-taro-sulu",
+            "fijada_dia": 9,
+            "n_variantes": 3
+          },
+          {
+            "concepto": "metal_amarillo",
+            "form": "kali-pama",
+            "fijada_dia": 11,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "marea_roja",
+            "form": "duna-bana-kali-taro",
+            "fijada_dia": 15,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "tambor_caribe",
+            "form": "bani-taro-sulu",
+            "fijada_dia": 17,
+            "n_variantes": 3
+          },
+          {
+            "concepto": "cometa",
+            "form": "kali-rua-bana",
+            "fijada_dia": 30,
+            "n_variantes": 3
+          }
+        ]
+      }
+    },
+    {
+      "id8": "bdc54134",
+      "seed_run_id": "bdc54134-9bb5-4308-a71b-135e99900f67",
+      "categoria": "experimento",
+      "rol": "ablacion",
+      "pareja": "038d7b9d",
+      "hito": "Experimento de control (ablación) — sin las 3 inyecciones",
+      "started_at": "2026-07-06T20:18:10.343435+00:00",
+      "total_dias": 30,
+      "total_turnos": 60,
+      "agentes": 34,
+      "respuestas": 294,
+      "avg_score": 7.3,
+      "pct_caquetio": 0.997,
+      "neologismos_adoptados": 39,
+      "convergencia": {
+        "lectura": "emergente",
+        "inicio": 0.6957,
+        "fin": 0.6499,
+        "delta_pct": -6.6,
+        "dias": 30,
+        "serie": [
+          0.6957,
+          0.6758,
+          0.7118,
+          0.6715,
+          0.6521,
+          0.6349,
+          0.6258,
+          0.6404,
+          0.6217,
+          0.6807,
+          0.6729,
+          0.6984,
+          0.6933,
+          0.6855,
+          0.6696,
+          0.6514,
+          0.6491,
+          0.649,
+          0.6461,
+          0.6456,
+          0.6423,
+          0.6413,
+          0.6407,
+          0.6427,
+          0.6423,
+          0.6432,
+          0.642,
+          0.6443,
+          0.6528,
+          0.6499
+        ]
+      },
+      "fijacion": {
+        "conceptos_fijados": 4,
+        "formas": [
+          {
+            "concepto": "eclipse",
+            "form": "kali-ma-bana",
+            "fijada_dia": 9,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "metal_amarillo",
+            "form": "kali-dunawe",
+            "fijada_dia": 11,
+            "n_variantes": 2
+          },
+          {
+            "concepto": "fiebre_manchas",
+            "form": "kali-wara-bana",
+            "fijada_dia": 12,
+            "n_variantes": 3
+          },
+          {
+            "concepto": "marea_roja",
+            "form": "**duna-karu-amana**",
+            "fijada_dia": 15,
+            "n_variantes": 2
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lib/runs.ts
+++ b/lib/runs.ts
@@ -23,6 +23,8 @@ export interface Convergencia {
 
 export interface FormaFijada {
   concepto: string;
+  /** Glosa del referente que la comunidad necesitaba nombrar. */
+  descripcion: string | null;
   form: string;
   fijada_dia: number | null;
   n_variantes: number | null;

--- a/lib/runs.ts
+++ b/lib/runs.ts
@@ -1,0 +1,91 @@
+import fs from "fs";
+import path from "path";
+
+// Índice cross-run: la espina dorsal comparativa que permite contar la
+// EVOLUCIÓN entre simulaciones (no un solo run). Lo genera
+// curiana_sim/export_runs_index.py desde Supabase local; la página en
+// producción solo lee este JSON estático. Ver MIGRACION_RUNS_EVOLUCION.md.
+const INDEX_PATH = path.join(process.cwd(), "content", "simulador", "runs", "index.json");
+
+export type RunCategoria = "insignia" | "koine" | "experimento" | "baseline";
+/** Lectura de convergencia usada; "acumulada" infla — mostrar con reserva. */
+export type LecturaConvergencia = "emergente" | "ventana" | "acumulada";
+
+export interface Convergencia {
+  lectura: LecturaConvergencia;
+  inicio: number;
+  fin: number;
+  delta_pct: number | null;
+  dias: number;
+  /** Serie de la lectura elegida, para sparkline. */
+  serie: number[];
+}
+
+export interface FormaFijada {
+  concepto: string;
+  form: string;
+  fijada_dia: number | null;
+  n_variantes: number | null;
+}
+
+export interface Fijacion {
+  conceptos_fijados: number;
+  formas: FormaFijada[];
+}
+
+export interface RunIndexEntry {
+  id8: string;
+  seed_run_id: string;
+  categoria: RunCategoria;
+  /** Solo en categoría "experimento": qué brazo del par es. */
+  rol: "normal" | "ablacion" | null;
+  /** id8 del run apareado (el otro brazo del experimento). */
+  pareja: string | null;
+  hito: string;
+  started_at: string;
+  total_dias: number | null;
+  total_turnos: number | null;
+  agentes: number;
+  respuestas: number;
+  avg_score: number | null;
+  pct_caquetio: number | null;
+  neologismos_adoptados: number;
+  convergencia: Convergencia | null;
+  fijacion: Fijacion | null;
+}
+
+export interface RunsIndex {
+  version: number;
+  generado: string;
+  runs: RunIndexEntry[];
+}
+
+export function getRunsIndex(): RunsIndex | null {
+  try {
+    const raw = fs.readFileSync(INDEX_PATH, "utf-8");
+    return JSON.parse(raw) as RunsIndex;
+  } catch {
+    return null;
+  }
+}
+
+/** Un run del índice por su prefijo id8. */
+export function getRunIndexEntry(id8: string): RunIndexEntry | null {
+  return getRunsIndex()?.runs.find((r) => r.id8 === id8) ?? null;
+}
+
+/** El par de un experimento (normal + ablación) por el id8 de cualquiera. */
+export function getParejaExperimento(id8: string): {
+  normal: RunIndexEntry;
+  ablacion: RunIndexEntry;
+} | null {
+  const idx = getRunsIndex();
+  if (!idx) return null;
+  const a = idx.runs.find((r) => r.id8 === id8);
+  if (!a?.pareja) return null;
+  const b = idx.runs.find((r) => r.id8 === a.pareja);
+  if (!b) return null;
+  const normal = a.rol === "normal" ? a : b;
+  const ablacion = a.rol === "ablacion" ? a : b;
+  return { normal, ablacion };
+}

--- a/lib/sim-theme.ts
+++ b/lib/sim-theme.ts
@@ -55,6 +55,14 @@ export const EVENTO_TIPOS: Record<string, { label: string; color: string }> = {
   momento: { label: "momento", color: "#5B4FCF" },
 };
 
+// ── Categorías de run (índice cross-run de evolución) ─────────────────
+export const RUN_CATEGORIAS: Record<string, { label: string; color: string }> = {
+  baseline: { label: "línea base", color: "#6D8A9E" },
+  koine: { label: "koiné", color: "#C47A2B" },
+  experimento: { label: "experimento", color: "#5B4FCF" },
+  insignia: { label: "edición", color: "#B04040" },
+};
+
 // ── Semánticos (feedback) ─────────────────────────────────────────────
 export const SEMANTIC = {
   success: "#2E7D4F",

--- a/proyecto-linguistico-caquetío/MIGRACION_RUNS_EVOLUCION.md
+++ b/proyecto-linguistico-caquetío/MIGRACION_RUNS_EVOLUCION.md
@@ -1,0 +1,112 @@
+# Migración de runs → página estática: mostrar la evolución entre simulaciones
+
+Diseño de trabajo para la rama `feat/migracion-runs-evolucion`. El objetivo no
+es solo migrar más datos: es darle a `/simulador` una **dimensión temporal
+entre runs**, para contar el arco del proyecto (caquetío 8% → 92% → 99%; deriva
+plana → koiné con diccionario → experimento de control) en vez de una sola foto.
+
+## El problema
+
+Hoy `/simulador` muestra **un solo run** (`2e729f3f`, del 22-jun, pre-koiné):
+
+- La capa **editorial** (`content/simulador/editorial.json` + `lib/editorial.ts`)
+  ya es multi-run: tiene `runs[]`, `run_activo`, y la validación reconoce que
+  "runs futuros traerán sus propios seeds".
+- Pero la capa de **datos** es de un solo run: `resumen.json`, `personajes.json`,
+  `neologismos.json` son singulares — cada `export_*_seed.py` los **sobreescribe**.
+  Solo puede vivir el detalle de un run a la vez.
+- No hay **nada cross-run**: ni la convergencia, ni la fijación, ni la evolución
+  del caquetío se pueden comparar entre simulaciones porque no existe una
+  estructura que las junte.
+
+Además, dos tipos de dato de la era koiné no tienen representación en la página:
+`koine_metrics` (curvas de convergencia) y `koine_lexicon` (el diccionario
+emergente — el resultado más contable del proyecto).
+
+## La estrategia: índice cross-run + detalle por run
+
+Dos capas nuevas, bien separadas:
+
+### 1. Índice cross-run (la espina dorsal comparativa) — ✅ hecho en esta rama
+
+`content/simulador/runs/index.json`, generado por
+`curiana_sim/export_runs_index.py`. Una fila por run **curado** (no todos: la
+selección es explícita en `MANIFIESTO` dentro del script; smokes y runs de
+desarrollo quedan en `BITACORA_RUNS.md`, no en la página).
+
+Cada fila trae lo mínimo para comparar y para dibujar la evolución:
+
+- identidad: `id8`, `seed_run_id`, `categoria` (baseline/koine/experimento/insignia),
+  `hito` editorial, `started_at`, días/turnos, agentes.
+- lingüística: `avg_score`, `pct_caquetio`, `neologismos_adoptados`.
+- `convergencia`: lectura más exigente con datos (emergente > ventana >
+  acumulada), con `inicio`/`fin`/`delta_pct` y la `serie` completa para
+  sparkline. **Marca la `lectura`** para que la página muestre la reserva: la
+  acumulada infla por acumulación del léxico base (ver `DISENO_KOINE.md §7`).
+- `fijacion`: conceptos fijados + las formas ganadoras (concepto, forma, día,
+  nº de variantes que compitieron).
+- `pareja`/`rol`: enlaza los dos brazos de un experimento normal↔ablación.
+
+Loader tipado: `lib/runs.ts` (`getRunsIndex`, `getRunIndexEntry`,
+`getParejaExperimento`).
+
+Degradación honesta: los runs anteriores al 2026-07-04 (`9bb920eb`, `20091e1f`)
+no tienen ventana/emergente (columnas NULL) → el índice reporta su acumulada y
+la marca como tal. No se inventa una métrica que no se midió.
+
+### 2. Detalle por run (refactor pendiente de los exporters actuales)
+
+Mover de singular → por-run:
+
+```
+content/simulador/
+  runs/
+    index.json                    ← ✅ espina cross-run
+    2e729f3f/{resumen,personajes,neologismos}.json
+    20091e1f/{resumen,personajes,neologismos,koine_lexicon}.json
+    ...
+```
+
+Los tres `export_*_seed.py` ya aceptan `run_id` como argumento; el cambio es
+que escriban a `runs/<id8>/` en vez de sobreescribir la raíz, y que el índice
+sepa qué detalle existe. `lib/resumen.ts`, `lib/personajes.ts`,
+`lib/neologismos.ts` ganan un parámetro de run (con el run activo como default,
+para no romper las páginas actuales).
+
+> Compatibilidad: mientras se migra, dejar los JSON singulares en la raíz como
+> alias del run insignia, o migrar loaders y páginas en el mismo commit. No
+> dejar la página a medias apuntando a rutas que aún no existen.
+
+## Cambios de UI propuestos (requieren tu criterio de diseño — NO hechos aún)
+
+1. **`/simulador` gana una sección "La evolución"** entre las ediciones y el
+   detalle del run insignia: una línea de tiempo de los runs curados con su
+   hito y una micro-métrica (caquetío %, convergencia). Es el arco del proyecto
+   de un vistazo. Fuente: `getRunsIndex()`.
+2. **Sección "El diccionario koiné"**: las formas fijadas de `20091e1f` (y del
+   experimento) — concepto, forma ganadora, de cuántas variantes, qué día. Es
+   el resultado más tangible y no está en la página hoy.
+3. **Sección "La prueba de control"**: el par `038d7b9d`/`bdc54134` lado a lado
+   — las dos curvas de convergencia emergente y la diferencia (−17.9% vs −6.6%).
+   Es la pieza científica; `getParejaExperimento("038d7b9d")` la sirve entera.
+4. El índice de "Ediciones" existente puede leer `categoria`/`hito` del índice
+   en vez de tenerlos hardcodeados en `editorial.json`.
+
+Las voces editoriales (Manaure, narrador) de cada run nuevo siguen viviendo en
+`editorial.json` — el índice es dato medido, no narrativa. Se cruzan en la
+página, como ya se hace hoy.
+
+## Egress / producción
+
+Sin riesgo nuevo: todo sale de Supabase **local** a JSON commiteado. La página
+en producción nunca consulta la base (misma razón por la que se borró el Vercel
+viejo). Añadir un run a la página = correr los exporters localmente + commit.
+
+## Estado de la rama
+
+- ✅ `export_runs_index.py` + `content/simulador/runs/index.json` (6 runs curados).
+- ✅ `lib/runs.ts` (loader tipado + helper de pareja de experimento).
+- ⏳ Refactor de los tres `export_*_seed.py` a `runs/<id8>/`.
+- ⏳ Reparar `20091e1f`: correr `generar_perfiles_curados()` post-hoc (no tiene
+  perfiles — el teardown lo cortó en el turno 57). Es el run del diccionario koiné.
+- ⏳ UI (secciones 1–4 de arriba) — pendiente de tu criterio de diseño.

--- a/proyecto-linguistico-caquetío/curiana_sim/export_runs_index.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/export_runs_index.py
@@ -1,0 +1,185 @@
+"""
+Exporta el ÍNDICE cross-run de evolución para /simulador en Curiana Radio.
+
+A diferencia de los otros export_*_seed.py (que escriben el detalle de UN run),
+este produce la espina dorsal comparativa: una fila por run curado con sus
+métricas clave, para que la página pueda contar la EVOLUCIÓN entre simulaciones
+(8% → 92% → 99% de caquetío, deriva plana → koiné con diccionario → experimento
+de control). Ver MIGRACION_RUNS_EVOLUCION.md.
+
+Filosofía evergreen (igual que el resto de exporters): lee de Supabase LOCAL y
+escribe JSON estático commiteado; la página en producción nunca toca la base.
+
+La CURACIÓN es explícita: solo se exportan los runs listados en MANIFIESTO, con
+su hito editorial y categoría. Los smokes y runs de desarrollo NO se publican —
+quedan documentados en BITACORA_RUNS.md, no en la página. Añadir un run nuevo =
+una línea en MANIFIESTO.
+
+Uso:
+    python export_runs_index.py
+    (sin argumentos; la selección vive en MANIFIESTO abajo)
+"""
+import json
+import os
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+from curiana_database import CurianaDB
+
+CONTENT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "content", "simulador")
+RUNS_DIR = os.path.join(CONTENT_DIR, "runs")
+
+# --- Curación editorial ----------------------------------------------------
+# Prefijo de 8 chars del run_id → metadatos editoriales. El orden define el
+# orden narrativo en la página (cronológico = arco del proyecto). Categorías:
+#   insignia    → el run destacado que la página cuenta en detalle
+#   koine       → runs de la era koiné (convergencia + fijación)
+#   experimento → el par normal/ablación (la evidencia de control)
+#   baseline    → hito histórico (primer run calibrado)
+# `pareja` enlaza un run de ablación con su control normal (mismo experimento).
+MANIFIESTO = [
+    {"id8": "2e729f3f", "categoria": "baseline",
+     "hito": "Primer run largo calibrado — caquetío al 92%, deriva plana"},
+    {"id8": "f8ef263d", "categoria": "koine",
+     "hito": "Primer run koiné — convergencia confirmada"},
+    {"id8": "9bb920eb", "categoria": "koine",
+     "hito": "Run largo (60T) — población constante, métrica persistida"},
+    {"id8": "20091e1f", "categoria": "koine",
+     "hito": "Fijación por competencia — diccionario koiné de 7 conceptos"},
+    {"id8": "038d7b9d", "categoria": "experimento", "rol": "normal", "pareja": "bdc54134",
+     "hito": "Experimento de control (normal) — koiné con andamiaje"},
+    {"id8": "bdc54134", "categoria": "experimento", "rol": "ablacion", "pareja": "038d7b9d",
+     "hito": "Experimento de control (ablación) — sin las 3 inyecciones"},
+]
+
+
+def _first_last(rows: list[dict], col: str):
+    """Primer y último valor no-nulo de una columna ordenada por día."""
+    vals = [(r["day"], r[col]) for r in rows if r.get(col) is not None]
+    if not vals:
+        return None, None
+    vals.sort()
+    return vals[0][1], vals[-1][1]
+
+
+def convergencia(metrics: list[dict]) -> dict | None:
+    """Resume la convergencia con la lectura MÁS EXIGENTE que tenga datos.
+
+    Preferencia: emergente > ventana > acumulada. Los runs anteriores a la
+    corrección metodológica del 2026-07-04 solo tienen la acumulada (las otras
+    columnas son NULL); se reporta esa y se marca la lectura usada para que la
+    página pueda mostrar la reserva (la acumulada infla por acumulación del
+    léxico base compartido — ver DISENO_KOINE.md §7).
+    """
+    if not metrics:
+        return None
+    metrics = sorted(metrics, key=lambda r: r["day"])
+    for col, lectura in (
+        ("distance_emergente", "emergente"),
+        ("distance_ventana", "ventana"),
+        ("distance", "acumulada"),
+    ):
+        ini, fin = _first_last(metrics, col)
+        if ini is not None and fin is not None:
+            ini, fin = float(ini), float(fin)
+            delta_pct = round((fin - ini) / ini * 100, 1) if ini else None
+            return {
+                "lectura": lectura,
+                "inicio": round(ini, 4),
+                "fin": round(fin, 4),
+                "delta_pct": delta_pct,
+                "dias": len(metrics),
+                # Serie completa de la lectura elegida, para un sparkline.
+                "serie": [
+                    round(float(r[col]), 4) for r in metrics if r.get(col) is not None
+                ],
+            }
+    return None
+
+
+def resumir_run(db: CurianaDB, entrada: dict) -> dict | None:
+    id8 = entrada["id8"]
+    runs = db.client.table("simulation_runs").select("*").execute().data
+    run = next((r for r in runs if r["id"].startswith(id8)), None)
+    if not run:
+        print(f"  ⚠  {id8}: no está en simulation_runs, se omite")
+        return None
+    run_id = run["id"]
+
+    resp = (
+        db.client.table("agent_responses")
+        .select("score,pct_caquetio,agent_name")
+        .eq("run_id", run_id).execute().data
+    )
+    n_resp = len(resp)
+    agentes = len({r["agent_name"] for r in resp})
+    avg_score = round(sum(r["score"] for r in resp) / n_resp, 2) if n_resp else None
+    pct_caq = round(sum(r["pct_caquetio"] for r in resp) / n_resp, 3) if n_resp else None
+
+    neos = db.client.table("neologisms").select("status").eq("run_id", run_id).execute().data
+    adoptados = len([n for n in neos if n["status"] == "adoptado"])
+
+    metrics = db.client.table("koine_metrics").select("*").eq("run_id", run_id).execute().data
+    fijadas = db.client.table("koine_lexicon").select("*").eq("run_id", run_id).execute().data
+
+    return {
+        "id8": id8,
+        "seed_run_id": run_id,
+        "categoria": entrada["categoria"],
+        "rol": entrada.get("rol"),
+        "pareja": entrada.get("pareja"),
+        "hito": entrada["hito"],
+        "started_at": run["started_at"],
+        "total_dias": run.get("total_days"),
+        "total_turnos": run.get("total_turns"),
+        "agentes": agentes,
+        "respuestas": n_resp,
+        "avg_score": avg_score,
+        "pct_caquetio": pct_caq,
+        "neologismos_adoptados": adoptados,
+        "convergencia": convergencia(metrics),
+        "fijacion": {
+            "conceptos_fijados": len(fijadas),
+            "formas": sorted(
+                (
+                    {"concepto": f["concepto_id"], "form": f["form"],
+                     "fijada_dia": f.get("fijada_dia"), "n_variantes": f.get("n_variantes")}
+                    for f in fijadas
+                ),
+                key=lambda x: x["fijada_dia"] or 999,
+            ),
+        } if fijadas else None,
+    }
+
+
+def main():
+    db = CurianaDB()
+    filas = []
+    for entrada in MANIFIESTO:
+        fila = resumir_run(db, entrada)
+        if fila:
+            filas.append(fila)
+            conv = fila["convergencia"]
+            conv_txt = (
+                f"{conv['lectura']} {conv['delta_pct']:+}%" if conv else "sin métrica"
+            )
+            print(f"  ✓ {fila['id8']} · {fila['categoria']:11} · caq {fila['pct_caquetio']} · {conv_txt}")
+
+    index = {
+        "version": 1,
+        "generado": datetime.now(timezone.utc).isoformat(),
+        "runs": filas,
+    }
+
+    os.makedirs(RUNS_DIR, exist_ok=True)
+    out = os.path.join(RUNS_DIR, "index.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(index, f, ensure_ascii=False, indent=2)
+    print(f"\nruns/index.json escrito ({len(filas)} runs curados)")
+
+
+if __name__ == "__main__":
+    main()

--- a/proyecto-linguistico-caquetío/curiana_sim/export_runs_index.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/export_runs_index.py
@@ -145,7 +145,8 @@ def resumir_run(db: CurianaDB, entrada: dict) -> dict | None:
             "conceptos_fijados": len(fijadas),
             "formas": sorted(
                 (
-                    {"concepto": f["concepto_id"], "form": f["form"],
+                    {"concepto": f["concepto_id"], "descripcion": f.get("descripcion"),
+                     "form": f["form"],
                      "fijada_dia": f.get("fijada_dia"), "n_variantes": f.get("n_variantes")}
                     for f in fijadas
                 ),


### PR DESCRIPTION
## Qué hace

MVP de la migración de runs a la página estática: `/simulador` gana la **dimensión temporal entre simulaciones**.

### Datos (índice cross-run)
- `export_runs_index.py` genera `content/simulador/runs/index.json`: una fila por run **curado** (MANIFIESTO explícito — smokes y runs de desarrollo no se publican). 6 runs: baseline → 3 koiné → par experimental normal/ablación.
- Convergencia con la lectura más exigente disponible (emergente > ventana > acumulada), **marcada** — los runs pre-corrección degradan honestamente a la acumulada con nota †.
- `lib/runs.ts`: loader tipado + `getParejaExperimento()`.

### UI (2 secciones nuevas en /simulador)
- **La evolución, simulación a simulación**: línea de tiempo de expediciones — hito editorial, caquetío % (el arco 92→99→100), convergencia con sparkline, fijación.
- **El diccionario koiné**: las 17 formas fijadas por competencia con su glosa («una estrella con cola que cruza el cielo» → `kali-subo`), variantes rivales, día, run de origen. Con la nota epistémica del proyecto.
- Server components puros; el sitio sigue 100% estático (cero Supabase en runtime — verificado).

### Diseño
Ejecuta el sistema "Cronista digital" existente: rail de folio, serif editorial, monospace para el instrumento, colores desde `sim-theme.ts` (nuevo token `RUN_CATEGORIAS`).

### Verificación
- Build estático 31/31 páginas, `tsc` y `eslint` limpios.
- DOM inspeccionado en preview: 6 entradas de timeline, 4 sparklines, 17 entradas de diccionario, ambas notas presentes.
- Responsive: mobile sin overflow horizontal, diccionario colapsa a 1 columna.
- Consola sin errores ni warnings.

Diseño completo de la migración en `proyecto-linguistico-caquetío/MIGRACION_RUNS_EVOLUCION.md` (detalle por run y sección del experimento quedan para el siguiente sprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)