### PR TITLE
Minar Antczak 2017, cerrar los barridos de Oliver cap. 3, y abrir Oviedo y Baños (#57 #58 #59)

### DIFF
--- a/proyecto-linguistico-caquetío/3-mundo/corpus/parentesco.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/parentesco.yaml
@@ -500,7 +500,7 @@
     (morfología craneofacial) cuestiona el modelo clásico de una "invasión caribe" con reemplazo
     poblacional biológico de las Antillas.
   fuente: atestiguado
-  referencia: "historiografía caribeña sobre 'Caribe' como categoría colonial/legal, y estudios de morfología craneofacial que cuestionan el modelo de invasión caribe precontacto (fuentes secundarias web — ver hoja de fuentes). Nota: esto es un dato sobre el debate historiográfico en sí, no una afirmación directa sobre la Curiana"
+  referencia: "PARTE CON FUENTE REVISADA POR PARES (verificado 2026-08-04, issue #58): Antczak, Urbani & Antczak 2017, J World Prehist 30:131-175, p.157 (\"the spatial boundaries between Cariban, Arawakan and other indigenous speakers should not be considered impermeable\"; sitio de La Cajara con mezcla de cinco tradiciones cerámicas), p.132 (la conflación de cerámica, lengua y biología como \"outdated monolithic conception\") y p.160 (para la supuesta subyugación valencioide: \"archaeological data to support such a scenario is absent\" — faltan aldeas quemadas, traumas esqueléticos y desplazamiento). PARTE TODAVÍA SIN FUENTE CITABLE: la 'morfología craneofacial' y la categoría legal/colonial de 'caribe' NO están en Antczak et al. 2017 ni en ninguna obra del repo — siguen apoyadas en búsquedas web. Nota: esto es un dato sobre el debate historiográfico en sí, no una afirmación directa sobre la Curiana"
   dominios: [parentesco, politica]
   agentes_relacionados: [Marokoto-ni]
   implicacion_simulacion: >

--- a/proyecto-linguistico-caquetío/4-fuentes/INDICE_FUENTES.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/INDICE_FUENTES.md
@@ -36,6 +36,30 @@ medido: 2026-08-04
    `MorenoMayar_et_al_2018_Science_Early_Human_Dispersals.pdf`, ver
    [[moreno-mayar-2018]].
 
+## ⚠️ Cómo NO medir una fuente (aprendido el 2026-08-04)
+
+La tanda de minería de esa noche tropezó **tres veces** con la misma clase de
+error, y las tres veces el síntoma fue idéntico: *un `grep` devuelve cero y uno
+concluye que la fuente no habla del tema*. No era la fuente: era la consulta.
+
+| Fuente | El `grep` que falló | Por qué | La realidad |
+|---|---|---|---|
+| [[antczak-2017-cariban]] | `Caqueti` → 0 | el PDF descompone acentos: `Caquet´ıo` | 8 menciones, media p. 157 sobre la frontera caquetía |
+| [[oviedo-y-banos]] | `caquet` → 0 | Oviedo escribe **`caiquetía`**, y `Coriana` por Curiana | 7 menciones, incluido el pasaje de Manaure |
+| [[oliver-1989-cap3]] | `Todariquiba` → 0 con `pypdf` | `pypdf` lo parte en `T odariquiba`; `pdftotext` no | 7 apariciones limpias |
+
+Reglas que salen de ahí, y que valen para toda minería futura:
+
+1. **Buscar por raíz corta y sin acentos** (`caquet`, `Manaur`, `Paraguan`)
+   antes de dar por ausente un tema.
+2. **Probar la otra receta de extracción** antes de concluir. `pdftotext` y
+   `pypdf` no producen el mismo texto sobre el mismo PDF.
+3. **Las fuentes coloniales no usan la ortografía moderna.** Antes de buscar un
+   etnónimo o un topónimo en una crónica, leer una página al azar y ver cómo lo
+   escribe *esa* obra.
+4. Un cero es un resultado que hay que **verificar**, no uno que se pueda
+   reportar directamente.
+
 ## Inventario medido
 
 ### Disponibles y con texto
@@ -43,17 +67,17 @@ medido: 2026-08-04
 | Fuente | Pp. | Estado de minado | Sostiene | Prioridad |
 |---|---|---|---|---|
 | [[zavala-reyes-2015]] | 20 | ✅ **completo (288/288)** | 7 hechos · **164 lex.** · **62 citas para F1** | hecha |
-| [[oliver-1989-cap3]] | 113 | parcial (2 sesiones) | **15 hechos** · 2 lex. | barridos restantes |
+| [[oliver-1989-cap3]] | 113 | ✅ **minado** (4 barridos cerrados 2026-08-04) | **15 hechos** · 2 lex. | hecha |
 | [[oliver-1989-cap2]] | 109 | **sin minar** | 1 hecho | **F5 · ALTA — la única del gate que queda** |
 | [[arcaya-1920]] | 348 | minado (religión/familia) | **13 hechos** · 1 lex. | media |
 | [[jahn-1927]] | 510 | parcial (3 sesiones) | **16 hechos** · 4 lex. | media |
 | [[alvarado-1921]] | 354 | ✅ **minado** (109 de 1551 a fondo) | A=3 B=36 C=13 **D=57** · **18 adjudicaciones** | hecha |
 | [[gatschet-1885]] | 7 (2 txt) | ✅ **minado** | 48 léxicas + 31 topón. + 6 fórmulas · **5 citas** | hecha |
 | [[van-buurt-2014]] | 48 | ✅ **minado** | §6=88 · §11=29 · 180 topón. · **8 citas** | hecha |
-| [[oviedo-y-banos]] | 519 | **sin minar** | 1 hecho (vía Zavala) | alta |
+| [[oviedo-y-banos]] | 519 | ✅ **minado** — solo el cap. III toca a los caquetíos | 1 hecho, **ascendido a cita directa** | hecha |
 | [[camacho-2011]] | 13 | minado | **16 hechos** | hecha |
 | [[antczak-2015-las-aves]] | 38 | minado | 7 hechos | hecha |
-| [[antczak-2017-cariban]] | 45 | **sin minar** | 0 | media |
+| [[antczak-2017-cariban]] | 45 | ✅ **minado** | 0 hechos · refuerza `parentesco-032` | hecha |
 | [[adam-1879]] | 27 | minado | 1 hecho | hecha |
 | [[angleria-1892]] | 460+492 | parcial (1 dato) | 1 hecho | media |
 | [[las-casas-1875]] | 613 | minado — **nulo ×3** | 0 | baja |

--- a/proyecto-linguistico-caquetío/4-fuentes/antczak-2017-cariban.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/antczak-2017-cariban.md
@@ -8,10 +8,13 @@ genero: arqueo-linguistica
 local: "fuentes_caquetios/Antczak_et_al_2017_Cariban_Migration_Orinoco.pdf"
 paginas: 45
 capa_texto: si
-estado_minado: sin-minar
+estado_minado: minado
+cobertura: "leído íntegro para la pregunta caribe/caquetío; 6 hechos propuestos, ninguno fusionado todavía"
 prioridad: media
-sostiene: {hechos_corpus: 0, entradas_lexicon: 0}
-verificado: 2026-07-29
+tareas: [F10]
+sostiene: {hechos_corpus: 0, entradas_lexicon: 0, entradas_reforzadas: 1}
+verificado: 2026-08-04
+minado: 2026-08-04
 aliases: ["Antczak et al. 2017", "Cariban Migration"]
 ---
 
@@ -19,43 +22,166 @@ aliases: ["Antczak et al. 2017", "Cariban Migration"]
 
 ## Qué es
 
-**Una fuente académica moderna, open access, que el proyecto tiene y no ha
-abierto.** No figura en la tabla de fuentes de [[PLAN_MAESTRO]] §1.1. Evalúa la
-hipótesis del movimiento migratorio de hablantes **caribes** desde el Orinoco
-medio hacia el centro-norte de Venezuela, cruzando datos arqueológicos,
+Paper open access (CC) que evalúa la hipótesis del movimiento migratorio de
+hablantes **caribes** desde el Orinoco medio hacia el **centro-norte** de
+Venezuela (cuenca del lago de Valencia), cruzando datos arqueológicos,
 lingüísticos, etnohistóricos, genéticos y ecológicos.
 
-Su conclusión: ruta terrestre/fluvial alternativa, y fechas **800-900 d.C.** en
-vez de 600-800 d.C.
+Su conclusión propia: ruta terrestre/fluvial alternativa, y fechas **800-900
+d.C.** en vez de 600-800 d.C.
 
-## Por qué le importa a este proyecto
+## Lo primero que hay que decir: no trata de lo que el proyecto creía
 
-El proyecto sostiene una tesis fuerte sobre **quiénes eran "los caribes"** —
-[[01_familia_caquetia]] §2 y §5: categoría porosa, categoría legal colonial,
-expansión activa en el s. XIV, arqueología que cuestiona el reemplazo
-poblacional. Toda esa discusión se apoya hoy en **búsquedas web** y en
-[[adam-1879]].
+El corpus lo señaló como la fuente para respaldar su tesis sobre la **expansión
+caribe hacia las Antillas Menores en el siglo XIV**. Eso **no está aquí**. El
+paper no menciona a los kalinago, ni a Breton, ni el doble registro de habla, ni
+la morfología craneofacial, ni las Antillas Menores como escenario, ni la
+categoría legal colonial de "caribe". Su escenario es otro (el lago de Valencia)
+y su siglo es otro (IX-X d.C.).
 
-Aquí hay un paper revisado por pares, de 45 páginas, del mismo equipo que ya es
-fuente del corpus ([[antczak-2015-las-aves]]), que trata exactamente el
-movimiento de poblaciones caribes en Venezuela. **Es la fuente natural para
-sustituir esas referencias web por una cita real.**
+Lo que sí trae, y no se esperaba, es **medio artículo sobre la frontera
+caquetío-caribe** — que es una pregunta mejor que la que se le iba a hacer.
 
-## Estado técnico (verificado 2026-07-29)
+## Qué ha dado — minado 2026-08-04 (tarea del issue #58)
 
-6.8 MB · 45 páginas · capa de texto **excelente** (99K caracteres en 30 pp.) ·
-open access (CC), sin restricción de uso.
+### 1. La frontera occidental, atestiguada (p. 157)
+
+La página 157 es la más productiva del paper para este proyecto:
+
+- Oliver 1989 sitúa una formación arahuaca **"pre-Caquetío"** dentro de la
+  tradición **Macro-Dabajuroide**, en los actuales Falcón y Lara, que hacia
+  **700-800 d.C.** habría dado origen a las tradiciones Tierroide y Dabajuroide.
+- Los alfareros dabajuroides migran al **valle del Yaracuy** en ese período y
+  hacia **900 d.C.** se difunden más allá; ocupan la costa caribeña al norte de
+  la depresión del Yaracuy y **las islas de Aruba, Bonaire y Curazao**. Es, en
+  arqueología, la ruta insular que [[van-buurt-2014]] documenta en léxico.
+- En el Yaracuy entran en contacto con grupos del tronco **macro-caribe**,
+  posibles ancestros de los **jiraharas** históricos (Kaufman 1990). Es el
+  respaldo académico de la categoría `jirajaroide-contacto` del lexicón.
+- **Entre 1200 d.C. y el Contacto**, los grupos de descendencia arahuaca
+  (dabajuroide) y caribe (valencioide) están **en disputa por el acceso y
+  control de los archipiélagos de Las Aves de Sotavento, Las Aves de Barlovento
+  y Los Roques** (Antczak & Antczak 2006 — es decir, [[antczak-2015-las-aves]]).
+- **La presencia dabajuroide en el norte de Falcón parece haber CONTENIDO el
+  asentamiento valencioide en la costa occidental**: los rasgos cerámicos
+  valencioides están *virtualmente ausentes* en la depresión del Yaracuy y en
+  Quíbor, que es territorio caquetío de contacto temprano.
+
+> Esto último es lo más valioso, y conviene decirlo sin adornos: **el conflicto
+> caquetío-caribe que el canon trata como amenaza difusa tiene, en el registro
+> arqueológico, un objeto concreto y una fecha que cae dentro de la ventana de
+> la simulación** — el control de unos archipiélagos, desde 1200 d.C. hasta el
+> Contacto. No es un miedo ambiental: es una disputa territorial documentada.
+
+### 2. La porosidad de las fronteras étnicas — ahora con cita real
+
+La frase que el corpus necesitaba y sostenía con búsquedas web, aquí revisada
+por pares (p. 157):
+
+> "the spatial boundaries between Cariban, Arawakan and other indigenous
+> speakers should not be considered impermeable."
+
+Y el sitio de La Cajara (Cojedes), con mezcla de cerámica arauquinoide, osoide,
+tocuyanoide, tierroide y valencioide, como caso material de esa permeabilidad.
+
+Más aún, en el propio lado caquetío (p. 157, José Oliver 2016 *pers. comm.*):
+**no todos los rasgos arqueológicos de los sitios de la costa de Falcón son
+dabajuroides**, lo que "plantea un desafío a nuestra comprensión de los
+caquetíos protohistóricos". La porosidad no es solo de los caribes: es también
+de la identidad caquetía, que es la que la simulación da por sentada.
+
+### 3. El método, que es lo que de verdad respalda `parentesco-032`
+
+- La conflación de cerámica, lengua y biología es una "**outdated monolithic
+  conception**" que privilegiaba las migraciones de largo alcance sobre los
+  desarrollos locales (p. 132).
+- Sobre la supuesta subyugación violenta de los ocumaroides costeros por el
+  cacicazgo valencioide: "**archaeological data to support such a scenario is
+  absent**" — faltan aldeas quemadas, traumas esqueléticos y desplazamiento
+  poblacional (p. 160, y ya en p. 138).
+- Las interacciones entre grupos indígenas ocupan un "**spectrum between war and
+  peace**"; la literatura las empujó a los extremos por falta de datos, no por
+  tenerlos (p. 160). Los marcos que proponen son aculturación, transculturación,
+  **etnogénesis** e hibridez.
+
+### 4. Genética: el paper dice lo mismo que la nota de [[fernandes-2020]]
+
+Figuera-Pérez (2015) halla que el ADNmt amerindio de las poblaciones criollas
+actuales difiere entre el noroeste y el centro-norte/noreste, y esa diferencia
+**se superpone geográficamente** a la distribución etnohistórica de hablantes
+arahuacos (caquetío) y caribes. Pero los autores lo dicen con la cautela que
+importa (p. 140):
+
+> "**ethnicity cannot be determined using mtDNA**"
+
+Es exactamente la advertencia de método que `parentesco-032` y la nota de
+[[fernandes-2020]] ya llevaban. Queda respaldada, no corregida.
+
+### 5. Cerámica: una firma material del límite (p. 144)
+
+Fournier et al. (2000, 2014), por difracción de rayos X sobre cerámica
+prehispánica de 24 sitios espeleológicos: el Orinoco medio y los sitios
+valencioides cocieron **por debajo de 900 °C**. Contrastando con toda la muestra
+nacional, hay un grupo que supera los **900 °C** en la península de
+**Chichiriviche**, que se solapa con la región occidental de Falcón,
+históricamente caquetía, cerca del límite arahuaco/caribe de Durbin (1977).
+
+Los autores son explícitos en que no es concluyente y que la datación es
+limitada y problemática. **No usarlo como hecho cerrado**; sí como la única
+pista tecnológica que el proyecto tiene de que "cerámica caquetía" pudiera ser
+una categoría material y no solo geográfica.
+
+## Veredicto sobre las cuatro entradas que el issue #58 mandaba verificar
+
+| Entrada | Etiqueta | Veredicto |
+|---|---|---|
+| `parentesco-028` | reconstruido | **No lo toca.** Kalinago, Breton y el doble registro no aparecen. Sigue apoyado en [[adam-1879]]. |
+| `parentesco-029` | hipotetico | **No lo toca.** La tesis de las dos ideologías del parentesco no se afirma ni se niega. |
+| `parentesco-032` | atestiguado | **Respaldado a medias, y hay que decirlo.** La porosidad de la etiqueta y la crítica al reemplazo poblacional quedan con cita real. La **morfología craneofacial** y la **categoría legal colonial** siguen sin fuente citable: no están en este paper. |
+| `parentesco-033` | hipotetico | **Reforzado sin dejar de ser hipótesis.** "Boundaries should not be considered impermeable" y la etnogénesis como marco le dan cobertura académica al *tipo* de hipótesis; ninguna fuente afirma su contenido. |
+
+`parentesco-032` era la entrada más frágil del corpus: **etiquetada
+`atestiguado` sobre búsquedas web**. Su `referencia` queda actualizada para
+citar a Antczak en lo que Antczak sostiene y para marcar, en el mismo campo, lo
+que sigue sin sostén. Bajarla de etiqueta o partirla en dos es decisión de
+Miguel, no de esta sesión.
+
+## Hechos propuestos para el corpus (no fusionados)
+
+Seis, todos de la p. 157 salvo el último, y todos `atestiguado` salvo donde se
+indica. Se dejan aquí, en la nota, siguiendo la disciplina de que el minador
+propone y el humano fusiona:
+
+1. Formación "pre-Caquetío" macro-dabajuroide en Falcón/Lara → Tierroide y
+   Dabajuroide, 700-800 d.C. (Oliver 1989 vía Antczak et al. 2017:157).
+2. Ruta dabajuroide Yaracuy → costa → Aruba, Bonaire, Curazao hacia 900 d.C.
+3. Contacto dabajuroide con el tronco macro-caribe en el Yaracuy; posibles
+   ancestros de los jiraharas (Kaufman 1990).
+4. **Disputa arahuaco/caribe por Las Aves y Los Roques, 1200 d.C.-Contacto.**
+   El único conflicto caquetío-caribe con objeto y fecha dentro de la ventana
+   de la simulación.
+5. La presencia dabajuroide en el norte de Falcón contuvo el asentamiento
+   valencioide en la costa occidental.
+6. Cerámica de Chichiriviche cocida a >900 °C frente al resto de la muestra
+   nacional (p. 144) — `reconstruido`, no `atestiguado`: los propios autores
+   dicen que no es concluyente.
 
 ## Qué falta
 
-1. Minarlo con la pregunta *"¿qué se sabe realmente del movimiento caribe hacia
-   el norte de Venezuela, y en qué fechas?"*.
-2. Cruzar sus fechas (800-900 d.C.) con la cronología de la simulación (s.
-   XIV-XV) y con la afirmación del corpus de que la expansión caribe hacia las
-   Antillas Menores estaba *"activa durante todo el siglo XIV"*.
-3. Verificar si respalda o corrige `parentesco-028/029/032/033` — las entradas
-   más especulativas del corpus.
+1. **Las Antillas Menores del s. XIV siguen sin fuente.** La afirmación del
+   corpus de que la expansión caribe estaba "activa durante todo el siglo XIV"
+   no la sostiene este paper. Si se quiere sostener, hace falta otra obra
+   (Boomert 2000 es la referencia que este paper usa para Trinidad y el arco
+   antillano).
+2. **La morfología craneofacial** de `parentesco-032` sigue siendo web. El paper
+   ni la menciona.
+3. Antczak & Antczak 2006 (*Los ídolos de las Islas Prometidas*) es la fuente
+   de la disputa por los archipiélagos y **no está en el repo**; aquí llega de
+   segunda mano.
+4. Cruzar la p. 157 con [[oliver-1989-cap3]]: el paper cita a Oliver para la
+   formación pre-caquetía, y el capítulo está en el repo. La cadena se puede
+   cerrar de primera mano.
 
 ## Enlaces
 
-[[antczak-2015-las-aves]] · [[adam-1879]] · [[fernandes-2020]] · [[moreno-mayar-2018]]
+[[antczak-2015-las-aves]] · [[adam-1879]] · [[fernandes-2020]] · [[moreno-mayar-2018]] · [[oliver-1989-cap3]] · [[van-buurt-2014]] · [[01_familia_caquetia]]

--- a/proyecto-linguistico-caquetío/4-fuentes/oliver-1989-cap3.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/oliver-1989-cap3.md
@@ -7,11 +7,12 @@ genero: academico
 local: "fuentes_caquetios/Chapter 3 Ethnohistory.DOC-comprimido.pdf"
 paginas: 113
 capa_texto: si
-estado_minado: parcial
+estado_minado: minado
+cobertura: "familia (sesión 1), geografía política (sesión 5), economía/cerámica/guerra/religión (2026-08-04, issue #59)"
 prioridad: media
-tareas: [barridos temáticos restantes]
-sostiene: {hechos_corpus: 15, entradas_lexicon: 2}
-verificado: 2026-07-29
+sostiene: {hechos_corpus: 15, entradas_lexicon: 2, entradas_reforzadas: 1}
+verificado: 2026-08-04
+minado: 2026-08-04
 aliases: ["Oliver 1989 cap. 3", "Oliver cap. 3", "Ethnohistory"]
 ---
 
@@ -32,7 +33,7 @@ sesiones enteras del programa cultural ([[mapa-familia]] y
 | Tamaño | 1.8 MB · 113 páginas |
 | Capa de texto | **sí**, buena (~310K caracteres) |
 | Receta | `pdftotext -enc UTF-8` o `pypdf`; ambos funcionan |
-| Artefacto conocido | "Todariquiba" sale como **"T odariquiba"** (kerning del PDF) en sus ~6 apariciones. No es error de transcripción — buscar con el espacio |
+| Artefacto conocido | **Es de `pypdf`, no del PDF** (medido 2026-08-04): `pypdf` parte "Todariquiba" en **"T odariquiba"** en sus 7 apariciones; `pdftotext -enc UTF-8`, con o sin `-layout`, la da **limpia** en las 7. La receta manda: si una búsqueda no da nada, probar la otra antes de concluir que el dato no está |
 
 ## Qué ha dado
 
@@ -62,13 +63,163 @@ no del precontacto que la simulación modela — y el propio Oliver desconfía d
 lectura simple: duda entre "hijo" carnal y clasificatorio, y registra que la
 legitimidad se impugnaba por **la madre**. Ver [[01_familia_caquetia]] §1.
 
+## Los cuatro barridos restantes — minado 2026-08-04 (issue #59)
+
+Se le preguntó por **economía, cerámica, guerra y religión**. La cosecha es
+desigual: guerra y economía son abundantes, la cerámica es una sola frase (pero
+decisiva), y la religión es escasa **y casi toda de Barquisimeto, no de la
+costa** — que es justo donde vive la simulación.
+
+> ⚠️ **La advertencia que atraviesa los cuatro barridos.** Oliver dedica el
+> capítulo a demostrar que **los caquetíos NO eran una cultura homogénea**: la
+> Curiana de este proyecto es **caquetío costero** (Coro, Todariquiba), y buena
+> parte de lo que sigue es de **Barquisimeto/Yaracuy**, que él contrasta
+> explícitamente con la costa. Importar lo uno por lo otro es el mismo error que
+> [[01_familia_caquetia]] §1 ya evita con la sucesión. Cada hallazgo abajo va
+> marcado con su polity.
+
+### Guerra — el barrido más productivo
+
+- **[Barquisimeto] Doble jefatura: Jefe de Paz y Jefe de Guerra** (pp. 276-279).
+  Oliver propone que son **personas distintas**, porque los atributos se
+  contradicen: el Jefe de Guerra **acumula** rango por hazañas militares, y lo
+  exhibe en adornos corporales; el Jefe de Paz **debe redistribuir** —maíz,
+  *maçato*, yuca, legumbres a cambio de trabajo en los campos— y pierde
+  autoridad si acumula. Explícitamente "vagamente reminiscente del *Big Man*
+  melanesio", con las cautelas de Ross (1978).
+- **[Barquisimeto] Los dos oficios solo operan en su contexto.** En paz los
+  aldeanos declaran que "no tienen señor que los gobierne"; en guerra la
+  autoridad se centraliza y jerarquiza. Federmann (1530) y el documento de 1579
+  coinciden en la negativa a reconocer un jefe paramount.
+- **[Barquisimeto] Aldeas fortificadas** ("fortificadas", quizá empalizadas), 23
+  aldeas agrupadas, ~4.000 habitantes cada una (Federmann [1557] 1958:66-67).
+- **[Barquisimeto/Yaracuy] El ciclo de paz y guerra tiene motor agrícola**
+  (p. 278): valles de tamaño limitado + crecimiento demográfico → expansión
+  sobre territorio ya poblado → guerra. Y la jefatura de paz **depende** del
+  excedente agrícola, que la presión demográfica erosiona. Solo la victoria o la
+  derrota completa rompe el ciclo.
+- **[Yaracuy] Confederación elástica**: aldeas aliadas de dos en dos o de cuatro
+  en cuatro, menos poderosas que Barquisimeto por no estar unidas — pero
+  Federmann anota que **se unirían si fueran atacadas** con fuerza suficiente.
+- **[Cojedes-Llanos] Guerra de captura de esclavos, institucionalizada** (n. 126,
+  p. 277). Federmann pidió comprar una *naboria* en la aldea de **Itabana** y se
+  la negaron, "aunque acostumbraban a comprarlas y venderlas entre sí". Oliver
+  subraya que **esto solo vale para el bajo Cojedes**, y que no hay tal
+  afirmación para los caquetíos de otras áreas.
+- **[Contraste] Los kalina/kalinago sí hacen del raid de prisioneros el motor
+  del prestigio** (Dreyfus 1983-4); la guerra caquetía de Barquisimeto es, en
+  cambio, "constreñida", y su causa probable es la merma de espacio agrícola.
+  Es un matiz que **le quita generalidad al modelo caribe** de
+  `parentesco-028/029`.
+
+### Religión — poco, y casi nada costero
+
+- **[Barquisimeto] Sacrificio humano por sequía** (documento de 1579, Arellano
+  Moreno 1964:189-190). Cuando falta el agua, compran a la madre la muchacha
+  "más hermosa y mejor agestada" de diez años para arriba, la llevan a la ribera
+  del río y la degüellan con una piedra sin filo, "y ofrecen la sangre por
+  sacrificio, y dicen que aquella quieren dar **al sol por mujer**" — porque el
+  sol está enojado y por eso no llueve. Tras la llegada española lo siguen
+  haciendo **a escondidas**.
+  > Dato **colonial y de Barquisimeto**. No es norma precontacto de la Curiana
+  > costera, y proyectarlo sería exactamente lo que la regla del proyecto
+  > prohíbe. Se registra porque es el único rito caquetío descrito con detalle
+  > en todo el capítulo, y porque la ecuación **sol-enojado → sequía → esposa**
+  > es material cosmológico de primer orden si alguna vez se decide usarlo.
+- **[Barquisimeto] El *boratio* vive apartado**, en una casita de paja propia,
+  fuera de la aldea principal (1579). Y el jefe de paz de Barquisimeto **no** es
+  a la vez gran chamán.
+- **[Costa] Manaure sí lo era** (p. ~251 y ss.): su poder no era solo secular
+  sino **sagrado** — Oliver sospecha que su reputación descansaba en su
+  capacidad de gran chamán "que podía controlar y predecir fenómenos naturales",
+  mediando entre lo sobrenatural y lo natural. Etiqueta corporal elaborada:
+  llevado siempre en hamaca por un séquito, adornos de oro y cuentas de concha.
+- **[Llanos del norte] Ninguno de los jefes** aparece caracterizado con poderes
+  chamánicos; el liderazgo militar con los guaycaríes es colaborativo y menos
+  centralizado.
+
+> **La estructura que sale de cruzar los tres**: el caquetío costero **fusiona**
+> poder secular y sagrado en una sola persona (Manaure); Barquisimeto los
+> **separa** en tres (jefe de paz, jefe de guerra, boratio apartado); los Llanos
+> no registran el eje sagrado. La Curiana de la simulación está en el extremo
+> fusionado — y Shaboro como piache aparte de Manaure es, en rigor, más el
+> modelo de Barquisimeto que el costero.
+
+### Economía
+
+- **[Costa/Guajira] Red de alianzas comercial**: cuentas de concha, **sal** y
+  **azabache**. Las aldeas de la región desarrollaron una "confederación" —una
+  red amplia de alianzas— sobre la base del comercio.
+- **[Barquisimeto] Comerciaban sal con sus propios enemigos**, rodeados de
+  ellos. El oro venía de las serranías de **Nirgüa-Buria**; la sal, probablemente
+  por el valle del **Yaracuy**.
+- **[Estratégico] El límite Barquisimeto/Yaracuy es el paso entre los Llanos y
+  la costa caribeña**: controlarlo era controlar el comercio y las
+  comunicaciones. Es una de las causas de la competencia entre ambas polities.
+- **[Barquisimeto] El *maçato* (cerveza de maíz) es el instrumento político**
+  del jefe de paz: el más estimado es quien lo dispensa con más generosidad — y
+  además "sabe dar ejemplo: buen trabajador".
+
+### Cerámica — una sola frase, y vale por el barrido entero
+
+> "the Coastal Caquetío distribution in time and space is **precisely
+> congruent** with the distribution of the **Dabajuran Sub-Tradition** of
+> Falcón"
+
+Y en paralelo, los complejos del interior se atan a la **Sub-Tradición
+Tierran**. Es decir: Oliver hace corresponder sus dos polities caquetías
+(costera vs. Barquisimeto) con las dos sub-tradiciones cerámicas
+(Dabajurán vs. Tierran).
+
+Además: sitio arqueológico con **cerámica dabajurana y mayólica del s. XVI** en
+**Tomodore**; y formas de vasija aparecidas tarde en el área de Coro (Los
+Médanos, Portacelli) que **solo pueden derivar del área del Ranchería** —
+correspondiendo con el comercio caquetío de la Guajira.
+
+> ⚠️ **Cruzar con [[antczak-2017-cariban]] p. 157, que cita este mismo pasaje y
+> luego lo complica**: "no todos los rasgos arqueológicos recuperados en los
+> sitios de la costa de Falcón son dabajuroides, lo que plantea un desafío a
+> nuestra comprensión de los caquetíos protohistóricos" (José Oliver 2016,
+> *pers. comm.*). El propio Oliver matizó en 2016 la ecuación que había hecho
+> en 1989.
+
+### Lexicón: `capu` gana una segunda fuente independiente
+
+El documento de 1579 cita, **marcándolo como caquetío explícitamente**, la
+palabra con que el chamán llama a lo que los españoles entienden por "demonio":
+
+> "allí dentro llaman al demonio, que en su lengua llaman **capú** (y ésto es en
+> la lengua caquetía) […] y este nombre que ellos tienen puesto al demonio
+> (también) nos tienen puesto a nosotros. Y esto es en la lengua caquetía, que
+> es la más común"
+
+`capu` ya estaba en el lexicón como `caquetío-atestiguado` vía
+[[zavala-reyes-2015]] #60, que lo trae de Galeotto Cey. Ahora tiene **dos
+fuentes independientes** —Cey y el documento de 1579— separadas y coincidentes.
+Es el mismo tipo de convergencia que [[gatschet-1885]]↔[[van-buurt-2014]], y
+sube la entrada de "atestiguada por una fuente" a "atestiguada por dos".
+
+El detalle etnográfico que trae de regalo —**los caquetíos aplicaron el mismo
+nombre a los españoles**— es demasiado bueno para no dejarlo anotado.
+
+> 📌 **Por qué la segunda cita no está en el código.** `capu` vive en
+> `curiana_sim/lexicon_zavala.py`, que **lo genera**
+> `minar_zavala_glosario.py`: cualquier anotación a mano se pierde en la
+> siguiente regeneración. La cita de 1579 se queda aquí hasta que se decida
+> cómo un lema generado puede acumular fuentes de fuera del glosario de Zavala
+> — que es un problema real del diseño del lexicón, no un olvido de esta
+> sesión, y afecta a toda entrada que alguna vez gane una segunda atestación.
+
 ## Qué falta
 
