### PR TITLE
fix(koine): veredicto distingue plateau de convergencia sostenida

### DIFF
--- a/proyecto-linguistico-caquetío/BITACORA_RUNS.md
+++ b/proyecto-linguistico-caquetío/BITACORA_RUNS.md
@@ -67,11 +67,12 @@ ablación converge igual, la koineización era andamiaje, no emergencia.
   un rebote (días 12–17, entrada de formas nuevas) y **sigue convergiendo**
   hasta 0.575. El andamiaje no solo acelera: sostiene la convergencia después
   del equilibrio inicial.
-- ⚠️ **El veredicto impreso de la ablación dice "CONVERGE ✓"** porque compara
-  inicio vs fin de forma naive (−6.6% es negativo). Es correcto pero engañoso
-  leído solo: la trayectoria es plateau, no convergencia sostenida. El
-  veredicto binario debería considerar la pendiente reciente, no solo los
-  extremos — anotado como ajuste pendiente.
+- ✅ **El veredicto impreso de la ablación decía "CONVERGE ✓"** porque comparaba
+  inicio vs fin de forma naive (−6.6% es negativo). Era correcto pero engañoso
+  leído solo: la trayectoria es plateau, no convergencia sostenida. **Resuelto**
+  (`veredicto_convergencia()` en `curiana_koine.py`, 2026-07-08): el veredicto
+  mira ahora la pendiente del último tercio y distingue `converge` /
+  `plateau` / `diverge`. La ablación pasó a imprimir "SE ESTABILIZA ~".
 - **La ablación aún fija conceptos (4/10):** los eventos de nombramiento
   siguen ocurriendo (solo se apagan las inyecciones de prompt), así que hay
   fijación residual genuina — los agentes reusan variantes que oyeron en el

--- a/proyecto-linguistico-caquetío/MIGRACION_RUNS_EVOLUCION.md
+++ b/proyecto-linguistico-caquetío/MIGRACION_RUNS_EVOLUCION.md
@@ -102,11 +102,33 @@ Sin riesgo nuevo: todo sale de Supabase **local** a JSON commiteado. La página
 en producción nunca consulta la base (misma razón por la que se borró el Vercel
 viejo). Añadir un run a la página = correr los exporters localmente + commit.
 
-## Estado de la rama
+## Estado
 
+**En producción (2026-07-07/08):**
 - ✅ `export_runs_index.py` + `content/simulador/runs/index.json` (6 runs curados).
