### PR TITLE
feat(simulador): prueba de control + página propia /simulador/runs

### DIFF
--- a/app/simulador/page.tsx
+++ b/app/simulador/page.tsx
@@ -4,8 +4,9 @@ import { getRunActivo, getRunsPublicados } from "@/lib/editorial";
 import { getManaureFragment } from "@/lib/manaure";
 import { getResumen } from "@/lib/resumen";
 import { getAllPersonajes } from "@/lib/personajes";
-import { getRunsIndex } from "@/lib/runs";
+import { getRunsIndex, getParejaExperimento } from "@/lib/runs";
 import { EvolucionTimeline, DiccionarioKoine } from "@/components/simulador/evolucion";
+import { ExperimentoControl } from "@/components/simulador/experimento";
 import ManaureVoice from "@/components/simulador/ManaureVoice";
 import LanguageDriftChart from "@/components/simulador/LanguageDriftChart";
 import { Epoca, EventoItem, DataAside, Asterismo } from "@/components/simulador/prose";
@@ -30,6 +31,7 @@ export default function SimuladorPage() {
   const run = getRunActivo();
   const resumen = getResumen();
   const runsIndex = getRunsIndex();
+  const experimento = getParejaExperimento("038d7b9d");
   const nombrePorSlug = new Map(getAllPersonajes().map((p) => [p.slug, p.nombre]));
 
   const hero = run.manaure_hero ? getManaureFragment(run.manaure_hero) : null;
@@ -173,6 +175,19 @@ export default function SimuladorPage() {
             </p>
             <EvolucionTimeline runs={runsIndex.runs} />
           </section>
+
+          {experimento && (
+            <>
+              <Asterismo />
+              <section id="experimento" className="scroll-mt-24">
+                <Overline>La prueba de control</Overline>
+                <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+                  ¿La lengua converge sola?
+                </h2>
+                <ExperimentoControl normal={experimento.normal} ablacion={experimento.ablacion} />
+              </section>
+            </>
+          )}
 
           <Asterismo />
           <section id="diccionario-koine" className="scroll-mt-24">

--- a/app/simulador/page.tsx
+++ b/app/simulador/page.tsx
@@ -4,9 +4,7 @@ import { getRunActivo, getRunsPublicados } from "@/lib/editorial";
 import { getManaureFragment } from "@/lib/manaure";
 import { getResumen } from "@/lib/resumen";
 import { getAllPersonajes } from "@/lib/personajes";
-import { getRunsIndex, getParejaExperimento } from "@/lib/runs";
-import { EvolucionTimeline, DiccionarioKoine } from "@/components/simulador/evolucion";
-import { ExperimentoControl } from "@/components/simulador/experimento";
+import { getRunsIndex } from "@/lib/runs";
 import ManaureVoice from "@/components/simulador/ManaureVoice";
 import LanguageDriftChart from "@/components/simulador/LanguageDriftChart";
 import { Epoca, EventoItem, DataAside, Asterismo } from "@/components/simulador/prose";
@@ -21,6 +19,7 @@ export function generateMetadata(): Metadata {
 }
 
 const ANEXOS = [
+  { href: "/simulador/runs", label: "La evolución", desc: "El arco entre simulaciones: convergencia, experimento de control y diccionario koiné." },
   { href: "/simulador/personajes", label: "Personajes", desc: "Las veinte voces curadas del run y sus arcos." },
   { href: "/simulador/lexicon", label: "Léxico", desc: "El vocabulario reconstruido, palabra por palabra." },
   { href: "/simulador/neologisms", label: "Neologismos", desc: "Todas las palabras inventadas: las que prendieron y las que no." },
@@ -31,7 +30,6 @@ export default function SimuladorPage() {
   const run = getRunActivo();
   const resumen = getResumen();
   const runsIndex = getRunsIndex();
-  const experimento = getParejaExperimento("038d7b9d");
   const nombrePorSlug = new Map(getAllPersonajes().map((p) => [p.slug, p.nombre]));
 
   const hero = run.manaure_hero ? getManaureFragment(run.manaure_hero) : null;
@@ -158,56 +156,32 @@ export default function SimuladorPage() {
         </>
       )}
 
-      {/* El meta-relato: qué pasó ENTRE las simulaciones */}
+      {/* El meta-relato vive en su propia página; aquí lo anunciamos como
+          destino destacado, no lo enterramos al pie de la crónica. */}
       {runsIndex && runsIndex.runs.length > 1 && (
         <>
           <Asterismo />
-          <section id="evolucion" className="scroll-mt-24">
-            <Overline>Bitácora de expediciones</Overline>
-            <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
-              La evolución, simulación a simulación
+          <Link
+            href="/simulador/runs"
+            className="group block rounded-2xl border border-(--sim-rule) bg-(--sim-paper-deep) p-6 transition-colors hover:border-(--sim-fuego) sm:p-8"
+          >
+            <Overline>Más allá de esta edición</Overline>
+            <h2 className="sim-display mt-1 text-2xl font-semibold tracking-tight text-(--sim-ink) transition-colors group-hover:text-(--sim-fuego) md:text-3xl">
+              La evolución entre las {runsIndex.runs.length} simulaciones →
             </h2>
-            <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
-              Cada corrida es una expedición: mismo golfete, misma gente, y un instrumento que cada
-              vez mide mejor. Lo que empezó como una comunidad que apenas sostenía su lengua terminó
-              formando una koiné — y la última expedición salió con un grupo de control para probar
-              que la convergencia no era un truco del andamiaje.
+            <p className="mt-2 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+              El arco completo del proyecto: de una lengua que apenas se sostenía a una koiné con
+              diccionario propio, la prueba de control que lo confirma, y las palabras que la
+              comunidad fijó por competencia.
             </p>
-            <EvolucionTimeline runs={runsIndex.runs} />
-          </section>
-
-          {experimento && (
-            <>
-              <Asterismo />
-              <section id="experimento" className="scroll-mt-24">
-                <Overline>La prueba de control</Overline>
-                <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
-                  ¿La lengua converge sola?
-                </h2>
-                <ExperimentoControl normal={experimento.normal} ablacion={experimento.ablacion} />
-              </section>
-            </>
-          )}
-
-          <Asterismo />
-          <section id="diccionario-koine" className="scroll-mt-24">
-            <Overline>Lo que la comunidad nombró</Overline>
-            <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
-              El diccionario koiné
-            </h2>
-            <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
-              Cuando algo nuevo llegó al golfete — un cometa, una fiebre, un metal amarillo — la
-              comunidad necesitó nombrarlo. Varias formas compitieron; estas ganaron.
-            </p>
-            <DiccionarioKoine runs={runsIndex.runs} />
-          </section>
+          </Link>
         </>
       )}
 
       {/* Anexos: la wiki de referencia detrás de la historia */}
       <footer className="mt-14 border-t border-(--sim-rule) pt-8">
         <Overline>Seguir explorando</Overline>
-        <ul className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <ul className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {ANEXOS.map((a) => (
             <li key={a.href}>
               <Link href={a.href} className="group block">

--- a/app/simulador/runs/page.tsx
+++ b/app/simulador/runs/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getRunsIndex, getParejaExperimento } from "@/lib/runs";
+import { EvolucionTimeline, DiccionarioKoine } from "@/components/simulador/evolucion";
+import { ExperimentoControl } from "@/components/simulador/experimento";
+import { Asterismo } from "@/components/simulador/prose";
+import { Overline, EmptyState } from "@/components/simulador/ui";
+
+export const metadata: Metadata = {
+  title: "La evolución entre simulaciones — Simulador Caquetío | Curiana Radio",
+  description:
+    "El arco del proyecto, simulación a simulación: de una lengua que apenas se sostenía a una koiné con diccionario propio, y la prueba de control que lo confirma.",
+};
+
+// El meta-relato del proyecto: qué pasó ENTRE las simulaciones. Vive en su
+// propia página (no enterrado al pie de la edición insignia) porque es la
+// lectura comparativa, no la crónica de un run. Datos: lib/runs.ts.
+export default function RunsPage() {
+  const runsIndex = getRunsIndex();
+  const experimento = getParejaExperimento("038d7b9d");
+
+  if (!runsIndex || runsIndex.runs.length === 0) {
+    return (
+      <article className="mx-auto max-w-[720px]">
+        <header>
+          <Overline>Bitácora de expediciones</Overline>
+          <h2 className="mt-1 sim-display text-2xl font-semibold text-(--sim-ink) md:text-3xl">
+            La evolución entre simulaciones
+          </h2>
+        </header>
+        <div className="mt-8">
+          <EmptyState
+            title="Aún no hay runs curados"
+            hint="Corre export_runs_index.py contra Supabase local tras las simulaciones."
+          />
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="mx-auto max-w-[720px]">
+      <header>
+        <Link
+          href="/simulador"
+          className="sim-mono text-[0.7rem] uppercase tracking-[0.14em] text-(--sim-ink-faint) transition-colors hover:text-(--sim-fuego)"
+        >
+          ← Volver a la edición
+        </Link>
+        <div className="mt-4">
+          <Overline>Bitácora de expediciones</Overline>
+        </div>
+        <h2 className="mt-1 sim-display text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+          La evolución, simulación a simulación
+        </h2>
+        <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+          Cada corrida es una expedición: mismo golfete, misma gente, y un instrumento que cada vez
+          mide mejor. Lo que empezó como una comunidad que apenas sostenía su lengua terminó formando
+          una koiné — y la última expedición salió con un grupo de control para probar que la
+          convergencia no era un truco del andamiaje.
+        </p>
+      </header>
+
+      <section id="evolucion" className="mt-4 scroll-mt-24">
+        <EvolucionTimeline runs={runsIndex.runs} />
+      </section>
+
+      {experimento && (
+        <>
+          <Asterismo />
+          <section id="experimento" className="scroll-mt-24">
+            <Overline>La prueba de control</Overline>
+            <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+              ¿La lengua converge sola?
+            </h2>
+            <ExperimentoControl normal={experimento.normal} ablacion={experimento.ablacion} />
+          </section>
+        </>
+      )}
+
+      <Asterismo />
+      <section id="diccionario-koine" className="scroll-mt-24">
+        <Overline>Lo que la comunidad nombró</Overline>
+        <h2 className="sim-display mt-1 text-3xl font-semibold tracking-tight text-(--sim-ink) md:text-4xl">
+          El diccionario koiné
+        </h2>
+        <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+          Cuando algo nuevo llegó al golfete — un cometa, una fiebre, un metal amarillo — la comunidad
+          necesitó nombrarlo. Varias formas compitieron; estas ganaron.
+        </p>
+        <DiccionarioKoine runs={runsIndex.runs} />
+      </section>
+    </article>
+  );
+}

--- a/components/simulador/ConvergenciaChart.tsx
+++ b/components/simulador/ConvergenciaChart.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+
+// Dos curvas de distancia idiolectal media por día (lectura emergente): el run
+// normal y su control de ablación. La evidencia de koineización no es que la
+// normal baje — es la BRECHA entre ambas. Colores: normal en violeta de
+// "experimento" (--sim), ablación en gris apagado (el control, sin andamiaje).
+const COLOR_NORMAL = "#5B4FCF";
+const COLOR_ABLACION = "#9d7f66";
+
+interface Props {
+  normal: number[];
+  ablacion: number[];
+}
+
+export default function ConvergenciaChart({ normal, ablacion }: Props) {
+  const n = Math.max(normal.length, ablacion.length);
+  const data = Array.from({ length: n }, (_, i) => ({
+    dia: i + 1,
+    normal: normal[i] != null ? +normal[i].toFixed(4) : null,
+    ablacion: ablacion[i] != null ? +ablacion[i].toFixed(4) : null,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 8, right: 12, left: -8, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#d8c8a3" vertical={false} />
+        <XAxis
+          dataKey="dia"
+          tickFormatter={(v) => `D${v}`}
+          tick={{ fill: "#8a7657", fontSize: 11, fontFamily: "Inter, sans-serif" }}
+          tickLine={false}
+          axisLine={{ stroke: "#d8c8a3" }}
+          interval="preserveStartEnd"
+          minTickGap={24}
+        />
+        <YAxis
+          tick={{ fill: "#8a7657", fontSize: 11, fontFamily: "Inter, sans-serif" }}
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          domain={["auto", "auto"]}
+          tickFormatter={(v) => v.toFixed(2)}
+        />
+        <Tooltip
+          formatter={(value: number, name: string) => [value?.toFixed(4), name]}
+          labelFormatter={(v) => `Día ${v}`}
+          contentStyle={{
+            background: "#f8f1de",
+            border: "1px solid #d8c8a3",
+            borderRadius: 12,
+            boxShadow: "0 8px 24px rgba(79,62,53,0.12)",
+            fontFamily: "Inter, sans-serif",
+            fontSize: 12,
+          }}
+          labelStyle={{ color: "#2f2517", fontWeight: 600, marginBottom: 4 }}
+          cursor={{ stroke: "#c4b28b", strokeWidth: 1 }}
+        />
+        <Legend
+          verticalAlign="top"
+          height={28}
+          wrapperStyle={{ fontFamily: "Inter, sans-serif", fontSize: 12 }}
+        />
+        <Line
+          type="monotone"
+          dataKey="normal"
+          name="Normal (con andamiaje)"
+          stroke={COLOR_NORMAL}
+          strokeWidth={2.5}
+          dot={false}
+          activeDot={{ r: 3, strokeWidth: 0 }}
+          connectNulls
+        />
+        <Line
+          type="monotone"
+          dataKey="ablacion"
+          name="Ablación (control)"
+          stroke={COLOR_ABLACION}
+          strokeWidth={2}
+          strokeDasharray="5 4"
+          dot={false}
+          activeDot={{ r: 3, strokeWidth: 0 }}
+          connectNulls
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/simulador/experimento.tsx
+++ b/components/simulador/experimento.tsx
@@ -1,0 +1,124 @@
+// La prueba de control: el par normal vs. ablación. La sección más "de
+// laboratorio" del simulador — su tesis es metodológica, no narrativa: la
+// koineización emergente se prueba por la DIFERENCIA entre un run con el
+// andamiaje de prompt encendido y su gemelo con el andamiaje apagado.
+// Datos: getParejaExperimento() en lib/runs.ts.
+import type { RunIndexEntry } from "@/lib/runs";
+import ConvergenciaChart from "@/components/simulador/ConvergenciaChart";
+
+function pct(delta: number | null): string {
+  if (delta == null) return "—";
+  return `${delta > 0 ? "+" : "−"}${Math.abs(delta).toFixed(1)}%`;
+}
+
+// Una columna de la comparación (un brazo del experimento).
+function Brazo({
+  run,
+  color,
+  etiqueta,
+}: {
+  run: RunIndexEntry;
+  color: string;
+  etiqueta: string;
+}) {
+  const conv = run.convergencia;
+  return (
+    <div className="flex-1">
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="inline-block h-2.5 w-2.5 rounded-full" style={{ background: color }} />
+        <span className="font-sans text-sm font-semibold text-(--sim-ink)">{etiqueta}</span>
+        <code className="sim-mono rounded bg-(--sim-paper-deep) px-1.5 py-0.5 text-[0.7rem] text-(--sim-ink-soft)">
+          {run.id8}
+        </code>
+      </div>
+      <dl className="mt-3 space-y-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="sim-mono text-[0.65rem] uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+            Convergencia
+          </dt>
+          <dd className="sim-mono text-lg font-semibold tabular-nums text-(--sim-ink)">
+            {pct(conv?.delta_pct ?? null)}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="sim-mono text-[0.65rem] uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+            Conceptos fijados
+          </dt>
+          <dd className="sim-mono text-lg font-semibold tabular-nums text-(--sim-ink)">
+            {run.fijacion?.conceptos_fijados ?? 0}
+            <span className="text-(--sim-ink-faint)"> / 10</span>
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="sim-mono text-[0.65rem] uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+            Palabras adoptadas
+          </dt>
+          <dd className="sim-mono text-lg font-semibold tabular-nums text-(--sim-ink)">
+            {run.neologismos_adoptados}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function ExperimentoControl({
+  normal,
+  ablacion,
+}: {
+  normal: RunIndexEntry;
+  ablacion: RunIndexEntry;
+}) {
+  const dNormal = normal.convergencia?.delta_pct ?? null;
+  const dAblacion = ablacion.convergencia?.delta_pct ?? null;
+  const factor =
+    dNormal != null && dAblacion != null && dAblacion !== 0
+      ? Math.abs(dNormal / dAblacion)
+      : null;
+
+  return (
+    <div>
+      <p className="mt-3 max-w-reading font-sans text-[0.95rem] leading-relaxed text-(--sim-ink-soft)">
+        ¿Y si la lengua converge sola, sin que nada la empuje? Para saberlo corrimos dos veces la
+        misma simulación: una <strong className="font-semibold text-(--sim-ink)">normal</strong>, y
+        otra de <strong className="font-semibold text-(--sim-ink)">control</strong> con el andamiaje
+        apagado — sin sugerir contagio entre agentes, sin abrir competencias por nombrar las cosas,
+        sin reforzar las formas ya usadas. Si ambas convergen igual, la koiné era un truco del
+        andamiaje. No lo fue.
+      </p>
+
+      <figure className="mt-6">
+        <ConvergenciaChart
+          normal={normal.convergencia?.serie ?? []}
+          ablacion={ablacion.convergencia?.serie ?? []}
+        />
+        <figcaption className="sim-mono mt-3 text-[0.65rem] uppercase tracking-[0.14em] text-(--sim-ink-faint)">
+          Fig. 2 · Distancia idiolectal media por día (lectura emergente: solo formas nuevas). Baja =
+          las voces se acercan. La normal sigue cayendo; el control se estanca hacia el día 16.
+        </figcaption>
+      </figure>
+
+      <div className="mt-8 flex flex-col gap-6 rounded-2xl border border-(--sim-rule) bg-(--sim-paper-deep) p-6 sm:flex-row">
+        <Brazo run={normal} color="#5B4FCF" etiqueta="Normal" />
+        <div aria-hidden="true" className="hidden w-px self-stretch bg-(--sim-rule) sm:block" />
+        <Brazo run={ablacion} color="#9d7f66" etiqueta="Ablación (control)" />
+      </div>
+
+      {factor != null && (
+        <p className="mt-6 max-w-reading font-serif text-lg leading-snug text-(--sim-ink)">
+          Con el andamiaje encendido, la comunidad converge{" "}
+          <strong className="font-semibold text-(--sim-fuego)">{factor.toFixed(1)}× más</strong> que
+          su control. Esa diferencia — no la caída de la curva normal por sí sola — es la evidencia
+          de que la koiné <em>emerge</em>.
+        </p>
+      )}
+
+      <p className="mt-6 max-w-reading font-sans text-xs leading-relaxed text-(--sim-ink-faint)">
+        Nota metodológica: la convergencia se lee en tres escalas (acumulada, ventana y emergente);
+        esta figura usa la emergente, la más exigente, que solo mira las formas nacidas en la
+        simulación. La acumulada de ambos runs es casi idéntica (−44% vs −41%) porque converge por
+        mera acumulación del vocabulario compartido — un artefacto, no koineización.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Qué hace

Completa las tres secciones cross-run **y las mueve a su propia página** para que sean descubribles (antes quedaban al 48% de scroll de la edición insignia — invisibles en la práctica).

### Sección nueva: La prueba de control (experimento normal vs ablación)
- **ConvergenciaChart.tsx** (cliente, Recharts): las dos series de convergencia emergente lado a lado — normal (`038d7b9d`, sólida, sigue cayendo) vs ablación (`bdc54134`, punteada, se estanca al día 16). La brecha **es** la evidencia.
- **experimento.tsx** (servidor): la tesis — la comunidad con andamiaje converge **2.7× más** que su control; comparación de brazos (convergencia, fijación 6 vs 4/10, adoptadas 63 vs 39); nota metodológica sobre las tres lecturas y el artefacto de la acumulada.

### Página propia /simulador/runs
- Las tres secciones (evolución, experimento, diccionario koiné) viven ahora en `/simulador/runs` con header y back-link. La evolución arranca al **9%** de la página (antes 48%).
- `/simulador` gana un **callout destacado** hacia ella donde estaban las secciones, y entra en los anexos (grid 2×2).

### Verificación
- Build estático **32/32** páginas (incluye `/simulador/runs`), `tsc` y `eslint` limpios.
- SSR verificado: las 3 secciones, 6 runs en la timeline, factor 2.7×, brazos del experimento, diccionario (`kali-subo`), back-link, notas.
- El chart Recharts (cliente) se confirmó renderizando 2 líneas a 724px; el viewport del preview se colgó en 0 después (glitch del entorno). Se re-verifica en el smoke de producción.
- Sitio 100% estático (cero Supabase en runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)