-- **Barridos temáticos restantes.** Se minó a fondo para familia (sesión 1) y
-  geografía política (sesión 5). No se le ha preguntado por economía, cerámica,
-  guerra ni religión.
 - No importar sin más el dato de las malocas del interior a la Curiana costera:
   **el propio Oliver los distingue**.
+- **Los hallazgos de arriba están en la nota, no en el corpus.** Ninguno se ha
+  fusionado a `3-mundo/corpus/`: son propuesta para revisión, en la misma
+  disciplina que los minadores del lexicón.
+- La **religión costera** sigue siendo el hueco: todo el detalle ritual del
+  capítulo es de Barquisimeto. Para la Curiana costera hay que ir a
+  [[arcaya-1920]], [[jahn-1927]] y [[oviedo-y-banos]].
 - Cadena de citas a verificar: Ballesteros [1550] en Bécker 1950, Martí 1969,
   Ponce y Vaccari 1977, [[ramos-perez-1978]] — todos llegan **vía Oliver**.
 

--- a/proyecto-linguistico-caquetío/4-fuentes/oviedo-y-banos.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/oviedo-y-banos.md
@@ -5,12 +5,15 @@ autor: "Oviedo y Baños, José de"
 anio: "1885 [1723]"
 genero: cronica
 local: "fuentes_caquetios/Oviedo_Banhos_Conquista_Poblacion_Venezuela.pdf (519 pp., ÚTIL)"