-- ✅ `lib/runs.ts` (loader tipado + helper de pareja de experimento).
-- ⏳ Refactor de los tres `export_*_seed.py` a `runs/<id8>/`.
-- ⏳ Reparar `20091e1f`: correr `generar_perfiles_curados()` post-hoc (no tiene
-  perfiles — el teardown lo cortó en el turno 57). Es el run del diccionario koiné.
-- ⏳ UI (secciones 1–4 de arriba) — pendiente de tu criterio de diseño.
+- ✅ `lib/runs.ts` (loader tipado + `getParejaExperimento()`).
+- ✅ **Página propia `/simulador/runs`** con las tres secciones: la evolución
+  (timeline cross-run), la prueba de control (experimento normal vs. ablación,
+  `ConvergenciaChart` de doble línea) y el diccionario koiné. `/simulador` la
+  anuncia con un callout destacado + anexo. Resolvió el problema de
+  descubribilidad (las secciones estaban al 48% de scroll de la edición
+  insignia; ahora la evolución arranca al 9% de su propia página).
+
+**Pendiente:**
+- ⏳ **Detalle por run** (`runs/<id8>/{resumen,personajes,neologismos}.json`):
+  refactor de los tres `export_*_seed.py` a escribir por run + loaders con
+  parámetro de run + ruta dinámica `/simulador/runs/[id8]` para que cada
+  entrada del timeline sea navegable. Hoy el timeline no es clickable porque no
+  hay a dónde ir. **Es infraestructura sin consumidor todavía**; conviene
+  hacerlo junto con la UI que lo consuma, no antes.
+- ⏳ **Reparar `20091e1f`** (el run del diccionario koiné, sin perfiles porque el
+  teardown lo cortó en el turno 57). Escribe solo a Supabase local y cuesta
+  centavos de Haiku, pero **no es un one-liner**: `generar_perfiles_curados`
+  es un método de `ObserverAgent` (`curiana_observer.py:538`,
+  `observer.generar_perfiles_curados(db, run_id)`) y necesita un `ObserverAgent`
+  construido con un cliente Anthropic + el léxico. Lo más limpio es un script
+  chico que replique el bloque `--perfiles` del orquestador
+  (`curiana_orchestrator_v2.py:961`) apuntado al `run_id` de `20091e1f`, y
+  luego `python export_personajes_seed.py 20091e1f-...` para regenerar su seed.
+  (Además hoy no tiene consumidor en la página hasta que exista el detalle por
+  run — ver punto anterior.)

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
@@ -315,6 +315,52 @@ def distancia_idiolectal(idiolectos: dict[str, "IdiolectoAgente"], min_formas: i
     return round(sum(distancias) / len(distancias), 4) if distancias else None
 
 
+def veredicto_convergencia(
+    puntos: list[tuple[int, float]],
+    umbral_total: float = 0.05,
+    umbral_reciente: float = 0.02,
+) -> tuple[str, str]:
+    """Clasifica la trayectoria de la distancia idiolectal en el tiempo.
+
+    Un veredicto binario (fin < inicio) marca "converge" aunque la curva haya
+    bajado solo al principio y luego se ESTANCARA — el caso típico de un run de
+    ablación (baja los primeros días por el mundo compartido, se aplana después
+    sin andamiaje). Aquí se mira también la pendiente del último tercio para
+    separar convergencia SOSTENIDA de un plateau.
+
+    puntos: lista de (día, distancia) con valores no nulos. Se ordena por día.
+    Retorna (codigo, mensaje); codigo ∈ {converge, plateau, diverge, insuficiente}.
+
+      converge     — bajó en total (> umbral_total) y el último tercio sigue
+                     bajando (> umbral_reciente).
+      plateau      — bajó en total pero el último tercio se estancó o subió.
+      diverge      — no bajó en total (se mantuvo o subió).
+      insuficiente — menos de 2 puntos comparables.
+
+    Umbrales en cambio RELATIVO (la distancia vive en ~0.4–0.7): total 5%,
+    reciente 2%.
+    """
+    if len(puntos) < 2:
+        return ("insuficiente", "datos insuficientes (ningún par de días comparable)")
+    pts = sorted(puntos)
+    d_ini, d_fin = pts[0][1], pts[-1][1]
+    if not d_ini:
+        return ("insuficiente", "distancia inicial nula")
+    delta_total = (d_fin - d_ini) / d_ini
+
+    # Tramo reciente: desde el inicio del último tercio hasta el final. Con
+    # pocos puntos cae a una ventana de 2 (penúltimo → último).
+    corte = min(len(pts) - 2, (2 * len(pts)) // 3)
+    d_rec_ini = pts[corte][1]
+    delta_reciente = (d_fin - d_rec_ini) / d_rec_ini if d_rec_ini else 0.0
+
+    if delta_total <= -umbral_total:
+        if delta_reciente <= -umbral_reciente:
+            return ("converge", "CONVERGE ✓ (koineización sostenida)")
+        return ("plateau", "SE ESTABILIZA ~ (bajó y se estancó — sin convergencia sostenida)")
+    return ("diverge", "NO converge ✗ (sin koineización)")
+
+
 # ══════════════════════════════════════════════════════════════════════
 # V. INYECCIÓN EN EL PROMPT
 # ══════════════════════════════════════════════════════════════════════

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -60,6 +60,7 @@ from curiana_koine import (
     prompt_emocionar,
     prompt_idiolecto,
     distancia_idiolectal,
+    veredicto_convergencia,
 )
 
 
@@ -923,13 +924,16 @@ def auto_mode(
         # Veredicto sobre la métrica MÁS EXIGENTE con datos suficientes:
         # emergente > ventana > acumulada (la acumulada converge casi siempre
         # por acumulación del vocabulario base — no es evidencia por sí sola).
+        # No basta con fin < inicio: una curva que baja al principio y se
+        # estanca (típico de la ablación) daría un falso "converge". El
+        # veredicto mira también la pendiente del último tercio (ver
+        # veredicto_convergencia en curiana_koine.py).
         for etiqueta, idx in (("emergente", 3), ("ventana", 2), ("acumulada", 1)):
             puntos = [(p[0], p[idx]) for p in serie_distancia if p[idx] is not None]
             if len(puntos) >= 2:
+                _codigo, mensaje = veredicto_convergencia(puntos)
                 d_ini, d_fin = puntos[0][1], puntos[-1][1]
-                veredicto = ("CONVERGE ✓ (la koiné se forma)" if d_fin < d_ini
-                             else "NO converge ✗ (sin koineización)")
-                print(f"  Veredicto [{etiqueta}]: inicio {d_ini} → fin {d_fin}  →  {veredicto}")
+                print(f"  Veredicto [{etiqueta}]: inicio {d_ini} → fin {d_fin}  →  {mensaje}")
                 break
         else:
             print("  Veredicto: datos insuficientes (ningún par de días comparable)")

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
@@ -7,7 +7,21 @@ from curiana_koine import (
     CompetenciaLexica,
     distancia_idiolectal,
     emocionar_de,
+    veredicto_convergencia,
 )
+
+# Series de convergencia emergente reales (koine_metrics) de los dos brazos del
+# experimento 2026-07-06 — la evidencia de que el veredicto binario engañaba.
+SERIE_NORMAL_038 = [
+    0.6997, 0.6253, 0.6069, 0.5634, 0.533, 0.5161, 0.509, 0.5047, 0.5413, 0.5363,
+    0.5346, 0.5721, 0.5682, 0.5858, 0.6321, 0.6392, 0.6404, 0.6216, 0.6195, 0.5934,
+    0.5907, 0.5917, 0.5835, 0.5791, 0.5763, 0.5792, 0.5842, 0.5823, 0.5714, 0.5746,
+]
+SERIE_ABLACION_BDC = [
+    0.6957, 0.6758, 0.7118, 0.6715, 0.6521, 0.6349, 0.6258, 0.6404, 0.6217, 0.6807,
+    0.6729, 0.6984, 0.6933, 0.6855, 0.6696, 0.6514, 0.6491, 0.649, 0.6461, 0.6456,
+    0.6423, 0.6413, 0.6407, 0.6427, 0.6423, 0.6432, 0.642, 0.6443, 0.6528, 0.6499,
+]
 
 
 def _idios(nombres):
@@ -34,6 +48,37 @@ def test_distancia_none_con_datos_insuficientes():
     # ventana sin habla registrada: nadie tiene vector reciente
     idios2 = _idios(["Manaure", "Shaboro"])
     assert distancia_idiolectal(idios2, ventana=True) is None
+
+
+# ── Veredicto de convergencia: plateau ≠ convergencia sostenida ──────
+
+def _puntos(serie):
+    return [(i + 1, v) for i, v in enumerate(serie)]
+
+
+def test_veredicto_normal_converge_sostenido():
+    """El run normal baja en total Y sigue bajando en el último tercio."""
+    codigo, _ = veredicto_convergencia(_puntos(SERIE_NORMAL_038))
+    assert codigo == "converge"
+
+
+def test_veredicto_ablacion_es_plateau_no_converge():
+    """El run de ablación baja al inicio y se estanca — el binario decía
+    'CONVERGE' porque fin < inicio; el nuevo veredicto lo llama plateau."""
+    codigo, _ = veredicto_convergencia(_puntos(SERIE_ABLACION_BDC))
+    assert codigo == "plateau"
+    # sanity: el binario viejo (fin < inicio) SÍ daba positivo — por eso engañaba
+    assert SERIE_ABLACION_BDC[-1] < SERIE_ABLACION_BDC[0]
+
+
+def test_veredicto_diverge_si_sube():
+    codigo, _ = veredicto_convergencia([(1, 0.4), (2, 0.5), (3, 0.6)])
+    assert codigo == "diverge"
+
+
+def test_veredicto_insuficiente_con_un_punto():
+    codigo, _ = veredicto_convergencia([(1, 0.5)])
+    assert codigo == "insuficiente"
 
 
 # ── Métrica por ventana: mide el habla RECIENTE, no el acumulado ─────


### PR DESCRIPTION
## Qué arregla

El veredicto de convergencia impreso al cerrar un run era **binario** (`fin < inicio` → CONVERGE), lo que daba un falso positivo cuando la curva baja al principio y luego se **estanca** — exactamente el run de ablación `bdc54134` (`0.6957 → 0.6499`, marcaba "CONVERGE ✓" pese a aplanarse en ~0.65 desde el día 16). Lo dejé anotado en la bitácora del experimento; este es el fix.

## Cambios

- **`veredicto_convergencia()`** en `curiana_koine.py`: función pura que mira el cambio **total** y la **pendiente del último tercio**. Códigos: `converge` / `plateau` / `diverge` / `insuficiente`. Umbrales relativos (total 5%, reciente 2%).
- **Orquestador**: reemplaza el binario por esta función.
- **4 tests** con las series emergentes reales de ambos brazos del experimento: normal → `converge`, ablación → `plateau`. Suite: **32 tests** (antes 28), todos verdes.

## Resultado

```
normal  038d7b9d: 0.6997 → 0.5746  =>  CONVERGE ✓ (koineización sostenida)
ablación bdc54134: 0.6957 → 0.6499  =>  SE ESTABILIZA ~ (bajó y se estancó — sin convergencia sostenida)
```

Solo afecta el print de cierre del run (Python de `curiana_sim/`); no toca el dashboard ni datos persistidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)