### PR TITLE
feat(seo): incluir /simulador en el sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next';
 import { getAllEditions } from '@/lib/content';
+import { getAllPersonajes } from '@/lib/personajes';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const editions = await getAllEditions();
@@ -29,5 +30,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.9,
   }));
 
-  return [...staticPages, ...editionPages];
+  // Simulador: la sección de contenido evergreen (antes ausente del sitemap).
+  const simuladorPages: MetadataRoute.Sitemap = [
+    { path: '/simulador', priority: 0.9 },
+    { path: '/simulador/runs', priority: 0.8 },
+    { path: '/simulador/personajes', priority: 0.7 },
+    { path: '/simulador/lexicon', priority: 0.7 },
+    { path: '/simulador/neologisms', priority: 0.7 },
+  ].map(({ path, priority }) => ({
+    url: `${baseUrl}${path}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority,
+  }));
+
+  // Fichas de personaje (rutas dinámicas del seed curado).
+  const personajePages: MetadataRoute.Sitemap = getAllPersonajes().map((p) => ({
+    url: `${baseUrl}/simulador/personajes/${p.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.5,
+  }));
+
+  return [...staticPages, ...editionPages, ...simuladorPages, ...personajePages];
 }


### PR DESCRIPTION
El sitemap solo listaba home, `/archivo` y las ediciones — **toda la sección `/simulador`** (el grueso del contenido evergreen: la simulación, la evolución entre runs, el léxico, los personajes) era invisible para los buscadores.

Agrega 25 entradas: `/simulador`, `/simulador/runs`, `/simulador/lexicon`, `/simulador/neologisms`, `/simulador/personajes` y las 20 fichas de personaje del seed curado.

Verificado: `tsc` limpio, `sitemap.xml` local incluye las 25 rutas (`/simulador/runs` confirmada).

⚠️ Nota aparte (pre-existente, no tocada aquí): `baseUrl` es `https://curianaradio.com`, un dominio que **no está conectado** en el proyecto Vercel (hoy sirve en `curiana-radio.vercel.app`). Si no se piensa conectar ese dominio, conviene corregir la base — pero es una decisión de dominio canónico, aparte de este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)