+edicion_del_ejemplar: "Biblioteca Ayacucho n.º 175 (la cita del corpus es a la edición de 1855 — paginación sin cotejar)"
 paginas: 519
 capa_texto: si
-estado_minado: sin-minar
-prioridad: alta
-sostiene: {hechos_corpus: 1, entradas_lexicon: 0}
-verificado: 2026-07-29
+estado_minado: minado
+cobertura: "leída entera para las 4 preguntas del issue #57; solo el cap. III (pp. 26-28) toca a los caquetíos"
+prioridad: baja
+sostiene: {hechos_corpus: 1, entradas_lexicon: 0, citas_ascendidas_a_directa: 1}
+verificado: 2026-08-04
+minado: 2026-08-04
 aliases: ["Oviedo y Baños", "Oviedo Baños 1885"]
 ---
 
@@ -34,24 +37,126 @@ arrastró la etiqueta de "PDF corrupto" del archivo equivocado.
 
 **Un solo hecho, y de tercera mano**: la cita de "el Manaure coriano, señor de
 toda aquella provincia… a quien rendían vasallaje algunas circunvecinas"
-(Oviedo y Baños 1855: 27) llega **vía [[zavala-reyes-2015]] p. 60**, no de una
+(Oviedo y Baños 1855: 27) llegaba **vía [[zavala-reyes-2015]] p. 60**, no de una
 lectura directa. Sostiene la paramountcy regional de
 [[05_geografia_politica_y_sucesion]] §3.
 
