### PR TITLE
FORMAS_SEED sembraba `piache`, que ya salió del habla (#40)

### DIFF
--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_koine.py
@@ -120,7 +120,7 @@ _ASPECTO_SUFIJO = {"completivo": "-ka", "continuativo": "-ni", "prospectivo": "-
 # por muestreo de dominio. Distintas entre agentes → divergencia inicial.
 FORMAS_SEED: dict[str, list[str]] = {
     "Manaure":    ["biro", "barsure", "kali", "kasha", "chiriguare", "maa-ka", "naa-ka"],
-    "Shaboro":    ["urari", "barsure", "piache", "saruro", "kasha", "suna-ni", "naba-ni"],
+    "Shaboro":    ["urari", "barsure", "boratio", "saruro", "kasha", "suna-ni", "naba-ni"],
     "Nubiri-sha": ["ama", "buri", "arua", "biro", "conuco", "paa-da", "raka-da"],
     "Watapana":   ["biro", "maure", "canoa", "habo", "arima", "naa-da", "wana-da"],
     "Dara-ko":    ["kuru", "canoa", "bara", "arima", "cunaro", "bagre", "wana-ni"],
@@ -129,7 +129,7 @@ FORMAS_SEED: dict[str, list[str]] = {
     "Tawaka":     ["chiriguare", "kabo", "arima", "habo", "wana-da", "naa-da"],
     "Saruro-sha": ["maure", "arua", "naure", "kuru", "kono-ni", "chaa-ni"],
     "Chiriguare": ["chiriguare", "sima", "habo", "kabo", "wana-ka", "naa-ka"],
-    "Buio-sha":   ["barsure", "piache", "kasha", "suka", "urari", "naba-ni"],
+    "Buio-sha":   ["barsure", "boratio", "kasha", "suka", "urari", "naba-ni"],
     "Corie-ko":   ["conuco", "buco", "kuru", "dali", "kaya", "kono-ni"],
     "Dare-nu":    ["canoa", "arima", "bara", "kuru", "naa-da", "wana-da"],
     "Kadushi":    ["habo", "canoa", "biro", "kali", "maure", "naa-ni"],
@@ -402,7 +402,7 @@ REFERENTES_NOVEDOSOS: list[dict] = [
     {"id": "cuentas_vidrio", "desc": "unas cuentas brillantes y duras que un mercader trajo de tierras lejanas, nunca vistas aquí"},
     {"id": "cometa",         "desc": "una estrella con cola que cruza el cielo varias noches seguidas"},
     {"id": "eclipse",        "desc": "el sol se oscurece en pleno día y luego vuelve, como si algo lo cubriera"},
-    {"id": "fiebre_manchas", "desc": "una fiebre nueva que llena la piel de manchas, que ningún piache había visto"},
+    {"id": "fiebre_manchas", "desc": "una fiebre nueva que llena la piel de manchas, que ningún boratio había visto"},
     {"id": "metal_amarillo", "desc": "un trozo de metal amarillo y pesado, distinto del oro conocido, llegado por trueque"},
     {"id": "bestia_orilla",  "desc": "un animal enorme nunca visto, varado y muerto en la orilla del golfete"},
     {"id": "marea_roja",     "desc": "el agua del golfete se tiñe de rojo durante días y mata a los peces"},

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_koine.py
@@ -185,3 +185,44 @@ def test_campo_decae_y_descarta():
     campo.decaer()
     assert campo.peso("biro") == 0.5
     assert campo.peso("kali") == 0.0   # 0.04 < umbral 0.05: la forma muere
+
+
+# ── El motor no puede sembrar palabras que ya salieron del habla ──────
+
+def test_formas_seed_solo_usa_palabras_del_lexicon():
+    """`FORMAS_SEED` siembra el idiolecto de cada agente desde el día 1. Si
+    siembra una forma que no está en `VOCABULARIO_BASE`, el motor le está
+    enseñando a los agentes una palabra que el proyecto ya descartó — y
+    `score_linguistico()` ni siquiera se la va a contar.
+
+    Es lo que pasó con `piache`: D10 la sacó del habla por ser voz caribe
+    (Alvarado p.248, corroborado por Jahn 1927 n.28), y `FORMAS_SEED` siguió
+    sembrándosela a Shaboro y Buio-sha. La reemplaza `boratio`, que es la forma
+    caquetía atestiguada del mismo oficio.
+    """
+    import re
+
+    from curiana_koine import FORMAS_SEED
+    from curiana_lexicon import VOCABULARIO_BASE
+
+    huerfanas = {}
+    for agente, formas in FORMAS_SEED.items():
+        for forma in formas:
+            # Las formas con aspecto (`wana-ka`) se validan por su raíz.
+            raiz = re.split(r"-", forma)[0]
+            if forma not in VOCABULARIO_BASE and raiz not in VOCABULARIO_BASE:
+                huerfanas.setdefault(forma, []).append(agente)
+
+    assert not huerfanas, (
+        "FORMAS_SEED siembra formas que no están en VOCABULARIO_BASE: "
+        + "; ".join(f"{f} ({', '.join(a)})" for f, a in sorted(huerfanas.items())))
+
+
+def test_ningun_referente_novedoso_menciona_piache():
+    """Los `desc` de REFERENTES_NOVEDOSOS entran al prompt vía
+    `competencia.activar()`, así que ponen sus palabras delante de los agentes.
+    `piache` salió del habla: tampoco puede colarse por ahí."""
+    from curiana_koine import REFERENTES_NOVEDOSOS
+
+    con_piache = [r["id"] for r in REFERENTES_NOVEDOSOS if "piache" in r["desc"]]
+    assert not con_piache, f"referentes que aún dicen 'piache': {con_piache}"


### PR DESCRIPTION
Cierra #40.

D10 sacó `piache` de `VOCABULARIO_BASE` por ser voz caribe (chaima y tamanaca, Alvarado p.248) y **`FORMAS_SEED` seguía sembrándosela a Shaboro y Buio-sha desde el día 1**. El motor le enseñaba a los agentes una palabra que el proyecto ya había descartado, y que `score_linguistico()` ni siquiera cuenta.

La reemplaza **`boratio`**, la forma caquetía atestiguada del mismo oficio, como proponía el issue.

## Dos hallazgos de la minería del 2026-08-04 la respaldan

- **Jahn 1927 n.28** corrobora de forma independiente que `piache` es voz caribe introducida por los españoles: *"La voz piache, al igual de las voces guaricha y cacique, ha sido introducida en el guajiro y otras lenguas indígenas por los españoles. Piache como equivalencia de curandero es voz chaima y tamanaca"*. La reclasificación de D10 era correcta.
- **Arcaya pp. 97-100** le da al `boratio` el perfil etnográfico más detallado que tiene el proyecto (oráculo, adivinación doméstica, cura paso a paso). No es solo el reemplazo correcto: ahora es la palabra mejor documentada de ese campo semántico.

## Una segunda puerta que el issue no mencionaba

`REFERENTES_NOVEDOSOS` tenía el `desc` de `fiebre_manchas` diciendo *"que ningún **piache** había visto"*. Esos textos entran al prompt vía `competencia.activar()`, o sea ponían la palabra delante de los agentes por otro camino. Corregido también.

## Tests guardián

Dos, y el primero es general en vez de específico: comprueba que **toda** forma de `FORMAS_SEED` esté en `VOCABULARIO_BASE`, validando por la raíz las que llevan aspecto (`wana-ka`). Audité las 60 listas antes de escribirlo — `piache` era la única huérfana, así que el guardián no arrastra deuda existente.

Verificado que **falla si se revierte** el cambio, para que no sea un test que pasa por casualidad.

122 tests, `test_quick.py` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
