### PR TITLE
fix(db): rescatar migración 20260621 (rename pct_arahuacano)

### DIFF
--- a/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260621000000_rename_pct_arahuacano.sql
+++ b/proyecto-linguistico-caquetío/curiana_sim/supabase/migrations/20260621000000_rename_pct_arahuacano.sql
@@ -1,0 +1,34 @@
+-- ══════════════════════════════════════════════════════════════════════
+-- Corrige inconsistencia: el commit e74b413 renombró arahuacano ->
+-- proto-arahuaco en supabase_schema.sql, pero nunca se generó la
+-- migración correspondiente. agent_responses.pct_arahuacano quedó
+-- desincronizada (causaba PGRST204 al guardar respuestas).
+-- ══════════════════════════════════════════════════════════════════════
+
+ALTER TABLE agent_responses RENAME COLUMN pct_arahuacano TO pct_proto_arahuaco;
+
+-- Mismo problema con el commit 968ef0b: canonicalizó el lexicon
+-- (separó POS de dominio semántico) solo en el doc de referencia.
+ALTER TABLE lexicon ADD COLUMN IF NOT EXISTS semantic_domain TEXT;
+
+DROP VIEW IF EXISTS language_drift_by_turn;
+
+CREATE VIEW language_drift_by_turn
+WITH (security_invoker = true) AS
+SELECT
+  t.run_id,
+  t.day,
+  t.turn_num,
+  t.moment,
+  t.season,
+  ROUND(AVG(ar.pct_caquetio)::NUMERIC,   3) AS avg_caquetio,
+  ROUND(AVG(ar.pct_wayunaiki)::NUMERIC,  3) AS avg_wayunaiki,
+  ROUND(AVG(ar.pct_lokono)::NUMERIC,     3) AS avg_lokono,
+  ROUND(AVG(ar.pct_taino)::NUMERIC,      3) AS avg_taino,
+  ROUND(AVG(ar.pct_proto_arahuaco)::NUMERIC, 3) AS avg_proto_arahuaco,
+  ROUND(AVG(ar.score)::NUMERIC,          2) AS avg_score,
+  COUNT(ar.id)                              AS agents_active
+FROM turns t
+JOIN agent_responses ar ON ar.turn_id = t.id
+GROUP BY t.run_id, t.day, t.turn_num, t.moment, t.season
+ORDER BY t.run_id, t.day, t.turn_num;


### PR DESCRIPTION
Rescate previo a la poda de ramas viejas: el archivo de esta migración vivía solo en `feature/supabase-local`, pero la migración **está aplicada** en la DB local (registrada en `supabase_migrations.schema_migrations`).

Sin este archivo, un `supabase db reset` desde main recrea `agent_responses.pct_arahuacano` (nombre viejo) y el orquestador falla con PGRST204 al guardar respuestas — exactamente el bug que la migración documenta y corrige. También agrega `lexicon.semantic_domain` y recrea la vista `language_drift_by_turn`.

Verificado contra la DB local: historia de migraciones = `20260613` (init) + `20260621` (esta); el resto del schema llegó por aplicación manual. Con este archivo, el orden de replay en un reset queda coherente (init → rename → resto).

Los otros 2 commits de la rama vieja (puertos, launch.json) ya están en main por otra vía — tras el merge se podan `feature/supabase-local`, `feat/simulador-wiki-narrativa` y `claude/zen-lewin-99d2ef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)