-## Qué falta — es la fuente sin minar con mejor relación esfuerzo/rendimiento
+> 🟢 **Ya no es de tercera mano** (2026-08-04, #57): el pasaje se localizó y se
+> leyó en el original, pp. 26-27 de la edición del repo. Ver el barrido abajo.
 
-El propio programa cultural la señaló específicamente **por su cobertura de la
-sucesión de cacicazgos**, y sigue sin abrirse. 519 páginas con texto extraíble,
-sobre la conquista de Venezuela, escritas por un criollo caraqueño en 1723 con
-acceso a documentación colonial hoy perdida.
+## Minado 2026-08-04 (issue #57) — una respuesta buena y tres negativas
 
-Preguntas concretas que se le deben hacer:
-1. **Manaure y el pacto con Ampíes** — la narración larga que Zavala cita en dos
-   líneas.
-2. **Sucesión cacical** en Coro y Paraguaná (cruzar con [[oliver-1989-cap3]]).
-3. **Todariquiba / San Bartolomé** y la geografía de los poblados.
-4. Vocabulario indígena disperso en la narración (fuente potencial de lexicón).
+Se abrió entera y se le hicieron las cuatro preguntas. **La primera dio mucho
+más de lo esperado; las otras tres dieron nada, y ese "nada" es el resultado
+más útil del barrido.**
+
+> 📌 **Advertencia de ortografía, que costó una falsa alarma.** Oviedo y Baños
+> **nunca escribe "caquetío"**: escribe **"caiquetía"/"Caiquetíos"** (7
+> apariciones), y llama a la provincia **"Coriana"**, no "Curiana" (9). Un
+> `grep` de "caquet" sobre este libro devuelve **cero** y hace concluir que la
+> obra no habla del pueblo. Habla. La misma trampa apareció con
+> [[antczak-2017-cariban]] (allí por descomposición de acentos): **contar cero
+> ocurrencias no es medir una fuente, es medir la consulta.**
+
+### 1. Manaure y el pacto con Ampíes — 🟢 la cadena de custodia se cierra
+
+El pasaje que el corpus citaba de tercera mano **está aquí, y es más largo y más
+rico que la línea que se le atribuía** (Biblioteca Ayacucho, pp. 26-27; cap. III):
+
+> "…de que el Cacique Manaure, poderoso en riquezas y vasallos, era señor de
+> toda aquella provincia, **habitada de la nación caiquetía**, y a quien rendían
+> vasallaje algunas circunvecinas"
+
+Es decir: la frase que sostenía `geografia_politica-003` y la paramountcy
+regional **ya no llega vía [[zavala-reyes-2015]] p. 60 — se lee en el original**.
+
+Y sigue, con lo que el resumen de Zavala no traía:
+
+- **La escena de la visita.** Manaure llega con **cien "indios nobles"** con
+  penachos de plumas, **brazaletes de perlas y orejeras de oro**, rodeando una
+  hamaca "tejida de curiosas labores".
+- **Lo cargan caciques**, no criados: *"en que venía (cargado en hombros de
+  caciques) el Manaure"*. Esto **corrige a [[oliver-1989-cap3]]**, que conjetura
+  que los porteadores serían "possibly as his naborias or personal servants". Si
+  quienes cargan la hamaca son ellos mismos caciques, la jerarquía que el gesto
+  expresa es mucho más fuerte que la de un señor con sirvientes: es un
+  *paramount* sobre otros jefes, exactamente la tesis que el proyecto sostiene.
+- **Regalo y alianza**: oro, martas y alhajas por valor de **once mil pesos**, y
+  de ahí "perpetua alianza", con toda la nación caiquetía prestando vasallaje.
+- **Exención de tributo.** Por su lealtad sostenida —incluso cuando "los
+  desafueros de nuestros soldados" les habrían dado razón para romperla— los
+  caquetíos quedaron **"libres de tributos y demoras"**. Es un dato de estatus
+  colonial que el proyecto no tenía.
+- **Fundación de Santa Ana de Coro** el día de Santa Ana de 1527, "por ser en la
+  provincia de Coriana"; Ampíes lo hace **sin orden ni facultad para ello**.
+- **Coro, descrito**: 10° de latitud norte, temperamento cálido "y en extremo
+  seco", a media legua de la marina, **"su terreno arenoso y falto de aguas, su
+  comarca abundante y regalada"**, con **"abundantes salinas"**. Es, en una
+  frase de 1723, la tesis de **tierra pobre / mar rico** que
+  [[mapa-ecologia]] sostiene hoy con ciencia moderna.
+
+### 2. Sucesión cacical en Coro y Paraguaná — 🔴 no está
+
+**Manaure aparece dos veces en 519 páginas, ambas en este mismo episodio de
+1527.** No hay sucesión, ni herederos, ni Don Martín, ni Don Alexandre, ni las
+probanzas. **Paraguaná** aparece **una vez**, y es un puerto donde desembarca un
+gobernador por vientos contrarios.
+
+> La obra fue señalada por el programa cultural **"por su cobertura de sucesión
+> cacical"**. Medido contra el texto, esa cobertura **no existe**: la sucesión
+> del cacicazgo de Coro está en [[oliver-1989-cap3]] (pp. 255-256, 268), que la
+> saca de probanzas, no de esta crónica. La expectativa era errónea, y conviene
+> que quede escrito para que nadie vuelva a gastar la noche buscándola aquí.
+
+### 3. Todariquiba / San Bartolomé — 🔴 tampoco
+
+- **"Todariquiba": cero apariciones.**
+- **"San Bartolomé": cero.** Las 31 apariciones de "Bartolomé" son todas
+  nombres de españoles (Bartolomé Belzar, Bartolomé García, Bartolomé Suárez…).
+
+La geografía de poblados caquetíos hay que seguir buscándola en
+[[oliver-1989-cap3]] y en Ponce y Vaccari 1977 (que llega vía Oliver).
+
+### 4. Vocabulario indígena — 🟡 lo hay, pero no es caquetío
+
+Los 26 marcadores `"que llaman"` glosan casi siempre **topónimos** y voces
+generales de Venezuela, y de regiones que no son la caquetía: `vera` (madera
+sólida para cimientos), `jobos` (frutilla), `mahagua` (corteza de árbol, sobre
+la que llegaron a escribir una carta), `chagualas` (de oro, en el rescate de
+Cristóbal Guerra frente a las playas de Coriana). Ninguna es atribuible al
+caquetío por esta obra, y **ninguna está hoy en el lexicón** — comprobado.
+
+Los dos hallazgos onomásticos sí valen:
+
+- **`Coriana`** es la forma que Oviedo usa siempre para la provincia, y da la
+  derivación explícita: Coro se llama así **"por ser en la provincia de
+  Coriana"**. El lexicón tiene `curiana` ('territorio de los caquetíos / lugar
+  del cardón'); esta es una variante de fuente primaria para cotejarla.
+- **Un cacique `Chicuramay` y su vasallo `Cuaricurian`**, en el episodio en que
+  Cuaricurian se ofrece a morir en lugar de su cacique, uno de veintitrés
+  condenados. Son dos antropónimos indígenas atestiguados y una escena de
+  lealtad vasallo-cacique con enorme valor narrativo.
+
+Nota de lengua franca, de otro capítulo: Francisco Fajardo, hijo de la cacica
+Doña Isabel, aplaca a un cacique hablándole **"en su lengua arbaca"** (arahuaca)
+— un mestizo usando el arahuaco como lengua de negociación política.
+
+## Qué falta
+
+1. **Cotejar la paginación.** El corpus cita "Oviedo y Baños 1855: 27" vía
+   Zavala; el ejemplar del repo es la edición de **Biblioteca Ayacucho**, donde
+   el pasaje cae en **pp. 26-27**. La coincidencia es buena señal pero no es
+   prueba: no se puede verificar desde aquí la paginación de la edición de 1855.
+   Al citarlo de primera mano, citar **la edición que se tiene**.
+2. **Fusionar al corpus.** Nada de lo de arriba se ha escrito en
+   `3-mundo/corpus/`: son propuestas. Los candidatos más claros son la escena de
+   la hamaca cargada por caciques (que corrige un supuesto de Oliver), la
+   exención de tributos, y la descripción de Coro como tierra seca con salinas.
+3. **`geografia_politica-003` puede subir de calidad de cita** — de "vía Zavala"
+   a fuente directa. Es tarea de F1/F10, no de esta sesión.
+4. El resto del libro (la conquista de Caracas, los Belzares, los Welser) **no
+   toca a los caquetíos** y no hace falta volver a él para este proyecto.
 
 ## Enlaces
 
