### PR TITLE
feat(simulador): nota de curación en /simulador/runs

### DIFF
--- a/app/simulador/runs/page.tsx
+++ b/app/simulador/runs/page.tsx
@@ -59,6 +59,12 @@ export default function RunsPage() {
           una koiné — y la última expedición salió con un grupo de control para probar que la
           convergencia no era un truco del andamiaje.
         </p>
+        <p className="mt-3 max-w-reading font-sans text-xs leading-relaxed text-(--sim-ink-faint)">
+          Se muestran las {runsIndex.runs.length} expediciones que aportan al relato: los runs largos
+          y calibrados. Las corridas de desarrollo y las pruebas cortas — la mayoría de las más de
+          veinte simulaciones que se hicieron — quedan registradas en la bitácora del proyecto, no
+          aquí.
+        </p>
       </header>
 
       <section id="evolucion" className="mt-4 scroll-mt-24">


### PR DESCRIPTION
Responde la pregunta natural de un visitante (y la que surgió al probar): "¿y los demás runs que se hicieron?".

Agrega una nota breve al header de `/simulador/runs` explicando que se muestran las **6 expediciones que aportan al relato** (los runs largos y calibrados) y que las corridas de desarrollo y pruebas cortas — la mayoría de las 20+ simulaciones — quedan registradas en la **bitácora del proyecto**, no en la página pública. Honestidad sobre la curación explícita del `MANIFIESTO`.

Verificado: build 32/32, tsc/eslint limpios, nota presente en SSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)