-[[oviedo-y-valdes-1851]] · [[zavala-reyes-2015]] · [[oliver-1989-cap3]]
+[[oviedo-y-valdes-1851]] · [[zavala-reyes-2015]] · [[oliver-1989-cap3]] · [[antczak-2017-cariban]] · [[mapa-ecologia]] · [[05_geografia_politica_y_sucesion]]

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-04 02:15**.
+<!--GENERADO--> Generado el **2026-08-04 02:20**.
 
 ## ¿Vamos bien?
 
@@ -138,16 +138,16 @@ Las obras que no aparecen tienen **penetración cero** en el lexicón. Entradas 
 
 | `estado_minado` | n |
 |---|---|
-| minado | 16 |
+| minado | 17 |
 | no-disponible | 4 |
 | segunda-mano | 3 |
 | parcial | 2 |
-| sin-minar | 2 |
 | bloqueada | 1 |
+| sin-minar | 1 |
 | descartada | 1 |
 | completo | 1 |
 
-**Prioridad ALTA sin minar (2):** [[oviedo-y-banos]] (`sin-minar`), [[oviedo-y-valdes-1851]] (`no-disponible`).
+**Prioridad ALTA sin minar (1):** [[oviedo-y-valdes-1851]] (`no-disponible`).
 
 <details><summary>Las 30 notas, una por fila</summary>
 
@@ -173,7 +173,7 @@ Las obras que no aparecen tienen **penetración cero** en el lexicón. Entradas 
 | [[adam-1879]] | minado | hecha | si | 0 | 0 | 1 |
 | [[alvarado-1921]] | minado | media | si | 0 | 15 | 1 |
 | [[angleria-1892]] | parcial | media | si | 0 | 0 | 1 |
-| [[oviedo-y-banos]] | sin-minar | alta | si | 0 | 0 | 1 |
+| [[oviedo-y-banos]] | minado | baja | si | 0 | 0 | 1 |
 | [[van-buurt-2014]] | minado | alta | si | 0 | 12 | 1 |
 | [[antczak-2017-cariban]] | minado | media | si | 0 | 0 | 0 |
 | [[fernandes-2020]] | no-disponible | baja | archivo-vacio | 0 | 0 | 0 |
@@ -257,7 +257,7 @@ Argumento y evidencia de cada una: [[DECISIONES_ABIERTAS]]. El **estado** manda 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 778 en 168 notas indexadas | 🟢 0 rotos |
+| Wikilinks | 789 en 168 notas indexadas | 🟢 0 rotos |
 | Tests (`curiana_sim/tests/`) | 91 passed, 0 failed | 🟢 |
 
 Guardianes: `python check_vault_links.py --strict` · `python -m pytest curiana_sim/tests/ -q`

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-04 02:01**.
+<!--GENERADO--> Generado el **2026-08-04 02:15**.
 
 ## ¿Vamos bien?
 
@@ -138,11 +138,11 @@ Las obras que no aparecen tienen **penetración cero** en el lexicón. Entradas 
 
 | `estado_minado` | n |
 |---|---|
-| minado | 14 |
+| minado | 16 |
 | no-disponible | 4 |
-| parcial | 3 |
-| sin-minar | 3 |
 | segunda-mano | 3 |
+| parcial | 2 |
+| sin-minar | 2 |
 | bloqueada | 1 |
 | descartada | 1 |
 | completo | 1 |
@@ -157,7 +157,7 @@ Las obras que no aparecen tienen **penetración cero** en el lexicón. Entradas 
 | [[brinton-1871]] | minado | hecha | si | 84 | 1 | 0 |
 | [[jahn-1927]] | parcial | media | si | 4 | 1 | 16 |
 | [[gatschet-1885]] | minado | alta | si | 4 | 4 | 0 |
-| [[oliver-1989-cap3]] | parcial | media | si | 2 | 5 | 15 |
+| [[oliver-1989-cap3]] | minado | media | si | 2 | 5 | 15 |
 | [[oviedo-y-valdes-1851]] | no-disponible | alta | no | 2 | 2 | 7 |
 | [[oliver-1989-cap2]] | minado | alta | parcial | 2 | 5 | 2 |
 | [[arcaya-1920]] | minado | media | si | 1 | 8 | 13 |
@@ -175,7 +175,7 @@ Las obras que no aparecen tienen **penetración cero** en el lexicón. Entradas 
 | [[angleria-1892]] | parcial | media | si | 0 | 0 | 1 |
 | [[oviedo-y-banos]] | sin-minar | alta | si | 0 | 0 | 1 |
 | [[van-buurt-2014]] | minado | alta | si | 0 | 12 | 1 |
-| [[antczak-2017-cariban]] | sin-minar | media | si | 0 | 0 | 0 |
+| [[antczak-2017-cariban]] | minado | media | si | 0 | 0 | 0 |
 | [[fernandes-2020]] | no-disponible | baja | archivo-vacio | 0 | 0 | 0 |
 | [[gilij-1780-1783]] | bloqueada | baja | no | 0 | 0 | 0 |
 | [[las-casas-1875]] | minado | baja | si | 0 | 0 | 0 |
@@ -257,7 +257,7 @@ Argumento y evidencia de cada una: [[DECISIONES_ABIERTAS]]. El **estado** manda 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 764 en 168 notas indexadas | 🟢 0 rotos |
+| Wikilinks | 778 en 168 notas indexadas | 🟢 0 rotos |
 | Tests (`curiana_sim/tests/`) | 91 passed, 0 failed | 🟢 |
 
 Guardianes: `python check_vault_links.py --strict` · `python -m pytest curiana_sim/tests/ -q`


### PR DESCRIPTION
Cierra #57, #58 y #59. **Apilado sobre #77** — mergear ese primero.

Tres fuentes minadas. Ninguna tocó el corpus: todo va como propuesta en las notas de fuente, en la disciplina de los minadores del lexicón.

## Antczak et al. 2017 (#58)

**No trata de lo que el proyecto creía.** Se le pedía respaldar la expansión caribe a las Antillas Menores en el s. XIV; ahí no hay kalinago, ni Breton, ni doble registro, ni morfología craneofacial. Su escenario es el lago de Valencia y su siglo el IX-X.

Lo que sí trae es media p. 157 sobre la **frontera caquetío-caribe**, que es mejor pregunta: la formación "pre-Caquetío" macro-dabajuroide; la ruta Yaracuy → costa → Aruba, Bonaire y Curazao hacia 900 d.C.; el contacto con el tronco macro-caribe (posibles ancestros jiraharas — respaldo de `jirajaroide-contacto`); y **la disputa arahuaca/caribe por Las Aves y Los Roques entre 1200 d.C. y el Contacto** — el único conflicto caquetío-caribe con objeto y fecha dentro de la ventana de la simulación.

Veredicto sobre las cuatro entradas que el issue mandaba verificar: `-028` y `-029` no los toca, `-033` queda reforzado sin dejar de ser hipótesis, y **`-032` respaldado a medias**. Era la entrada más frágil del corpus (`atestiguado` sobre búsquedas web); ahora la porosidad de fronteras y la crítica al reemplazo poblacional tienen cita revisada por pares, y lo que sigue sin fuente queda dicho en el mismo campo. Bajarle la etiqueta es decisión de Miguel → **D12**.

## Oliver 1989 cap. 3 (#59)

Los cuatro barridos que faltaban: economía, cerámica, guerra y religión.

**Guerra** es el más productivo: doble jefatura de Barquisimeto, aldeas fortificadas de ~4.000, ciclo paz/guerra con motor agrícola, y guerra de captura de esclavos institucionalizada **solo** en el bajo Cojedes.

**Religión** es escasa y casi toda de Barquisimeto (el sacrificio al sol de 1579, el boratio apartado), registrada marcada como colonial y no costera. Cruzada con Manaure sale la estructura que más vale: **la costa fusiona poder secular y sagrado, Barquisimeto los separa, los Llanos no registran el eje sagrado.**

**Cerámica** es una frase que vale por el barrido: el caquetío costero es "precisely congruent" con la sub-tradición Dabajurana — y Antczak cita ese mismo pasaje y lo complica con una comunicación personal del propio Oliver en 2016. Las dos fuentes se cruzan solas.

**`capu`** gana una segunda fuente independiente (documento de 1579, marcándola como caquetía). La cita se queda en la nota porque `lexicon_zavala.py` es generado y la borraría al regenerar — queda dicho como problema de diseño.

**El artefacto de kerning estaba mal atribuido**: medido, `pypdf` parte "Todariquiba" en las 7 apariciones y `pdftotext` la da limpia en las 7.

## Oviedo y Baños (#57) — una respuesta y tres negativas

**1. Manaure y Ampíes** — el pasaje que el corpus citaba de tercera mano está en el original (pp. 26-27) y es más rico. Manaure viene **"cargado en hombros de caciques"**, lo que **corrige a Oliver**, que conjeturaba criados: si quienes cargan la hamaca son caciques, el gesto sostiene la tesis del paramount mucho mejor. Más: once mil pesos en regalos, exención perpetua de tributos, y Coro descrita en 1723 como tierra seca y arenosa con abundantes salinas — la tesis de tierra pobre / mar rico.

**2, 3 y 4 — no están.** Manaure aparece **dos veces en 519 páginas**. "Todariquiba": cero. "San Bartolomé": cero. El vocabulario indígena es general de Venezuela y de otras regiones. La obra fue señalada *por su cobertura de sucesión cacical*; medido contra el texto, **esa cobertura no existe**. Baja de prioridad ALTA a baja.

## La lección de método

Oviedo nunca escribe "caquetío": escribe **"caiquetía"**. Un grep de "caquet" devuelve cero. La misma trampa apareció con Antczak (acentos descompuestos) y con Oliver (`pypdf`). Tres fuentes, tres ceros falsos, una causa: **el cero medía la consulta, no la fuente.** Queda como sección propia en `INDICE_FUENTES.md` con las cuatro reglas que salen de ahí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
