### PR TITLE
Análisis de la base, arquitectura, harness y horizonte de contacto

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,17 @@
 {
   "permissions": {
     "allow": [
-      "Bash(npm install:*)"
+      "Bash(npm install:*)",
+      "Bash(xargs git log -1 --format='base: %ci %h')",
+      "Bash(python -c ' *)",
+      "Bash(git add *)",
+      "Bash(git commit -m 'feat\\(simulador\\): fragmentos de la voz de Manaure + loader MDX *)",
+      "Bash(git commit -m 'feat\\(simulador\\): capa editorial multi-run con eventos por epoca *)",
+      "Bash(git commit -m 'feat\\(simulador\\): componente ManaureVoice \\(hero/inline\\) + tokens de eventos *)",
+      "Bash(git commit -m 'feat\\(simulador\\): Timeline \\(cronologia scrollspy\\) + primitivas narrativas *)",
+      "Bash(git rm *)",
+      "Bash(npx tsc *)",
+      "Bash(npx eslint *)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/skills/minar-fuente/SKILL.md
+++ b/.claude/skills/minar-fuente/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: minar-fuente
+description: Minar una fuente documental del proyecto lingüístico caquetío (PDF o texto en fuentes_caquetios/) para una pregunta concreta. Usar cuando se pida minar, leer, barrer o extraer datos de una obra — Oliver, Jahn, Arcaya, Zavala, Oviedo, Alvarado, van Buurt, Gatschet, Antczak — o de una fuente nueva que se incorpore. También al verificar si una fuente sostiene una entrada del corpus o del lexicón.
+---
+
+# Minar una fuente
+
+Protocolo destilado de ocho minerías reales. Cada paso está porque **saltárselo
+costó un error concreto** que aquí se nombra.
+
+## 0. Antes de abrir nada: ¿qué pregunta le haces?
+
+Una minería sin pregunta produce un resumen, y un resumen no sirve para nada.
+La pregunta sale del issue, del corpus o del hueco que se quiere llenar.
+
+Si la pregunta viene de un issue, **léelo entero primero**: suele traer la
+receta técnica y el artefacto conocido.
+
+## 1. Extraer — y desconfiar del extractor
+
+```bash
+pdftotext -enc UTF-8 "fuentes_caquetios/OBRA.pdf" salida.txt
+```
+
+- **`pypdf` y `pdftotext` no producen el mismo texto.** Medido: `pypdf` parte
+  "Todariquiba" en `T odariquiba` en sus 7 apariciones; `pdftotext` la da limpia
+  en las 7. Y al revés, Arcaya devuelve **vacío** con `pypdf` y 467 KB con
+  `pdftotext`.
+- **Las tablas a dos columnas se desalinean** sin `-layout`. Si vas a leer una
+  tabla comparativa, extrae *otra vez* con `-layout` y compara. Así se
+  recuperaron `tapári`/`tarágla` en Jahn pp. 438-439.
+
+## 2. 🔴 Medir la ortografía ANTES de contar
+
+**Este paso existe porque el mismo error apareció tres veces en una noche.**
+
+Un `grep` que devuelve cero **no prueba que la fuente no hable del tema**:
+prueba que tu consulta no encontró nada. Los tres casos reales:
+
+| Fuente | El grep que falló | Por qué | La realidad |
+|---|---|---|---|
+| Antczak 2017 | `Caqueti` → 0 | el PDF descompone acentos: `Caquet´ıo` | 8 menciones |
+| Oviedo y Baños | `caquet` → 0 | escribe **`caiquetía`**, y `Coriana` por Curiana | 7 menciones |
+| Oliver cap. 3 | `Todariquiba` → 0 | `pypdf` lo parte | 7 apariciones |
+
+Antes de concluir nada:
+
+```bash
+# 1. raíz corta y sin acentos, no la palabra entera
+for t in caquet caiquet Coriana Curiana Manaur Paraguan; do
+  printf "%-12s %s\n" "$t" "$(grep -o -i "$t" salida.txt | wc -l)"
+done
+# 2. lee una página al azar y mira cómo escribe ESA obra los nombres
+```
+
+Las crónicas coloniales **no usan la ortografía moderna**. Nunca.
+
+## 3. Leer los pasajes, no los conteos
+
+Los conteos te llevan a la página; el dato está en el texto. Extrae contexto
+generoso (`grep -o ".\{300\}PATRÓN.\{400\}"`) y **lee lo que hay alrededor**.
+
+Localiza la **página impresa**, no la del PDF. Suelen diferir por un desfase
+constante que se calcula una vez (en Antczak: pdf + 130 = impresa).
+
+## 4. Escribir el resultado en la nota de la fuente
+
+**El resultado va en `4-fuentes/<slug>.md`, no en un markdown nuevo.** Es regla
+del proyecto (CLAUDE.md). Actualiza también el frontmatter: `estado_minado`,
+`cobertura`, `sostiene`, `verificado`, `minado`.
+
+Estructura que funciona:
+
+- **Qué es** y **si trata de lo que se creía** — Antczak resultó no tratar de lo
+  que el corpus asumía, y decirlo primero fue lo más útil de esa minería.
+- **Qué ha dado**, con página por hallazgo.
+- **Veredicto por entrada** si el encargo era verificar entradas del corpus.
+- **Qué falta**, incluida la deuda documental nueva que la minería genera.
+
+## 5. Las negativas valen tanto como las positivas
+
+Oviedo y Baños fue señalada *"por su cobertura de sucesión cacical"*. Medido: la
+cobertura **no existe** (Manaure aparece 2 veces en 519 páginas). Escribir eso
+ahorra que alguien vuelva a gastar una noche ahí.
+
+Un hallazgo negativo **bien medido** baja la prioridad de una fuente y eso es
+progreso.
+
+## 6. Propuesta, no fusión
+
+**No toques `curiana_lexicon.py` ni `3-mundo/corpus/*.yaml` en una minería.**
+
+Cada minador emite una *propuesta* (`lexicon_*.py`) o deja los hallazgos en la
+nota. La fusión al corpus es decisión humana. Es lo que ha permitido minar ocho
+fuentes sin romper nada.
+
+⚠️ Excepción con trampa: `lexicon_zavala.py` **sí** lo importa
+`curiana_lexicon`. Regenerarlo cambia `score_linguistico()`.
+
+## 7. Segundas atestaciones y conflictos
+
+Si la fuente confirma algo que ya estaba: eso **sube** una entrada de "una
+fuente" a "dos independientes", que es de lo más valioso que hay.
+
+Pero comprueba que sea **independiente de verdad**. Jahn parecía corroborar la
+filiación caquetía de `datihao` y no: está citando el mismo apéndice de Oviedo
+del que viene la duda. Una corroboración falsa es peor que ninguna.
+
+Si contradice al lexicón, **no reescribas la glosa**: añade la evidencia a
+`notas` y levanta/actualiza el issue. Cambiar una glosa mueve canon.
+
+## 8. Cerrar
+
+```bash
+python curiana_sim/guardianes.py     # los cinco en verde
+python curiana_sim/generar_tablero.py
+```
+
+Y en el commit: qué se preguntó, qué se encontró, **qué NO se encontró**, y qué
+deuda nueva queda. Si la minería tocó un issue, coméntalo ahí con la evidencia
+en vez de dejarlo solo en el markdown.

--- a/proyecto-linguistico-caquetío/1-plan/HARNESS.md
+++ b/proyecto-linguistico-caquetío/1-plan/HARNESS.md
@@ -1,0 +1,143 @@
+---
+tipo: nota
+pregunta: "¿Cómo se trabaja aquí sin que la infra haya que rehacerla luego?"
+medido: 2026-08-06
+---
+
+# El harness — cómo escala este proyecto
+
+> Escrito al salir Opus 5, revisando qué setup de desarrollo merece este
+> proyecto. La pregunta no es *"¿qué herramientas hay?"* sino *"¿qué es lo que
+> se rompe cuando esto crece, y qué lo evita sin rehacer la infra?"*.
+
+## Diagnóstico: no había harness
+
+Medido el 2026-08-06:
+
+| Pieza | Estado |
+|---|---|
+| `.claude/commands/` | 5 comandos, **todos del stack web** (Next.js, TypeScript, UI) — ninguno de este proyecto |
+| `.claude/skills/` | vacío |
+| `.claude/agents/` | vacío |
+| hooks | ninguno |
+| `settings.json` compartido | no existe (solo `settings.local.json`, personal) |
+| CLAUDE.md | 319 líneas, 19 KB, con 25 cifras exactas escritas a mano |
+
+**Todo el rigor del proyecto dependía de que el agente se acordara.** Y se
+acordaba —hay cinco guardianes escritos y buenos— pero acordarse no es un
+método: es suerte con buena racha.
+
+## El principio
+
+> **Lo que no puede fallar, no puede depender de que alguien lo recuerde.**
+
+Este proyecto tiene una virtud rara: sus invariantes son **ejecutables**. "El
+corpus es válido", "el grafo resuelve", "todo rasgo tiene fuente" no son buenas
+intenciones — son cinco scripts que devuelven 0 o 1. Eso es lo que hace que el
+harness sea barato: no hay que inventar la validación, solo cablearla.
+
+## Las cuatro capas, y qué va en cada una
+
+### 1. Guardianes — la verdad ejecutable
+
+```bash
+python curiana_sim/guardianes.py     # los 5, ~9 s
+```
+
+| Guardián | Qué protege |
+|---|---|
+| `pytest tests/` | el motor (125 tests) |
+| `test_quick.py` | el stack arranca sin API keys (8/8) |
+| `check_vault_links.py --strict` | ningún wikilink roto |
+| `compilar_corpus.py --check` | los 161 hechos validan |
+| `curiana_polities.py --check` | ningún rasgo sin fuente |
+
+**Regla**: nada se da por cerrado sin los cinco en verde. Cada uno **tiene que
+haber fallado alguna vez a propósito** para saber que sirve — los cinco lo han
+hecho.
+
+`generar_tablero.py --check` **queda fuera a propósito**: se pone viejo cada vez
+que cambia una cifra medida, que es constantemente. Se regenera, no se vigila.
+
+### 2. Skills — los procedimientos que se repiten
+
+Una skill es un procedimiento que ya se ha hecho varias veces y que **se hacía
+mal la primera vez**. No es documentación: es lo que evita repetir el error.
+
+| Skill | Estado | Por qué |
+|---|---|---|
+| `minar-fuente` | ✅ escrita | 8 minerías con la misma forma; el paso "verifica la ortografía antes de contar" existe porque el mismo error apareció **3 veces en una noche** |
+| `sesion-corpus` | pendiente | las 5 sesiones del programa cultural tienen estructura idéntica (pregunta → ensayo → YAML → hoja de fuentes) |
+| `analizar-run` | pendiente | ahora que `analizar_runs.py` existe, el procedimiento de leerlo es codificable |
+
+### 3. CLAUDE.md — solo lo que cambia el comportamiento
+
+Se cargó en cada sesión, así que su coste es por sesión. La regla que lo bajó de
+19 KB a 7,7 KB sin perder nada:
+
+> **Si el dato se puede consultar, va en un puntero. Si su ausencia causa un
+> error, va en CLAUDE.md.**
+
+Lo que **sí** va: los nueve invariantes, la tabla de trampas medidas (cada fila
+costó un error real), los comandos, y el mapa de dónde está cada cosa.
+
+Lo que **no**: cifras (→ `TABLERO.md`), metodología larga (→ `2-lengua/`),
+historia de las minerías (→ `4-fuentes/`), arquitectura (→ `ARQUITECTURA.md`).
+
+El archivo llegó a decir *"las cifras exactas NO van aquí"* y a continuación
+listar veinticinco. Un documento que se contradice a sí mismo no lo lee nadie.
+
+### 4. Permisos — que el agente no pregunte lo obvio
+
+`settings.local.json` acumulaba entradas efímeras (mensajes de commit concretos
+ya usados) y otras demasiado amplias (`Bash(git rm *)`, `Bash(python -c ' *)`).
+
+Lo que corresponde: un `settings.json` **compartido** con los comandos
+seguros y repetidos de este proyecto —`pytest`, `pdftotext`, `docker exec …
+psql`, los guardianes— y dejar `settings.local.json` para lo personal, además
+de sacarlo del control de versiones.
+
+## Lo que NO hay que montar
+
+Tan importante como lo anterior:
+
+- **Nada de subagentes por ahora.** El trabajo es secuencial y con mucho estado
+  compartido (el lexicón, el corpus, el canon). Un subagente arrancaría en frío
+  y volvería a derivar el contexto que ya está en la sesión.
+- **Nada de CI en la nube todavía.** Los guardianes corren en 9 segundos en
+  local. CI tendría sentido cuando haya más de una persona.
+- **Nada de hooks que bloqueen.** Un hook que impida cerrar cuando un guardián
+  falla suena bien y sería un incordio: hay estados intermedios legítimos
+  (minar una fuente rompe el tablero hasta regenerarlo). Los guardianes se
+  corren; no vigilan.
+
+## Qué escala mal si no se toca
+
+Del análisis de arquitectura, ordenado por cuándo va a doler:
+
+| # | Qué | Cuándo duele |
+|---|---|---|
+| 1 | `curiana_lexicon.py`: 7.554 líneas, **87% dato** | ya duele — cada palabra nueva es un commit al mismo archivo |
+| 2 | Ciclo `lexicon ↔ database` | cuando alguien suba un import al nivel del módulo |
+| 3 | El orquestador importa los 7 módulos del motor | al entrar una segunda polity (D14) |
+| 4 | 1.484 líneas de scripts ya consumidos | cada vez que alguien lee el repo |
+
+**La única que merece llamarse refactor es la 1**, y su solución no es "meterlo
+en la base" —perderías el diff, que es lo que hace creíble al proyecto— sino
+sacar el dato a `lexicon/*.yaml` por capa epistémica, cargado por una función
+que cachee. Se sigue revisando en PR, se sigue diffeando, y `lexicon_zavala`
+deja de ser un caso especial porque *todas* las fuentes serían datos.
+
+## El orden que propongo
+
+1. **Ya hecho**: `guardianes.py`, skill `minar-fuente`, CLAUDE.md reescrito.
+2. **Una tarde**: `settings.json` compartido · mover los 12 scripts a
+   `curiana_sim/historico/` · `normalize_source_language` a `curiana_lexicon`
+   (rompe el ciclo).
+3. **Cuando llegue D14**: extraer del orquestador la construcción del prompt.
+4. **El refactor de verdad**: el lexicón a datos. Cuando estorbe de verdad, no
+   antes.
+
+## Enlaces
+
+[[ARQUITECTURA]] · [[PLAN_MAESTRO]] · [[mapa-motor]] · [[ANALISIS_BASE_2026-08-06]]

--- a/proyecto-linguistico-caquetío/3-mundo/horizonte-de-contacto.md
+++ b/proyecto-linguistico-caquetío/3-mundo/horizonte-de-contacto.md
@@ -1,0 +1,115 @@
+---
+tipo: nota
+pregunta: "¿Hasta dónde llegaba el mundo de un caquetío? ¿Pudo tocar a los mayas?"
+medido: 2026-08-06
+estado: prospección bibliográfica — ninguna fuente nueva en el repo todavía
+---
+
+# El horizonte de contacto — hasta dónde llegaba su mundo
+
+> **Aviso de estado.** Esto es **prospección**, no minería. Ninguna de las obras
+> citadas está en `fuentes_caquetios/` todavía: son el mapa de qué conseguir y
+> por qué. Nada de aquí debe fusionarse al corpus hasta leer el original.
+
+## La respuesta corta a la pregunta maya
+
+**No. Un caquetío no se encontró con un maya — y la pregunta interesante es otra.**
+
+- **Contacto directo caquetío↔maya**: cero evidencia, y sería extraordinaria.
+  Son ~2.500 km, dos esferas de interacción distintas, y ningún cronista,
+  topónimo ni objeto lo sugiere.
+- **Conexión material entre los dos extremos**: **sí, y está demostrada
+  geoquímicamente**. Hay hachas de jadeíta en las Antillas Menores cuyo origen
+  se traza al valle del **Motagua, Guatemala** — la fuente de jade del mundo
+  maya.
+
+La formulación honesta es esa distinción: **una persona no hizo ese viaje; un
+objeto sí, pasando por muchas manos.** Y para la ficción eso es mejor material
+que un encuentro, porque es lo que de verdad pasaba.
+
+⚠️ Y un matiz que lo desinfla en parte: la jadeíta antillana estudiada es de
+época **saladoide (~250-500 d.C.)**, unos mil años **antes** del siglo XIV-XV
+que modela la simulación. Que la red existiera entonces no prueba que siguiera
+funcionando igual después.
+
+## Las tres esferas concéntricas
+
+### 1. Lo caquetío, atestiguado
+
+Lo que ya está minado y en el vault:
+
+| Alcance | Fuente | Etiqueta |
+|---|---|---|
+| Falcón llano, Paraguaná, Golfete | [[jahn-1927]] pp.200-202 (vía Arcaya) | `atestiguado` |
+| → Aruba, Bonaire, Curazao | [[jahn-1927]]; [[antczak-2017-cariban]] p.157 | `atestiguado` |
+| Yaracuy (**Vararida**), Barquisimeto, Llanos hasta Casanare | [[jahn-1927]] | `atestiguado` |
+| Comercio: cuentas de concha, **sal**, azabache; oro de Nirgüa-Buria | [[oliver-1989-cap3]] | `atestiguado` |
+| Disputa con caribes por Las Aves y Los Roques, 1200 d.C.–Contacto | [[antczak-2017-cariban]] p.157 | `atestiguado` |
+| Formas de vasija en Coro derivadas del **Ranchería** (Guajira) | [[oliver-1989-cap3]] | `atestiguado` |
+
+**El caquetío era una sociedad marinera con red propia.** Su horizonte
+documentado va del lago de Maracaibo al Yaracuy, y mar adentro hasta Los Roques.
+
+### 2. El círculo inmediato — lo que hay que minar ahora
+
+La red dabajuroide tenía contactos "directos o indirectos" con **Valencia
+central, la Guajira colombiana, los Andes de Trujillo, y el oriente venezolano**
+([tesis de Dijkhoff sobre Tanki Flip, Aruba](https://dn760004.eu.archive.org/0/items/MANA-DIG-TESIS-DIJKHOFF-1997/Dijkhoff-tesis-Tanki-Flip-1997.pdf)).
+
+Y el dato que ya trajo [[antczak-2017-cariban]]: la **"ruta de la variscita"**
+—cuentas de Los Roques que llegan a las culturas **Nahuange y Tayrona** del
+norte de Colombia (Acevedo et al. 2017)— implica que material del área caribe
+cruzaba dominios arahuacos para llegar a territorio **chibcha**.
+
+> Eso es lo más lejos que el proyecto puede seguir un objeto **con cita propia
+> hoy**: del archipiélago venezolano a la Sierra Nevada de Santa Marta.
+
+### 3. El Caribe entero — dónde está la conexión con Mesoamérica
+
+**La evidencia dura**: artefactos de jadeíta en el Golden Rock (San Eustaquio),
+Elliot's (Antigua), Granada y San Salvador (Bahamas), analizados
+petrográfica y geoquímicamente. En Granada, **dos tercios** de las jadeítas se
+trazan a la fuente guatemalteca y un tercio a fuentes antillanas (Cuba,
+República Dominicana).
+
+**La capacidad náutica maya, documentada**: el 30 de julio de 1502, frente a
+**Guanaja** (islas de la Bahía, Honduras), la expedición de Colón interceptó una
+**canoa comercial maya** de un solo tronco con 25 remeros, que cargaba cerámica,
+textiles de algodón, hachas de piedra amarilla, macanas con filo de pedernal,
+**hachas y cascabeles de cobre** y **cacao**. Es la prueba etnohistórica de que
+existía comercio marítimo maya de largo alcance en el Caribe occidental.
+
+**Lo que falta para unir los dos puntos**: nadie ha documentado la parte del
+medio. Entre el Caribe occidental (maya) y el Caribe suroriental (caquetío) hay
+un vacío que la literatura llena con "redes de interacción marítima" —jade,
+obsidiana, cerámica— sin trazar una ruta concreta.
+
+## Qué conseguir, y en qué orden
+
+| # | Obra | Por qué | Dónde |
+|---|---|---|---|
+| 1 | **Dijkhoff 1997**, *Tanki Flip / Henriquez* (tesis, Aruba) | La red dabajuroide desde el lado insular, que es el lado caquetío | PDF abierto en archive.org (enlace arriba) |
+| 2 | **Antczak & Antczak 2006**, *Los ídolos de las Islas Prometidas* | Ya es fuente de segunda mano del corpus (la disputa por Los Roques). Cerrarlo de primera mano | — |
+| 3 | **Acevedo et al. 2017**, ruta de la variscita | El alcance occidental máximo con cita propia | vía Antczak 2017 |
+| 4 | **Harlow et al.**, jadeítas de Antigua / San Eustaquio | La única conexión material con el mundo maya | [AMNH, PDF abierto](http://research.amnh.org/users/gharlow/AntiguaJade_PP.pdf) |
+| 5 | **Boomert 2000**, *Trinidad, Tobago and the Lower Orinoco* | El eslabón entre el Orinoco y el arco antillano; ya citado por Antczak y ausente del repo | — |
+
+## Cómo usar esto en la simulación, si se usa
+
+Tres cosas que el dato **sí** permite, y una que no:
+
+1. **Sí**: objetos que llegan de más lejos de lo que nadie del poblado ha
+   viajado. Una cuenta, un hacha verde, un cascabel de cobre. Es exactamente el
+   `REFERENTES_NOVEDOSOS` que el motor ya tiene — y ahora con respaldo.
+2. **Sí**: la distinción entre *lo que un caquetío conocía por haber ido*
+   (Aruba, el Yaracuy, Los Roques) y *lo que conocía de oídas* (la Guajira, la
+   Sierra Nevada, "más allá").
+3. **Sí**: Kadushi, el mercader de Aruba, es el personaje que la red histórica
+   justifica. Su rol curado —"portador de lenguas y noticias que amplían el
+   horizonte de su comunidad"— coincide con el dato sin haberlo buscado.
+4. **No**: un maya en escena, ni noticia directa de Yucatán. Sería `hipotetico`
+   en el mejor de los casos, y del tipo que el proyecto no acepta.
+
+## Enlaces
+
+[[polities-caquetias]] · [[antczak-2017-cariban]] · [[jahn-1927]] · [[oliver-1989-cap3]] · [[antczak-2015-las-aves]] · [[mapa-geografia-politica]]

--- a/proyecto-linguistico-caquetío/5-experimento/ARQUITECTURA.md
+++ b/proyecto-linguistico-caquetío/5-experimento/ARQUITECTURA.md
@@ -1,0 +1,160 @@
+---
+tipo: nota
+pregunta: "¿Cómo está construido el motor, y dónde va a doler?"
+medido: 2026-08-06
+modulos: 50
+lineas: 30651
+---
+
+# Arquitectura del motor — medida, no recordada
+
+> Todo lo de aquí sale de leer el AST y el grafo de imports, no de la memoria
+> de nadie. Fecha de medición: 2026-08-06.
+
+## El titular
+
+**30.651 líneas en 50 módulos. El motor de verdad son ~4.300.** El resto es
+dato-como-código (~12.000), minadores (~5.500), scripts de un solo uso ya
+consumidos (~1.500) y herramientas de medición (~2.300).
+
+Eso no es malo en sí — pero conviene saberlo, porque casi todas las decisiones
+de escalado que parecen "refactorizar el motor" son en realidad **decisiones
+sobre dónde vive el dato**.
+
+## Las cinco capas que hay hoy
+
+```
+┌─ MOTOR (~4.300 líneas) ─ lo que corre una simulación
+│   curiana_orchestrator_v2  1043   el bucle; importa a los otros seis
+│   curiana_observer          708   scoring, análisis, perfiles curados
+│   curiana_database          690   Supabase + LangSmith + composición
+│   curiana_agents            578   los 60 personajes (dato, no lógica)
+│   curiana_koine             563   idiolectos, competencia léxica, métricas
+│   curiana_state             404   día, estación, locaciones, eventos
+│   curiana_social            290   contagio léxico, prestigio, dialecto
+│
+├─ DATO-COMO-CÓDIGO (~12.000)
+│   curiana_lexicon          7554   ⚠️ 87% son 11 dicts anotados
+│   lexicon_van_buurt        1587   propuesta de minería
+│   cognados_oliver          1443   propuesta de minería
+│   lexicon_alvarado         1243   propuesta de minería
+│   lexicon_toponimos         739 · lexicon_gatschet 618 · lexicon_candidatos 466
+│   lexicon_zavala            372   ⚠️ el único que el motor IMPORTA
+│
+├─ MINADORES (~5.500)  minar_*.py — uno por fuente, todos con la misma forma
+├─ MEDICIÓN (~2.300)   generar_tablero · compilar_corpus · curiana_polities ·
+│                      analizar_runs · auditar_82 · check_vault_links
+└─ ARQUEOLOGÍA (~1.500) 12 scripts sin importador y sin mención en la doc
+```
+
+## Los cuatro problemas reales
+
+### 1. 🔴 `curiana_lexicon.py` es una base de datos disfrazada de módulo
+
+| | Líneas | % |
+|---|---|---|
+| 11 dicts anotados (`AnnAssign`) | **6.540** | **87%** |
+| 20 funciones | 566 | 7% |
+| 2 clases | 162 | 2% |
+
+**Una línea de lógica por cada once de dato.** Y lo importan **17 módulos**, así
+que cada import parsea 6.540 líneas de literales.
+
+Esto es lo que va a doler al escalar: cada palabra nueva es un commit al mismo
+archivo, los conflictos de merge son inevitables, y no hay forma de consultar el
+lexicón sin cargarlo entero en memoria.
+
+> **El síntoma ya apareció**: `lexicon_zavala.py` es generado, `curiana_lexicon`
+> lo importa, y por eso una segunda atestación de `capu` no tiene dónde vivir
+> (issue abierto). El problema no es ese lema: es que el dato y el código
+> comparten archivo.
+
+### 2. 🟠 Ciclo `curiana_lexicon ↔ curiana_database`
+
+Los dos se importan mutuamente. Funciona **solo** porque los imports son locales
+a la función:
+
+- `curiana_lexicon` pide `normalize_source_language` en 3 sitios
+- `curiana_database` pide `VOCABULARIO_BASE` y `_familia_de_token` en 3 sitios
+
+Es una bomba de relojería: el día que alguien suba uno de esos imports al nivel
+del módulo —lo natural al limpiar— el import revienta en círculo.
+
+**La causa de fondo**: `normalize_source_language()` es lógica de *lengua*, no
+de *base de datos*, y está en el módulo equivocado. Moverla a `curiana_lexicon`
+rompe el ciclo sin tocar nada más.
+
+> Este ciclo ya costó un bug real: `word_source_language()` (en `database`) y
+> `_familia_de_token()` (en `lexicon`) hacían el mismo trabajo con distinto
+> criterio, y **la mitad del corpus se guardó sin lengua** durante 23 runs. Dos
+> caminos para la misma pregunta es exactamente lo que produce un ciclo.
+
+### 3. 🟡 1.484 líneas de arqueología
+
+Doce módulos sin importador y sin mención en la documentación:
+
+`aplicar_reconstruccion` · `copy_local_to_prod` · `export_lexicon_seed` ·
+`export_resumen_seed` · `patch_integrate_comparative` · `patch_lexicon_jirajaroide` ·
+`patch_lexicon_kalinago` · `patch_lexicon_lokono_full` · `patch_lexicon_wayunaiki_full` ·
+`regenerar_quotes_traduccion` · `seed_demo_run` · `wayunaiki_phonology`
+
+Son migraciones que ya corrieron. **No estorban al motor, pero sí a quien lee el
+repo**: cinco `patch_lexicon_*` sugieren que hay cinco formas de parchear el
+lexicón, y no hay ninguna — ya se aplicaron todas.
+
+No hay que borrarlas a ciegas: `wayunaiki_phonology` y
+`patch_integrate_comparative` contienen reglas que quizá sigan valiendo. Pero
+deberían estar en `curiana_sim/historico/` con un README que diga qué se aplicó
+y cuándo.
+
+### 4. 🟡 El orquestador conoce a todo el mundo
+
+`curiana_orchestrator_v2` importa los otros **siete** módulos del motor. Es el
+único punto donde se juntan, y hoy funciona porque el motor es pequeño.
+
+No es un problema todavía. Lo será cuando entre una segunda polity (D14) o un
+segundo tipo de run: ahí el orquestador pasa de "el bucle" a "el sitio donde se
+cablea todo", que es el patrón que obliga a refactorizar.
+
+## Lo que está bien y conviene no tocar
+
+- **La disciplina de minería**: cada `minar_*.py` emite una *propuesta* y no
+  toca el lexicón activo. Es lo que ha permitido minar ocho fuentes sin romper
+  nada, y es replicable tal cual para las fuentes nuevas.
+- **La capa de medición**: `generar_tablero`, `compilar_corpus`,
+  `curiana_polities --canon`, `analizar_runs`, `check_vault_links`. Cinco
+  guardianes que miden contra el dato y no contra la documentación. Es la mejor
+  decisión de arquitectura del proyecto.
+- **Las etiquetas epistémicas** atravesando lexicón y corpus. Es lo que hace que
+  el proyecto sea investigación y no fanfiction.
+- **El motor es pequeño**: 4.300 líneas para una simulación multi-agente con
+  scoring lingüístico, contagio social y métricas de convergencia es poco. La
+  complejidad está donde debe.
+
+## El orden en que yo lo abordaría
+
+| # | Qué | Por qué ahora | Coste |
+|---|---|---|---|
+| 1 | Mover `normalize_source_language` a `curiana_lexicon` | rompe el ciclo, sin cambiar comportamiento | 1 h |
+| 2 | Mover los 12 scripts a `curiana_sim/historico/` con README | el repo deja de mentir sobre qué se puede correr | 1 h |
+| 3 | Sacar `VOCABULARIO_BASE` a datos (YAML/SQLite) con una capa de acceso | **es la decisión de escalado de verdad** — ver abajo | 1-2 días |
+| 4 | Extraer del orquestador la construcción del prompt | lo pide D14 (segunda polity) y el confusor de longitud | 0.5 día |
+
+### Sobre el punto 3, que es el que se pregunta el proyecto
+
+El lexicón como código tiene una virtud real que no hay que perder: **está
+versionado, se revisa en PR y cada cambio tiene su commit y su porqué**. Eso es
+justamente lo que hace creíble al proyecto.
+
+La salida no es "meterlo en la base" —perderías el diff— sino **separar el dato
+del módulo conservando git**: un `lexicon/*.yaml` por capa epistémica, cargado
+por una función que cachee. Se sigue revisando en PR, se sigue diffeando, deja
+de ser un archivo de 7.554 líneas, y `lexicon_zavala` deja de ser un caso
+especial porque *todas* las fuentes serían datos.
+
+Es la única de las cuatro que merece llamarse refactor. Las otras tres son
+higiene y se pueden hacer en una tarde.
+
+## Enlaces
+
+[[mapa-motor]] · [[polities-caquetias]] · [[ANALISIS_BASE_2026-08-06]] · [[PLAN_MAESTRO]]

--- a/proyecto-linguistico-caquetío/5-experimento/analisis/ANALISIS_BASE_2026-08-06.md
+++ b/proyecto-linguistico-caquetío/5-experimento/analisis/ANALISIS_BASE_2026-08-06.md
@@ -1,0 +1,225 @@
+---
+tipo: analisis
+ambito: los 23 runs almacenados en la base local
+herramienta: curiana_sim/analizar_runs.py
+medido: 2026-08-06
+base: supabase local (docker), 54.936 usos de palabra
+---
+
+# Análisis de la base — 2026-08-06
+
+> Todo lo de abajo es **reproducible**: `python curiana_sim/analizar_runs.py --todo`.
+> Si una cifra parece rara, se vuelve a medir en vez de discutirla.
+
+## El inventario
+
+23 runs, del 2026-06-21 al 2026-07-06. Solo cuatro pasan de 30 turnos:
+
+| Run | Turnos | Ablación | Para qué sirve |
+|---|---|---|---|
+| `038d7b9d` | 60 | **no** | brazo normal del experimento de koiné |
+| `bdc54134` | 60 | **sí** | brazo de control |
+| `9bb920eb` | 60 | (pre) | anterior a la ablación |
+| `20091e1f` | 0 turnos / 290 respuestas | (pre) | el run con el bug del exportador (#42) |
+
+1.773 respuestas · 54.936 usos de palabra · 357 neologismos · 405 citas · 82 perfiles.
+
+---
+
+## 1. La koiné: la señal está, la prueba no
+
+Contraste pareado por día entre los dos brazos de 60 turnos.
+
+| Lectura | Normal | Ablación | Δ | p (t pareada) | d de Cohen | Días que gana el normal |
+|---|---|---|---|---|---|---|
+| acumulada | 0.4312 | 0.4527 | +0.0214 | 3.5e-05 | 0.89 | 26/30 |
+| ventana | 0.4500 | 0.4791 | +0.0290 | 3.1e-04 | 0.75 | 22/30 |
+| **emergente** | **0.5819** | **0.6571** | **+0.0752** | **7.7e-11** | **1.81** | **29/30** |
+
+**El brazo normal converge más que la ablación en las tres lecturas**, y la
+diferencia crece justo en la lectura más exigente. No es un empate con medias
+distintas: es sistemático día a día.
+
+### Tres reservas que hay que decir en voz alta
+
+1. **n = 1 run por brazo.** Los 30 días son pseudo-réplicas —comparten agentes,
+   semilla y trayectoria—, así que no son independientes. Los p-valores
+   contestan *"¿difieren estas dos series?"*, no *"¿difieren estas dos
+   condiciones?"*. Para lo segundo hay que repetir el par de runs y tratar el
+   **run** como unidad. Con lo que hay: señal fuerte, no prueba.
+2. **La brecha no crece.** En las tres lecturas la tendencia es plana o
+   levemente decreciente. El mecanismo produce un desplazamiento **inmediato y
+   sostenido**, no un efecto acumulativo. Si la hipótesis era *"la koiné se va
+   formando"*, el dato dice más bien *"el contagio fija una diferencia desde el
+   principio y la mantiene"*. Es un resultado distinto, y más modesto.
+3. **30 días simulados** es una prueba del mecanismo, no del fenómeno histórico.
+
+---
+
+## 2. 🔴 El hallazgo que obliga a releer todo lo demás
+
+**La longitud del `system_prompt` de un agente predice —negativamente— su score
+lingüístico.**
+
+```
+largo del prompt  vs  score:   r = −0.481   p = 0.0046   (n = 33 agentes)
+                               ρ = −0.480   p = 0.0047   (Spearman, robusto)
+```
+
+| Agente | Prompt | Score | | Agente | Prompt | Score |
+|---|---|---|---|---|---|---|
+| Manaure | 834 car. | **6.94** | | Pari-nu | 161 car. | **8.54** |
+| Shaboro | 747 | 7.04 | | Chiri-ko | 155 | 7.48 |
+| Watapana | 700 | 7.07 | | Piri-sha | 150 | 7.60 |
+
+**Cuanto más caracterizado está un personaje, peor habla caquetío.** Manaure, el
+diao, el centro narrativo del proyecto, tiene el prompt más largo y **el peor
+score de todos**.
+
+### Por qué esto es grave
+
+Cualquier lectura del tipo *"el agente X lideró / se resistió a la
+convergencia"* puede ser, en realidad, *"al agente X le escribimos un prompt más
+largo"*. Es un **confusor que atraviesa todo el dataset** y que hasta ahora
+nadie había controlado.
+
+No es una ley sociolingüística descubierta: es una propiedad de cómo está
+escrito el elenco. Pero está ahí, es medible, y **hay que controlarla en
+cualquier análisis por agente que se haga a partir de ahora**.
+
+### El corolario de género, que es el mismo hallazgo con otra cara
+
+El campo `etnia` distingue `caquetío` (23 agentes, todos M) de `caquetía` (15,
+todas F) — no son dos pueblos, es concordancia de género. Y sus métricas
+difieren de verdad:
+
+| | Score | pct_caquetío |
+|---|---|---|
+| Femenino (15 agentes) | 7.530 | 0.9579 |
+| Masculino (17 agentes) | 7.222 | 0.9105 |
+| | MW p=0.010, d=0.75 | MW p=0.041, d=0.65 |
+
+Se mantiene dentro de cada tier, así que no es confusión de tier. **Pero los
+prompts masculinos son más largos** (365 car. de media frente a 289), porque los
+protagonistas son hombres. Lo más probable es que el "efecto de género" **sea el
+efecto de longitud de prompt** visto por otro lado.
+
+> ⚠️ Si alguien reporta *"las mujeres lideraron la koineización"*, estará
+> reportando un artefacto de autoría. Queda escrito aquí para que no pase.
+
+---
+
+## 3. 🔴 La mitad del corpus estaba sin clasificar — corregido
+
+`word_uses.source_language` venía **NULL en 27.641 de 54.936 usos (50,3%)**, y
+el **100%** de esos eran formas morfológicamente complejas:
+
+| Tipo | Usos | Formas |
+|---|---|---|
+| con sufijo de aspecto (`-ka`/`-ni`/`-da`) | 18.752 | 220 |
+| otros compuestos con guion | 5.049 | 641 |
+| con prefijo posesivo (`ta-`/`pi-`/`nü-`) | 3.840 | 155 |
+| **formas simples** | **0** | **0** |
+
+O sea: **justo los usos que prueban que los agentes manejan la morfología** eran
+los que se perdían.
+
+**Causa**: había dos caminos de reconocimiento que no se hablaban.
+`score_linguistico()` usa `_familia_de_token()`, que deshace prefijos y sufijos;
+`word_source_language()` —el que persiste— hacía un lookup pelado contra
+`VOCABULARIO_BASE`. El motor reconocía la palabra para puntuar y la perdía al
+guardarla.
+
+**Arreglado** (`word_source_language` delega en `_familia_de_token`) y los 23
+runs históricos **rellenados** con `backfill_word_uses.py`: 1016 formas
+resueltas, 0 filas sin lengua. Verificado que ninguna de las 1413 entradas del
+lexicón cambia de lengua al pasar por la función nueva.
+
+---
+
+## 4. `pct_caquetio` está saturada — confirmado con dato
+
+Distribución de `pct_caquetio` en los dos runs de 60 turnos:
+
+```
+ 80- 90%     4    0.7%
+ 90-100%    48    8.1%  ████
+100-110%   542   91.2%  █████████████████████████████████████████████
+```
+
+**El 91% de las respuestas está en 1.0.** Desviación típica: 0.0277 (normal) y
+0.0129 (ablación). La métrica **no distingue nada** — es el issue #69, ahora con
+la medición delante.
+
+Consecuencia práctica: el análisis de arriba usa **`score`**, no `pct_caquetio`.
+Se nota en que la correlación con la longitud del prompt es robusta en score
+(Spearman −0.48) y ruido en pct_caquetío (Spearman +0.01): en una variable
+saturada, Pearson lo mueven cuatro outliers.
+
+---
+
+## 5. El léxico que emergió
+
+**Concentración fuerte**: 25 formas concentran el **50%** de los 54.936 usos;
+10 formas, el 26%. Es una distribución muy zipfiana, más de lo que cabría
+esperar con un lexicón de 1413 palabras disponibles.
+
+Las más usadas son el andamiaje gramatical, no el vocabulario cultural: `taya`
+(yo), `wara`, `kashi`, `ta-barsure` (mi alma), `mara`, `naba-ni`, `wana-ka`,
+`nüma` (él/ella). **Los agentes consolidaron una gramática antes que un mundo.**
+
+Reparto por lengua tras el arreglo: el caquetío domina de forma abrumadora, y
+las hermanas vivas quedan en trazas (lokono 1,2%, wayunaiki 1,1%, taíno 0,3%).
+El objetivo del proyecto —que el caquetío domine— **está cumplido con holgura**;
+tanta, que ya no queda margen para medir mejora. Ver §4.
+
+---
+
+## 6. Agentes
+
+- **El tier 2 puntúa más alto que el tier 1** (7.55 vs 7.20) y habla más
+  caquetío (0.974 vs 0.926). La élite habla peor: es el efecto de longitud de
+  prompt otra vez, porque los tier 1 son los más caracterizados.
+- **41 de 60 agentes** llegaron a hablar en algún run. 19 nunca aparecieron.
+- **Corie-ko** es el más activo (132 respuestas) y el más prolífico en
+  neologismos (37).
+- Los perfiles curados sí producen roles ricos y distintos ("Tejedora silenciosa
+  de deudas y favores; verdadera administradora de recursos y árbitro moral del
+  cacicazgo matrilineal").
+
+---
+
+## 7. Narrativa
+
+405 citas curadas, y la curación es **sólida al 98,5%**. Las citas buenas
+exhiben morfología compuesta real:
+
+> «Kali-bana-chaa ta-barsure—masa-bana-sha: masa+-bana+-sha wana-da wara
+> pana-dusha kashi.» — Guaranaro-sha, día 14
+
+Pero hay un sesgo pequeño y detectable: **6 citas degeneradas** (muy cortas o
+sin morfología) puntúan **por encima** de la media (9.07 vs 8.43). El caso
+extremo es la cita de mayor impacto de toda la base:
+
+> **«Ríe.»** — Paugis-sha, día 28 · impacto 9.8
+
+Una acotación escénica en español, puntuada como el momento más impactante del
+corpus. No es sistémico —1,5%—, pero el curador premia lo breve y contundente
+sin comprobar que sea lengua.
+
+---
+
+## Qué hacer con esto
+
+| # | Qué | Dónde |
+|---|---|---|
+| 1 | Controlar la longitud del prompt en todo análisis por agente | este documento §2 |
+| 2 | Rehacer las métricas: `pct_caquetio` saturada | issue #69 |
+| 3 | Repetir el par normal/ablación varias veces para tratar el run como unidad | §1 |
+| 4 | Normalizar el campo `etnia` (género ≠ etnia) | higiene, ya detectado |
+| 5 | Que el curador de citas exija un mínimo de lengua | §7 |
+| 6 | Igualar la longitud de los prompts, o medir controlando por ella | §2 |
+
+## Enlaces
+
+[[mapa-motor]] · [[DISENO_KOINE]] · [[BITACORA_RUNS]] · [[01_que_probaron_los_seis_runs]]

--- a/proyecto-linguistico-caquetío/CLAUDE.md
+++ b/proyecto-linguistico-caquetío/CLAUDE.md
@@ -1,319 +1,167 @@
 # Curiana — Simulador de Emergencia Lingüística Caquetía
 
-Proyecto de investigación + experimento computacional: una simulación multi-agente donde 60 personajes históricos (pueblo Caquetío, Golfete de Coro, Venezuela, siglos XIV-XV) hablan en caquetío-arahuaco reconstruido. Los agentes evolucionan el idioma en tiempo real: inventan palabras, adoptan neologismos de otros, y su "deriva lingüística" queda registrada en Supabase, curada y publicada como sitio estático en Curiana Radio (`/simulador`).
+Investigación + experimento computacional: 60 agentes históricos (pueblo
+Caquetío, Golfete de Coro, s. XIV-XV) hablan en caquetío-arahuaco reconstruido,
+inventan palabras y se contagian entre sí. La deriva se registra en Supabase, se
+cura y se publica en Curiana Radio (`/simulador`).
 
-## Stack
+> **Este archivo dice cómo trabajar aquí, no qué sabemos.** Lo que sabemos está
+> medido en `TABLERO.md` y explicado en el vault. Si buscas una cifra y la
+> encuentras escrita a mano en este archivo, es un bug: repórtalo.
 
-```
-curiana_sim/        → Python 3.11+ (simulación)
-  curiana_lexicon.py      → vocabulario de 1413 palabras (activas; 441 hipotéticas aisladas en lexicon_candidatos.py) + reglas morfológicas + prompts
-                            (muestra_caquetio_dinamica() prioriza caquetío por chunking contextual)
-  curiana_agents.py       → 60 agentes históricos en 3 tiers (caciques, adultos, jóvenes)
-  curiana_orchestrator_v2.py → orquestador principal (Claude Haiku por agente)
-  curiana_observer.py     → análisis lingüístico + scoring 0-10 + detección de neologismos
-                            + curación de perfiles de fin de run (analizar_agente_curado(),
-                            generar_perfiles_curados() → agent_profiles/agent_quotes)
-  curiana_social.py       → contagio léxico entre agentes (DifusionLexica: prestigio +
-                            grafo social + exposición acumulada) + variación dialectal por etnia
-  curiana_polities.py     → las 4 polities caquetías atestiguadas (costera,
-                            barquisimeto, yaracuy, llanos), con fuente por rasgo.
-                            POLITY_SIMULADA="costera" es la que modela el motor;
-                            coherencia_del_canon() cruza curiana_agents.py contra
-                            ella. Ver 3-mundo/polities-caquetias.md
-  curiana_state.py        → estado del mundo (día, estación, eventos, locaciones)
-                            ciclo estacional: DIAS_POR_ESTACION=60, alterna en
-                            avanzar_turno(); aplicar_efecto() mueve los niveles
-  curiana_database.py     → Supabase client + LangSmith wrapper + language_composition()
-                            + normalize_source_language() (8 categorías activas, ver abajo)
-  arahuaco_comparative.py → método comparativo (transducir, COGNADOS, reconstruir_caquetio)
-  supabase/migrations/    → schema versionado (init + fixes; supabase_schema.sql es referencia)
-```
+---
 
-> ⚠️ **Queries a la tabla `lexicon`:** PostgREST limita cada respuesta a
-> `max_rows` (1000, ver `supabase/config.toml`). Con ~1400 palabras, cualquier
-> query nueva sobre `lexicon` sin `.range()` se trunca silenciosamente.
-> Pagina con `.range(desde, desde+999)` hasta que la página devuelta tenga
-> menos de 1000 filas (ver `loadLexicon()` en `app/page.tsx` o `app/lexicon/page.tsx`).
+## Las reglas que no se rompen
 
-## Modelo LLM
+1. **Ninguna cifra a mano.** Se mide (`generar_tablero.py`) o no se dice. Han
+   circulado tres tamaños distintos del lexicón a la vez; el corpus tenía dos
+   censos (152 y 161) que no coincidían.
+2. **Etiqueta epistémica en todo.** Lexicón y corpus distinguen atestiguado /
+   reconstruido / hipotético. Una sola por entrada; **en duda, degradar**. Es lo
+   que hace que esto sea investigación y no fanfiction.
+3. **Precontacto ≠ colonial.** Casi todo el dato es de crónica del s. XVI. La
+   simulación es del XIV-XV. No se proyecta sin decidirlo explícitamente.
+4. **Los caquetíos no eran una sola sociedad.** Modelamos la polity **costera**
+   (`curiana_polities.py`). Importar un rasgo de Barquisimeto o los Llanos sin
+   marcarlo es el error que Oliver denuncia.
+5. **Minar propone, el humano fusiona.** Un minador **nunca** toca
+   `curiana_lexicon.py` ni `3-mundo/corpus/`. Emite `lexicon_*.py` o escribe en
+   la nota de la fuente.
+6. **Un cero hay que verificarlo.** Un `grep` sin resultados mide tu consulta,
+   no la fuente. Ver la skill `minar-fuente` §2 — pasó tres veces en una noche.
+7. **El resultado de minar va en `4-fuentes/<obra>.md`**, no en un markdown
+   nuevo.
+8. **Nunca secretos en archivos del proyecto** — ni gitignored: el repo
+   sincroniza a OneDrive.
+9. **Las decisiones viven en el tablero de GitHub** (label `decision`), no en
+   markdown. `DECISIONES_ABIERTAS.md` se retiró el 2026-08-06.
 
-`claude-haiku-4-5-20251001` para todos los agentes (costo-efectivo). El cliente se crea en `curiana_database.py::get_anthropic_client()`. Si `LANGSMITH_API_KEY` está en el entorno, wrappea automáticamente con `wrap_anthropic()`.
+---
 
-## Variables de entorno
+## Trampas medidas (cada una costó un error real)
 
-> ⚠️ **Supabase: correr en LOCAL por defecto (Docker), no en cloud.** El
-> proyecto cloud llegó a 8.17 GB de egress (límite del plan Free: 5 GB) por
-> el dashboard público con `realtime` + el patrón de tráfico típico de
-> `*.vercel.app` (escaneo automático). El proyecto Vercel se borró por esa
-> razón. Hasta decidir un reemplazo (Vercel con Deployment Protection, VPS
-> propio, etc.), todo el trabajo de desarrollo/simulación corre contra
-> Supabase local:
-> ```bash
-> cd curiana_sim && supabase start   # levanta Docker; ver supabase/config.toml
->                                     # (puertos 64321-64329, NO los default
->                                     #  54321-54329: esos los usan otros
->                                     #  proyectos supabase locales como
->                                     #  fintech.benditaia.cl. API=64321 DB=64322)
-> ```
-> `curiana_sim/.env` ya tiene ambos bloques (local activo, cloud comentado)
-> — para volver a cloud, intercambiar qué bloque está comentado.
+| Trampa | Qué pasa |
+|---|---|
+| **Supabase local, no cloud** | El cloud llegó a 8.17 GB de egress. Puertos **64321/64322**, no los 54321 por defecto (esos son de otro proyecto, fintech). Para consultar: `docker exec supabase_db_curiana_sim psql -U postgres -d postgres` |
+| **Cada entrypoint carga su `.env`** | Leer `os.environ` no basta: `load_dotenv(...)` al inicio del módulo o falla por credenciales |
+| **`pypdf` ≠ `pdftotext`** | Producen texto distinto del mismo PDF. Arcaya sale **vacío** con pypdf; `pdftotext` da 467 KB. Y pypdf parte `Todariquiba` en `T odariquiba` |
+| **Tablas a dos columnas** | Se desalinean sin `-layout`. Extraer las dos veces y comparar |
+| **`lexicon` en PostgREST** | `max_rows`=1000 y hay ~1400 palabras: toda query sin `.range()` se trunca **en silencio**. Ver `loadLexicon()` |
+| **`lexicon_zavala.py` es generado Y se importa** | Regenerarlo **cambia `score_linguistico()`**. Los otros `lexicon_*.py` no se importan |
+| **La consola de Windows es cp1252** | Todo script que imprima `─`, `✓` o acentos necesita `_forzar_utf8()` bajo `__main__` |
+| **`pct_caquetio` está saturada** | 91% de las respuestas en 1.0. **No la uses para comparar agentes** — usa `score`. Issue #69 |
+| **La longitud del prompt predice el score** | r = −0.48. Cualquier análisis por agente tiene que controlarla, o estarás midiendo cuánto escribiste tú. Ver `ANALISIS_BASE_2026-08-06.md` |
+
+---
+
+## Comandos
 
 ```bash
-# curiana_sim/.env  (ver .env.example)
-ANTHROPIC_API_KEY=sk-ant-...       # obligatorio
-SUPABASE_URL=http://127.0.0.1:64321   # local (supabase start). Sin esto, modo JSON local.
-SUPABASE_SERVICE_KEY=eyJ...           # service_role key local (ver `supabase status`)
-LANGSMITH_API_KEY=ls__...             # opcional
-LANGSMITH_PROJECT=curiana             # opcional
-```
-
-> ⚠️ **Carga de `.env` en scripts Python:** cada entrypoint que se corra
-> directo (`python curiana_xxx.py ...`) debe cargar `curiana_sim/.env` por sí
-> mismo — leer `os.environ` no basta. `curiana_orchestrator_v2.py` y
-> `curiana_database.py` ya lo hacen con `load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))`
-> al inicio del módulo. Si agregas un nuevo `__main__` (p.ej. en
-> `curiana_observer.py`), copia ese mismo bloque o fallará con
-> "Faltan SUPABASE_URL o SUPABASE_SERVICE_KEY".
-
-## Comandos clave
-
-```bash
-# Setup Python
 cd curiana_sim
 pip install -r requirements.txt
-python test_quick.py          # verifica el stack sin API keys (debe dar 8/8 OK)
 
-# Estado del proyecto, medido (NO copiar cifras de la doc: se desactualizan)
-python curiana_sim/generar_tablero.py           # reescribe TABLERO.md en la raíz
-python curiana_sim/generar_tablero.py --stdout  # lo imprime sin escribir
-python curiana_sim/generar_tablero.py --check   # exit 1 si TABLERO.md está viejo
-  # Mide lexicón, censo de citas (importa auditar_82.py), frontmatter de
-  # 4-fuentes/, corpus de 3-mundo/corpus/, el gate y las decisiones abiertas.
-  # Sin red por defecto (--gh cruza los issues reales). TABLERO.md es generado:
-  # no se edita a mano.
+python guardianes.py              # los 5 en verde antes de cerrar nada
+python guardianes.py --rapido     # sin los tests (más rápido)
 
-python -m pytest tests/ -q    # suite unitaria (koiné, léxico, observer, social,
-                              # corpus; sin API keys)
+python generar_tablero.py         # reescribe TABLERO.md (medido)
+python generar_tablero.py --gh    # + decisiones del tablero (usa red)
 
-# Validar el corpus cultural de 3-mundo/corpus/ (condición 4 del gate)
-python curiana_sim/compilar_corpus.py            # informe
-python curiana_sim/compilar_corpus.py --check    # exit 1 si hay errores
-python curiana_sim/compilar_corpus.py --fusionar corpus.yaml
-  # Valida etiquetas epistémicas, ids, referencias cruzadas entre hechos,
-  # que los `agentes_relacionados` existan en curiana_agents.py, y que
-  # `locacion`/`palabra_lexicon` enganchen con curiana_state/curiana_lexicon.
-  # No modifica los YAML: valida y emite.
-supabase start                 # levanta Supabase local (ver nota de egress arriba)
-python curiana_database.py seed  # siembra las palabras activas en Supabase
+python analizar_runs.py --todo    # análisis de los runs en la base
+python compilar_corpus.py --check # valida 3-mundo/corpus/
+python curiana_polities.py --canon
 
-# Correr simulación
-python curiana_orchestrator_v2.py                    # modo interactivo
-python curiana_orchestrator_v2.py --auto 10          # 10 turnos automáticos
-python curiana_orchestrator_v2.py --auto 240 --anio  # 1 año simulado
-python curiana_orchestrator_v2.py --auto 30 --perfiles --reporte
-  # --perfiles: genera perfiles curados por agente al cerrar el run
-  #             (rol, arco narrativo, frases célebres → agent_profiles/agent_quotes)
-  # --reporte:  reporte anual LLM al completar cada año simulado (días 121,
-  #             241, 361…). Estuvo inerte hasta el 2026-07-20: colgaba de un
-  #             cambio de estación que nunca ocurría, y además exigía
-  #             dia%120==0, que no coincide con ningún cambio de estación.
-  # --ablacion: run de CONTROL — apaga las inyecciones de prompt que empujan la
-  #             convergencia (contagio, competencias abiertas, muestreo ponderado).
-  #             La evidencia de koineización es la DIFERENCIA normal vs. ablación.
-  #             La convergencia se mide en 3 lecturas/día (acumulada/ventana/emergente,
-  #             ver 5-experimento/DISENO_KOINE.md §7); el veredicto usa la más exigente con datos.
+supabase start                    # Docker local (ver puertos arriba)
+python curiana_database.py seed   # siembra el lexicón activo
 ```
 
-## Metodología del lexicón y validación
+### Correr simulación
 
-> 📊 **Las cifras exactas NO van aquí: van en `TABLERO.md`**, que las mide
-> contra el dato en cada corrida (`python curiana_sim/generar_tablero.py`).
-> Este archivo da los números en orden de magnitud a propósito — una cifra
-> exacta escrita a mano envejece mal, y ya pasó tres veces.
->
-> 📖 **El estado medido y en prosa está en `2-lengua/lexicon.md`,
-> `2-lengua/morfologia.md`, `2-lengua/toponimia.md` y
-> `2-lengua/metodo-comparativo.md`.** Esta sección es el resumen operativo;
-> aquellas notas llevan las cifras con su fecha de medición.
+```bash
+python curiana_orchestrator_v2.py --auto 30 --perfiles --reporte
+#   --perfiles  perfiles curados por agente al cerrar (agent_profiles/quotes)
+#   --reporte   reporte anual LLM al completar cada año simulado
+#   --ablacion  run de CONTROL: apaga las inyecciones que empujan convergencia.
+#               La evidencia de koineización es la DIFERENCIA normal vs. ablación
+```
 
-El lexicón activo distingue 8 categorías de `fuente` (ver `normalize_source_language()`
-en `curiana_database.py`), porque "caquetío" mezclaba históricamente dato real
-con especulación sin marcar:
+---
 
-- **`caquetío-atestiguado`** — dato histórico real, citable a fuente
-  concreta. ⚠️ **Medido el 2026-08-03: en el dato es Zavala y casi nadie más** —
-  164 entradas lo citan; Oliver 2, Oviedo (vía terceros) 2, Galeotto Cey 2,
-  Arcaya 1, Jahn 1; Alvarado, Van Buurt y Gatschet, **cero**. Ver
-  `4-fuentes/INDICE_FUENTES.md`.
-  **Zavala cerrado al 100% (F7, 2026-08-03)**: `minar_zavala_glosario.py`
-  parsea las **288** entradas del glosario y genera `lexicon_zavala.py` —
-  225 (78%) van al habla activa, 63 (22%) quedan **fuera por diseño** (45
-  topónimos + 14 antropónimos + 4 descartes). No es deuda: es curación.
-  De los 28 homógrafos con español, tras revisión quedan **14** marcados;
-  11 perdieron la marca (no eran palabras del español, y marcarlas hacía que
-  `score_linguistico()` **sub-contara** caquetío legítimo) y 3 salieron del
-  habla (`hay`, `enea`, `guata`).
-- **`caquetío-reconstruido`** (82: 12 base + 2 topónimo + 68 núcleo
-  fundacional) — vocabulario de trabajo del proyecto: pronombres, numerales,
-  verbos básicos que `prompt_reglas_completo()`/`breve()` presentan a los
-  agentes desde el día 1. No siempre atestiguado, pero es la lengua de la
-  simulación, no un préstamo.
-- **`hipotético-no-verificado`** (441) — **AISLADAS del léxico activo**
-  (2026-06-28) a `curiana_sim/lexicon_candidatos.py` (`CANDIDATOS_NO_VERIFICADOS`).
-  Palabras generadas por `reconstruir_caquetio_gaps.py` transduciendo
-  fonológicamente CUALQUIER palabra wayunaiki/lokono/taíno con la misma glosa,
-  **sin verificar cognación real** contra `COGNADOS` (el único set curado, 37
-  entradas). La minería de pares objetivos (`minar_pares_validacion.py`) mostró
-  ~80% de fallos contra datos reales. Estando en `VOCABULARIO_BASE` producían
-  falsos positivos en `score_linguistico` (el "la"/"para" español matcheaba
-  contra entradas hipotéticas), así que se sacaron del léxico y de Supabase. No
-  se importan ni se siembran; quedan como material para una futura validación
-  sistemática.
-- **wayunaiki (781), lokono (228), taíno (57), proto-arahuaco (9), kalinago
-  (19), kalinago-caribe-overlay (4), jirajaroide-contacto (7)** — lenguas
-  hermanas/de contacto, tratadas como tan ajenas como el español para
-  scoring (ver siguiente sección).
+## Dónde está cada cosa
 
-**Para fortalecer la Capa 2 (reconstrucción con base real):** minar más
-fuentes publicadas con `fuentes_caquetios/*.pdf` (ya minado: Brinton 1871,
-que dio 4 pares LK-TN reales y corrigió un bug en `REGLAS_LK_TN`; *no* dio
-resultado: Perea Alonso 1942, que es gramática Lokono pura, no comparativa
-entre lenguas arahuacas). `arahuaco_comparative.py::validar()` corre la
-suite de validación (18 pares al momento de escribir esto).
+```
+INDICE.md          la puerta del vault
+TABLERO.md         el estado medido (generado — no se edita a mano)
+1-plan/            ¿qué hacemos y qué falta?
+2-lengua/          ¿cómo es el caquetío?  lexicon · morfologia · toponimia · metodo-comparativo
+3-mundo/           ¿cómo era ese pueblo?  5 mapas · polities-caquetias · corpus/ · ensayos/
+4-fuentes/         ¿de dónde lo sabemos?  una nota por obra + INDICE_FUENTES
+5-experimento/     ¿qué probamos?  mapa-motor · ARQUITECTURA · DISENO_KOINE · analisis/
+curiana_sim/       el motor + tests/
+fuentes_caquetios/ los PDF (se citan, no se editan)
+```
 
-### Minerías de 2026-08-03 (F3, F4, F6, F7) — propuestas, no fusiones
+**El motor** (`5-experimento/ARQUITECTURA.md` lo mide entero):
 
-Cuatro fuentes se minaron en paralelo. **Ninguna modificó `curiana_lexicon.py`**:
-cada una emite un módulo de propuesta para revisión humana, con la misma
-disciplina de `minar_zavala_glosario.py`.
+| Módulo | Qué hace |
+|---|---|
+| `curiana_orchestrator_v2` | el bucle; importa a los otros seis |
+| `curiana_lexicon` | vocabulario + reglas + prompts + `score_linguistico()` |
+| `curiana_agents` | los 60 personajes |
+| `curiana_koine` | idiolectos, competencia léxica, métricas de convergencia |
+| `curiana_social` | contagio léxico, prestigio, variación dialectal |
+| `curiana_state` | día, estación, locaciones, eventos |
+| `curiana_observer` | scoring, análisis, perfiles curados |
+| `curiana_database` | Supabase + LangSmith |
+| `curiana_polities` | las 4 polities atestiguadas; cuál simulamos |
 
-| Minador | Propuesta | Nota de fuente |
-|---|---|---|
-| `minar_alvarado_glosario.py` | `lexicon_alvarado.py` | 1551 lemas, 109 evaluados; A=3 B=36 C=13 **D=57** |
-| `minar_gatschet.py` | `lexicon_gatschet.py` | 48 léxicas + 31 topónimos + 6 fórmulas rituales |
-| `minar_van_buurt.py` | `lexicon_van_buurt.py` | §6 (88) y §11 (29) **en diccionarios separados** |
-| `minar_zavala_glosario.py` | `lexicon_zavala.py` | 288/288, el parseo cierra |
+**Los wikilinks resuelven por basename**, así que mover una nota no rompe
+enlaces; lo que se rompe son los enlaces markdown relativos.
 
-**`auditar_82.py` cruza las cuatro** y emite el veredicto por palabra para el
-censo de citas (F1). Estado al 2026-08-03: de 82 entradas sin cita, **61
-confirman · 13 reclasifican · 3 conflicto de glosa · 5 sin rastro** — 77 de 82
-(94%) adjudicables con evidencia. La lista se recalcula del lexicón en cada
-corrida, así que se encoge sola a medida que F1 aplica citas.
+---
 
-> ⚠️ **`lexicon_zavala.py` no es solo propuesta**: `curiana_lexicon.py` lo
-> importa (`GLOSARIO_ZAVALA`, `HOMOGRAFOS_ZAVALA`). Regenerarlo **cambia el
-> comportamiento de `score_linguistico()`**. Los otros tres módulos de propuesta
-> no se importan en ninguna parte.
-
-## Scoring lingüístico (`score_linguistico()` en `curiana_lexicon.py`)
-
-El objetivo del proyecto es que el caquetío **domine**, no solo que se evite
-el español. `score_linguistico()` penaliza dos fugas distintas:
-1. Español funcional (`el/la/de/que/...`) — penalización fuerte (hasta −3).
-2. Otra lengua arahuaca viva (wayunaiki/lokono/taíno) en vez de su forma
-   caquetía — penalización moderada (hasta −2.5), vía `_familia_de_token()`.
-
-El rescate intra-turno (`curiana_orchestrator_v2.py::call_agent()`) dispara
-reintento tanto por score bajo como por fuga a otra lengua arahuaca
-(`otro_arahuaco >= 3` y `pct_caquetio_especifico < 0.3`).
-
-Verificado en runs reales contra Supabase local: caquetío pasó de ~27% a
-~91-93% del output tras estos cambios + retaguear el núcleo fundacional.
-
-## Morfología caquetío-arahuaca
-
-Además de las reglas de trabajo del proyecto, `REGLAS_ZAVALA` incorpora seis
-afijos **atestiguados** en el glosario de Zavala Reyes 2015 y que faltaban:
-`-iro` (diminutivo — la única marca de diminutivo documentada), `-aima`
-(abundancia), `-ima` (humedad/quebrada), `-uco` (cauce), `-ubana` y `-uru`
-(desinencias de valor no precisado por la fuente). Amplían lo que los agentes
-pueden *construir*, no solo nombrar.
+## Morfología (lo mínimo para leer el output)
 
 ```
 Orden: pronombre + verbo-aspecto + complemento
 Pronombres: taya (yo), pia (tú), nüma (él/ella), tayamaa (nosotros)
-Aspectos: -ka (completivo), -ni (continuativo), -da (prospectivo)
-Prefijos posesivos: ta- (mi), pi- (tu), nü- (su)
-Locativos: -bana (orilla/borde), -ana (lugar de), -ko (interior de)
-Neologismos: agentes proponen [forma: componentes = significado]
+Aspectos:   -ka (completivo), -ni (continuativo), -da (prospectivo)
+Posesivos:  ta- (mi), pi- (tu), nü- (su)
+Locativos:  -bana (orilla/borde), -ana (lugar de), -ko (interior de)
+Neologismos: [forma: componentes = significado]
 ```
 
-## Arquitectura de datos
+`REGLAS_ZAVALA` añade seis afijos atestiguados: `-iro` (diminutivo), `-aima`,
+`-ima`, `-uco`, `-ubana`, `-uru`. El detalle y su evidencia, en
+`2-lengua/morfologia.md`.
+
+---
+
+## Modelo y entorno
+
+`claude-haiku-4-5-20251001` para todos los agentes. El cliente se crea en
+`curiana_database.py::get_anthropic_client()`; si `LANGSMITH_API_KEY` está en el
+entorno, se wrappea solo.
+
+```bash
+# curiana_sim/.env  (ver .env.example)
+ANTHROPIC_API_KEY=sk-ant-...          # obligatorio
+SUPABASE_URL=http://127.0.0.1:64321   # local. Sin esto, modo JSON
+SUPABASE_SERVICE_KEY=eyJ...           # service_role local (`supabase status`)
+LANGSMITH_API_KEY=...                 # opcional
+```
+
+---
+
+## Esquema de datos
 
 ```
 simulation_runs → turns → agent_responses → word_uses
                                           → neologisms
-                       → phrase_etymologies
-                       → agent_profiles → agent_quotes   (perfiles curados, --perfiles)
-lexicon  (seed desde VOCABULARIO_BASE)
+                       → agent_profiles → agent_quotes
+                       → koine_metrics · koine_lexicon
+lexicon
 ```
 
-Real-time en Supabase: `agent_responses`, `turns`, `neologisms`, `agent_profiles`,
-`agent_quotes` publicados en `supabase_realtime`.
-
-## Próximos pasos del proyecto
-
-1. Analizar los datos de la simulación larga ya corrida (ver
-   `agent_profiles`/`agent_quotes` y `language_drift_by_turn` en Supabase
-   local) — este era el objetivo original: simular, documentar, analizar.
-2. Decidir qué mostrar públicamente (la página debe mostrar el proyecto en
-   sí, curado — no necesariamente todos los datos crudos).
-3. Decidir el reemplazo del proyecto Supabase cloud borrado (ver nota de
-   egress arriba) antes de cualquier deploy público del dashboard.
-4. Seguir fortaleciendo la Capa 2 minando más fuentes publicadas (ver
-   sección de metodología arriba) si se quiere reconstruir más caquetío
-   con base real, validando las 441 `hipotético-no-verificado` ya aisladas en
-   `lexicon_candidatos.py` (minar fuentes y conservar solo las que pasen).
-
-## Estructura del vault (refactor 2026-08-04)
-
-El repo ES el vault, y está ordenado **por la pregunta que responde cada
-carpeta**, no por tipo de archivo. Si no sabes dónde va un archivo nuevo,
-pregúntate qué pregunta contesta.
-
-```
-INDICE.md · CLAUDE.md · check_vault_links.py   ← puerta, config y guardián
-1-plan/        ¿qué hacemos y qué falta?      PLAN_MAESTRO · LINEA_DE_TIEMPO · SIGUIENTE_TANDA
-2-lengua/      ¿cómo es el caquetío?          mapa-lengua · lexicon · morfologia · toponimia · metodo-comparativo
-3-mundo/       ¿cómo era ese pueblo?          5 mapas + polities-caquetias + ensayos/ + corpus/
-4-fuentes/     ¿de dónde lo sabemos?          INDICE_FUENTES + 30 notas de obra + sesiones/
-5-experimento/ ¿qué probamos con el simulador? mapa-motor · DISENO_KOINE · CANON_TIERRA · BITACORA_RUNS
-                                              · IDEA_PERFILES_AGENTES · MIGRACION_RUNS_EVOLUCION
-                                              · analisis/ · disenos/
-fuentes_caquetios/   los PDF (se citan, no se editan)
-curiana_sim/         el motor + tests/
-supabase/            el esquema versionado
-```
-
-Los **wikilinks resuelven por basename**, así que mover una nota no rompe
-enlaces; lo que se rompe son los enlaces markdown relativos.
-
-## Archivos de referencia
-
-- **`INDICE.md`** — nota raíz del vault (el repo ES el vault, ver
-  `1-plan/PLAN_MAESTRO.md` §2). Punto de entrada: enlaza los mapas,
-  [el tablero de decisiones](https://github.com/miguelgilurbina/curiana-radio/issues?q=is%3Aissue+label%3Adecision) y `4-fuentes/INDICE_FUENTES.md`.
-- **`2-lengua/`** — la lengua misma, en prosa: `lexicon.md` (qué palabras hay y
-  quién las sostiene), `morfologia.md` (afijos con su evidencia y su estado,
-  incluida la disputa `-bana`/`-ana`), `toponimia.md` (los topónimos como
-  ecuaciones bilingües) y `metodo-comparativo.md` (cómo se reconstruye, y el
-  desbalance wayunaiki/lokono). **Describen el código, no lo sustituyen**: la
-  fuente de verdad sigue siendo `curiana_sim/*.py`.
-- **`4-fuentes/`** — una nota por obra: estado técnico medido
-  (capa de texto, páginas), estado de minado, qué sostiene y qué falta.
-  **Cuando se mine una fuente, el resultado se escribe en su nota**, no en un
-  markdown nuevo. Verificar el grafo con
-  `python check_vault_links.py --strict` (desde la raíz del proyecto).
-- **[Decisiones abiertas](https://github.com/miguelgilurbina/curiana-radio/issues?q=is%3Aissue+label%3Adecision)** — lo que solo Miguel puede decidir. Viven en
-  el tablero de GitHub, con su argumento dentro; `1-plan/DECISIONES_ABIERTAS.md`
-  se retiró del repo el 2026-08-06 para no mantener dos copias.
-- `5-experimento/IDEA_PERFILES_AGENTES.md` — diseño de la sección de perfiles de
-  agentes (rol, arco narrativo, frases célebres) y su implementación.
-- `test_quick.py` — test suite sin API keys (debe dar 8/8 OK).
-- `requirements.txt` — dependencias pinneadas.
-- `.env.example` / `.env.local.example` — templates de variables de entorno.
-- `curiana_sim/minar_pares_validacion.py` — mina el propio corpus para
-  pares de validación objetivos (caquetío atestiguado + cognado hermano).
-- `curiana_sim/retag_nucleo_fundacional.py` /
-  `retag_reconstruccion_no_verificada.py` — scripts de corrección de
-  etiquetado del lexicón (documentan por qué quedó como quedó).
+⚠️ `word_uses.source_language` se resuelve con `_familia_de_token()`, que
+deshace prefijos y sufijos. Si vuelve a hacerse con un lookup pelado, **la mitad
+del corpus se guarda sin lengua** (pasó: 27.641 de 54.936 usos).

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -2,7 +2,7 @@
 tipo: indice-raiz
 proyecto: Curiana — proyecto lingüístico caquetío
 vault: este mismo repositorio
-actualizado: 2026-08-04
+actualizado: 2026-08-06
 ---
 
 # Curiana — índice del vault
@@ -59,6 +59,8 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 - ⚖️ [Decisiones abiertas](https://github.com/miguelgilurbina/curiana-radio/issues?q=is%3Aissue+label%3Adecision) — lo que solo Miguel puede decidir, en el
   tablero de GitHub. Cada una lleva su argumento y su evidencia dentro; ya no
   hay nota en el repo que las duplique.
+- 🔧 [[HARNESS]] — cómo se trabaja aquí y por qué; los guardianes.
+- 🏗️ [[ARQUITECTURA]] — el motor medido: 50 módulos, dónde va a doler.
 - 📚 [[INDICE_FUENTES]] — estado **medido** de las obras: qué se puede leer, qué
   está minado, qué sostiene cada una.
 - 🕰️ [[LINEA_DE_TIEMPO]] — las cuatro eras del proyecto y sobre qué base corrió
@@ -76,14 +78,14 @@ proyecto-linguistico-caquetío/          ← raíz del vault
 ├── CLAUDE.md · check_vault_links.py     ← config y guardián del grafo
 │
 ├── 1-plan/          ¿qué hacemos y qué falta?
-│   └── PLAN_MAESTRO · LINEA_DE_TIEMPO · SIGUIENTE_TANDA
+│   └── PLAN_MAESTRO · LINEA_DE_TIEMPO · SIGUIENTE_TANDA · HARNESS
 │
 ├── 2-lengua/        ¿cómo es el caquetío?
 │   └── mapa-lengua · lexicon · morfologia · toponimia · metodo-comparativo
 │
 ├── 3-mundo/         ¿cómo era ese pueblo?
 │   ├── mapa-familia · mapa-ecologia · mapa-creencia · mapa-transmision
-│   │   · mapa-geografia-politica
+│   │   · mapa-geografia-politica · polities-caquetias
 │   ├── CULTURA_CAQUETIA.md  ← el canon narrativo: cómo se vivía ahí
 │   ├── ensayos/     ← los 5 mini-ensayos (el argumento, no el índice)
 │   └── corpus/      ← 161 hechos en YAML + genealogía
@@ -93,12 +95,12 @@ proyecto-linguistico-caquetío/          ← raíz del vault
 │   └── sesiones/    ← bitácoras: qué se buscó, qué se halló, qué quedó abierto
 │
 ├── 5-experimento/   ¿qué probamos con el simulador?
-│   ├── mapa-motor · DISENO_KOINE · CANON_TIERRA · BITACORA_RUNS · …
+│   ├── mapa-motor · ARQUITECTURA · DISENO_KOINE · CANON_TIERRA · …
 │   ├── analisis/    ← qué produjeron los runs
 │   └── disenos/     ← biosfera, motor ambiental, toponimia, protocolos
 │
 ├── fuentes_caquetios/    ← los PDF (no se editan, se citan)
-├── curiana_sim/          ← el motor + 45 tests, el guardián
+├── curiana_sim/          ← el motor + 125 tests, los guardianes
 └── supabase/             ← el esquema versionado
 ```
 
@@ -138,13 +140,13 @@ El lexicón usa su propia escala paralela — `caquetío-atestiguado` (226),
 > lexicón, corpus, frontmatter de las fuentes, gate y decisiones— y reescribe
 > `TABLERO.md` con la fecha de medición.
 
-Los tres números que resumen el momento (medidos el 2026-08-04):
+Los tres números que resumen el momento (medidos el 2026-08-06):
 
 - **3 entradas del lexicón sin cita**, de las 82 que había el 2026-07-21. Las
   que quedan ya no son deuda de minería sino de decisión: no dejan rastro en
   ninguna de las cuatro fuentes minadas.
-- **152 hechos del corpus, los 152 con `referencia`.**
-- **1 de las 9 condiciones del gate** para reanudar simulaciones. El resto,
+- **161 hechos del corpus, los 161 con `referencia`.**
+- **2 de las 9 condiciones del gate** para reanudar simulaciones. El resto,
   con su porqué, en [[TABLERO]] §4.
 
 ## Convenciones

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -48,6 +48,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 | [[mapa-transmision]] | ¿Cómo sabía lo que sabía? | 34 |
 | [[mapa-geografia-politica]] | ¿Cuál era el mundo de Manaure? | 8 |
 | [[polities-caquetias]] | ¿Cuántos caquetíos había, y cuál simulamos? | 4 polities |
+| [[horizonte-de-contacto]] | ¿Hasta dónde llegaba su mundo? ¿Tocó a los mayas? | prospección |
 | [[mapa-motor]] | El código, los tests y los runs | — |
 
 ## Las notas de trabajo

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-06 23:19**.
+<!--GENERADO--> Generado el **2026-08-06 23:23**.
 
 ## ¿Vamos bien?
 
@@ -256,7 +256,7 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 750 en 176 notas indexadas | 🟢 0 rotos |
+| Wikilinks | 765 en 177 notas indexadas | 🟢 0 rotos |
 | Tests (`curiana_sim/tests/`) | 125 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-06 16:48**.
+<!--GENERADO--> Generado el **2026-08-06 23:19**.
 
 ## ¿Vamos bien?
 
@@ -21,7 +21,7 @@ editar_a_mano: no
 |---|---|---|---|
 | Entradas del lexicón **sin cita** | **3** | 82 (2026-07-21) | 🟢 −79 |
 | Hechos del corpus **con referencia** | **161 / 161** | — | 🟢 |
-| Tests del motor | **122 en verde** | 0 rojos | 🟢 |
+| Tests del motor | **125 en verde** | 0 rojos | 🟢 |
 | Gate para reanudar simulaciones | **2 de 9** condiciones | faltan 7 | 🔴 |
 | Decisiones esperando a Miguel | **12 abiertas** | 0 resueltas | 🟡 |
 
@@ -256,8 +256,8 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 736 en 170 notas indexadas | 🟢 0 rotos |
-| Tests (`curiana_sim/tests/`) | 122 passed, 0 failed | 🟢 |
+| Wikilinks | 750 en 176 notas indexadas | 🟢 0 rotos |
+| Tests (`curiana_sim/tests/`) | 125 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 
 **Avisos de `curiana_polities.py::coherencia_del_canon()`:**

--- a/proyecto-linguistico-caquetío/curiana_sim/analizar_runs.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/analizar_runs.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — análisis de los runs almacenados
+==========================================
+
+Lee la base local (Supabase/Postgres en Docker) y responde las tres preguntas
+que el proyecto se hace sobre sus propios datos:
+
+    --koine     ¿Hubo koineización? El contraste normal vs. ablación, con
+                estadística y no solo con medias.
+    --lengua    ¿Qué le pasó a la lengua? Composición, deriva, neologismos,
+                distribución del léxico.
+    --agentes   ¿Cómo se comportaron? Prestigio, adopción, diferencias por
+                tier y etnia.
+    --narrativa ¿Qué historias salieron? Citas, arcos, eventos.
+
+POR QUÉ ESTE MÓDULO EXISTE
+--------------------------
+El análisis se venía haciendo con consultas sueltas cuyo resultado acababa en
+un markdown y no se podía reproducir. Aquí las consultas **son el código**: si
+alguien duda de una cifra del informe, corre el comando y la vuelve a medir.
+Es la misma disciplina de `generar_tablero.py`.
+
+CONEXIÓN
+--------
+No usa psycopg2 (no está instalado): habla con Postgres por `docker exec` y lee
+CSV. Es más lento y da igual — son consultas de análisis, no de un bucle.
+El contenedor por defecto es el de este proyecto; ojo que en la misma máquina
+corre otro Supabase (fintech), por eso el nombre va explícito y no por puerto.
+
+Uso:
+    python analizar_runs.py --koine
+    python analizar_runs.py --lengua --neologismos
+    python analizar_runs.py --todo
+"""
+
+import argparse
+import io
+import subprocess
+import sys
+from textwrap import dedent
+
+import numpy as np
+import pandas as pd
+
+CONTENEDOR = "supabase_db_curiana_sim"
+
+# Los dos brazos del experimento de koiné del 2026-07-06. Van fijos porque el
+# contraste solo tiene sentido entre estos dos: mismo día, misma configuración,
+# misma semilla de elenco, y la única diferencia es `--ablacion`.
+RUN_NORMAL = "038d7b9d-3335-4b96-971d-8a3132c0319d"
+RUN_ABLACION = "bdc54134-9bb5-4308-a71b-135e99900f67"
+
+
+def q(sql: str) -> pd.DataFrame:
+    """Corre SQL en el Postgres del contenedor y devuelve un DataFrame."""
+    out = subprocess.run(
+        ["docker", "exec", CONTENEDOR, "psql", "-U", "postgres", "-d", "postgres",
+         "--csv", "-c", dedent(sql)],
+        capture_output=True, text=True, encoding="utf-8", timeout=180)
+    if out.returncode != 0:
+        raise RuntimeError(f"psql falló:\n{out.stderr.strip()[:500]}")
+    return pd.read_csv(io.StringIO(out.stdout))
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def titulo(t: str) -> None:
+    print(f"\n{'═' * 72}\n  {t}\n{'═' * 72}")
+
+
+def sub(t: str) -> None:
+    print(f"\n── {t} ──")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# KOINÉ — el contraste normal vs. ablación
+# ══════════════════════════════════════════════════════════════════════
+
+def analizar_koine() -> dict:
+    titulo("KOINÉ — ¿convergieron, y fue por el motor?")
+
+    df = q(f"""
+        SELECT r.config->>'ablacion' AS brazo, k.day,
+               k.distance AS acumulada,
+               k.distance_ventana AS ventana,
+               k.distance_emergente AS emergente
+        FROM koine_metrics k JOIN simulation_runs r ON r.id = k.run_id
+        WHERE k.run_id IN ('{RUN_NORMAL}', '{RUN_ABLACION}')
+        ORDER BY brazo, k.day
+    """)
+    # Ojo: `config->>'ablacion'` sale como texto 'true'/'false' de psql, y pandas
+    # lo lee como **bool** al parsear el CSV. Mapear por la cadena devuelve NaN
+    # para todo y deja el pareo vacío sin decir por qué. Se normaliza a texto.
+    df["brazo"] = df["brazo"].astype(str).str.lower().map(
+        {"false": "normal", "true": "ablacion"})
+    if df["brazo"].isna().any():
+        raise RuntimeError("no se pudo identificar el brazo de cada run")
+
+    n = df[df.brazo == "normal"].set_index("day")
+    a = df[df.brazo == "ablacion"].set_index("day")
+    dias = sorted(set(n.index) & set(a.index))
+    print(f"\n  días pareados: {len(dias)}")
+
+    from scipy import stats
+
+    resultados = {}
+    for lectura in ("acumulada", "ventana", "emergente"):
+        vn = n.loc[dias, lectura].astype(float).values
+        va = a.loc[dias, lectura].astype(float).values
+        dif = va - vn                      # positivo = la ablación converge MENOS
+
+        # Pareado por día: los dos brazos comparten el calendario de eventos.
+        t, p_t = stats.ttest_rel(vn, va)
+        try:
+            _, p_w = stats.wilcoxon(vn, va)
+        except ValueError:
+            p_w = float("nan")
+        d = dif.mean() / dif.std(ddof=1) if dif.std(ddof=1) else float("nan")
+
+        # ¿Se separan con el tiempo? Pendiente de la diferencia contra el día.
+        pend, inter, r, p_pend, se = stats.linregress(dias, dif)
+
+        resultados[lectura] = dict(
+            normal=vn.mean(), ablacion=va.mean(), delta=dif.mean(),
+            p_t=p_t, p_w=p_w, d=d, pend=pend, p_pend=p_pend,
+            gana_normal=int((dif > 0).sum()), n=len(dias))
+
+        sub(f"lectura «{lectura}»")
+        print(f"    normal   {vn.mean():.4f}      ablación {va.mean():.4f}")
+        print(f"    Δ (abl−nor) = {dif.mean():+.4f}   "
+              f"(mayor = la ablación converge menos, que es lo esperado)")
+        print(f"    t pareada  p = {p_t:.2e}    Wilcoxon p = {p_w:.2e}")
+        print(f"    d de Cohen (pareada) = {d:.2f}")
+        print(f"    días en que el normal converge más: "
+              f"{int((dif > 0).sum())}/{len(dias)}")
+        if p_pend >= 0.05:
+            lectura_tend = "— plana: el efecto no crece ni se apaga"
+        elif pend > 0:
+            lectura_tend = "— la brecha SE ABRE con el tiempo"
+        else:
+            lectura_tend = "— la brecha SE CIERRA con el tiempo"
+        print(f"    tendencia de la brecha: {pend:+.5f}/día (p={p_pend:.3f}) "
+              f"{lectura_tend}")
+
+    sub("veredicto")
+    em = resultados["emergente"]
+    print("    La lectura emergente es la más exigente y la que más separa los")
+    print(f"    brazos: Δ = {em['delta']:+.4f}, p = {em['p_t']:.1e}, d = {em['d']:.2f}.")
+    print(f"    El normal converge más que la ablación en {em['gana_normal']} de")
+    print(f"    {em['n']} días. La diferencia NO es de medias apenas distintas:")
+    print("    es sistemática día a día.")
+
+    sub("⚠️ lo que estos p-valores NO dicen")
+    print(dedent("""\
+        1. **n = 1 run por brazo.** Los 30 días son pseudo-réplicas: los días de
+           un mismo run comparten agentes, semilla y trayectoria, así que NO son
+           independientes. Los p-valores de arriba miden «¿difieren estas dos
+           series?», no «¿difieren estas dos condiciones?». Para lo segundo hace
+           falta repetir el par de runs varias veces y tratar el RUN como unidad.
+           Con lo que hay, el resultado es una señal fuerte, no una prueba.
+
+        2. **La brecha no crece.** En las tres lecturas la tendencia es plana o
+           ligeramente decreciente. O sea: el motor de convergencia produce un
+           desplazamiento **inmediato y sostenido**, no un efecto acumulativo.
+           Si la hipótesis era «la koiné se va formando», el dato dice más bien
+           «el contagio fija una diferencia desde el principio y la mantiene».
+
+        3. **30 días simulados es poco** para hablar de koineización histórica;
+           es una prueba del mecanismo, no del fenómeno."""))
+    return resultados
+
+
+# ══════════════════════════════════════════════════════════════════════
+# LENGUA
+# ══════════════════════════════════════════════════════════════════════
+
+def analizar_lengua() -> None:
+    titulo("LENGUA — composición, deriva y léxico")
+
+    sub("composición por brazo (media de las respuestas)")
+    comp = q(f"""
+        SELECT r.config->>'ablacion' AS brazo,
+               round(avg(a.pct_caquetio)::numeric, 4) AS caquetio,
+               round(avg(a.pct_wayunaiki)::numeric, 4) AS wayunaiki,
+               round(avg(a.pct_lokono)::numeric, 4) AS lokono,
+               round(avg(a.pct_taino)::numeric, 4) AS taino,
+               round(avg(a.score)::numeric, 3) AS score,
+               round(stddev(a.pct_caquetio)::numeric, 4) AS sd_caquetio,
+               round(stddev(a.score)::numeric, 4) AS sd_score,
+               count(*) AS n
+        FROM agent_responses a JOIN simulation_runs r ON r.id = a.run_id
+        WHERE a.run_id IN ('{RUN_NORMAL}', '{RUN_ABLACION}')
+        GROUP BY brazo ORDER BY brazo
+    """)
+    print(comp.to_string(index=False))
+
+    print("\n  ⚠️ Mirar `sd_caquetio` y `sd_score`: si son casi cero, las métricas")
+    print("     están saturadas y no distinguen nada (es el issue #69).")
+
+    sub("¿está saturada pct_caquetio? distribución en los dos runs de 60 turnos")
+    dist = q(f"""
+        SELECT width_bucket(pct_caquetio, 0, 1, 10) AS decil,
+               count(*) AS n
+        FROM agent_responses
+        WHERE run_id IN ('{RUN_NORMAL}', '{RUN_ABLACION}')
+        GROUP BY decil ORDER BY decil
+    """)
+    total = dist["n"].sum()
+    for _, r in dist.iterrows():
+        pct = 100.0 * r["n"] / total
+        barra = "█" * int(pct / 2)
+        lo = (r["decil"] - 1) * 10
+        print(f"    {lo:3d}-{lo+10:3d}%  {r['n']:5d}  {pct:5.1f}%  {barra}")
+
+    sub("las 25 palabras más usadas, y de qué lengua son")
+    top = q("""
+        SELECT word, source_language, count(*) AS usos,
+               count(DISTINCT agent_name) AS agentes,
+               count(DISTINCT run_id) AS runs
+        FROM word_uses GROUP BY word, source_language
+        ORDER BY usos DESC LIMIT 25
+    """)
+    print(top.to_string(index=False))
+
+    sub("reparto de usos por lengua (todos los runs)")
+    lang = q("""
+        SELECT source_language, count(*) AS usos,
+               count(DISTINCT word) AS formas
+        FROM word_uses GROUP BY source_language ORDER BY usos DESC
+    """)
+    lang["pct"] = (100.0 * lang["usos"] / lang["usos"].sum()).round(1)
+    print(lang.to_string(index=False))
+
+    sub("¿ley de Zipf? concentración del léxico")
+    z = q("""
+        SELECT word, count(*) AS usos FROM word_uses
+        GROUP BY word ORDER BY usos DESC
+    """)
+    usos = z["usos"].values
+    acum = np.cumsum(usos) / usos.sum()
+    for k in (10, 25, 50, 100):
+        if len(acum) >= k:
+            print(f"    las {k:3d} palabras más usadas concentran "
+                  f"{100 * acum[k - 1]:5.1f}% de los usos")
+    print(f"    formas distintas: {len(z)}   usos totales: {usos.sum()}")
+
+
+def analizar_neologismos() -> None:
+    titulo("NEOLOGISMOS — qué inventaron y qué cuajó")
+
+    sub("por estado")
+    est = q("""
+        SELECT status, count(*) AS n,
+               round(avg(coalesce(array_length(adopted_by,1),0))::numeric,2) AS adoptantes_medios
+        FROM neologisms GROUP BY status ORDER BY n DESC
+    """)
+    print(est.to_string(index=False))
+
+    sub("regla morfológica usada")
+    reglas = q("""
+        SELECT coalesce(nullif(trim(morphological_rule),''),'(sin regla)') AS regla,
+               count(*) AS n
+        FROM neologisms GROUP BY regla ORDER BY n DESC LIMIT 15
+    """)
+    print(reglas.to_string(index=False))
+
+    sub("quién propone (top 15) y con qué éxito")
+    quien = q("""
+        SELECT proposed_by AS agente, count(*) AS propuestos,
+               sum(coalesce(array_length(adopted_by,1),0)) AS adopciones,
+               round(avg(coalesce(array_length(adopted_by,1),0))::numeric,2) AS media
+        FROM neologisms GROUP BY proposed_by
+        ORDER BY propuestos DESC LIMIT 15
+    """)
+    print(quien.to_string(index=False))
+
+    sub("los que más se adoptaron")
+    top = q("""
+        SELECT form, meaning, proposed_by,
+               coalesce(array_length(adopted_by,1),0) AS adoptantes, status
+        FROM neologisms
+        WHERE coalesce(array_length(adopted_by,1),0) > 0
+        ORDER BY adoptantes DESC LIMIT 20
+    """)
+    print(top.to_string(index=False) if len(top) else "    (ninguno con adoptantes)")
+
+    sub("koiné: formas que se FIJARON")
+    fij = q("""
+        SELECT concepto_id, form, fijada_dia, soporte, n_variantes
+        FROM koine_lexicon ORDER BY fijada_dia
+    """)
+    print(fij.to_string(index=False) if len(fij) else "    (ninguna)")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# AGENTES
+# ══════════════════════════════════════════════════════════════════════
+
+def analizar_agentes() -> None:
+    titulo("AGENTES — prestigio, tier y comportamiento")
+
+    sub("por tier (todos los runs)")
+    tier = q("""
+        SELECT tier, count(DISTINCT agent_name) AS agentes, count(*) AS respuestas,
+               round(avg(score)::numeric,3) AS score,
+               round(avg(pct_caquetio)::numeric,4) AS caquetio,
+               round(avg(neologisms_proposed)::numeric,3) AS neo_por_resp
+        FROM agent_responses WHERE tier IS NOT NULL
+        GROUP BY tier ORDER BY tier
+    """)
+    print(tier.to_string(index=False))
+
+    sub("por etnia")
+    etnia = q("""
+        SELECT ethnicity AS etnia, count(DISTINCT agent_name) AS agentes,
+               count(*) AS respuestas,
+               round(avg(score)::numeric,3) AS score,
+               round(avg(pct_caquetio)::numeric,4) AS caquetio
+        FROM agent_responses WHERE ethnicity IS NOT NULL
+        GROUP BY ethnicity ORDER BY respuestas DESC
+    """)
+    print(etnia.to_string(index=False))
+    print("\n  ⚠️ Si aparecen 'caquetío' y 'caquetía' como filas distintas, es el")
+    print("     bug del campo `etnia` que detecta curiana_polities.py.")
+
+    sub("los 20 agentes más activos")
+    act = q("""
+        SELECT agent_name AS agente, tier, count(*) AS resp,
+               round(avg(score)::numeric,3) AS score,
+               round(avg(pct_caquetio)::numeric,4) AS caquetio,
+               sum(neologisms_proposed) AS neo
+        FROM agent_responses GROUP BY agent_name, tier
+        ORDER BY resp DESC LIMIT 20
+    """)
+    print(act.to_string(index=False))
+
+    sub("perfiles curados: rol en la comunidad")
+    perf = q("""
+        SELECT rol_comunidad, count(*) AS n
+        FROM agent_profiles WHERE rol_comunidad IS NOT NULL
+        GROUP BY rol_comunidad ORDER BY n DESC LIMIT 20
+    """)
+    print(perf.to_string(index=False) if len(perf) else "    (sin perfiles)")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# NARRATIVA
+# ══════════════════════════════════════════════════════════════════════
+
+def analizar_narrativa() -> None:
+    titulo("NARRATIVA — citas, arcos y eventos")
+
+    sub("las 15 citas de mayor impacto")
+    citas = q("""
+        SELECT agent_name AS agente, day AS dia, round(impacto_score::numeric,2) AS impacto,
+               left(quote, 90) AS cita
+        FROM agent_quotes ORDER BY impacto_score DESC NULLS LAST LIMIT 15
+    """)
+    for _, r in citas.iterrows():
+        print(f"\n    [{r['impacto']}] {r['agente']} (día {r['dia']})")
+        print(f"      «{r['cita']}»")
+
+    sub("agentes con más citas seleccionadas")
+    top = q("""
+        SELECT agent_name AS agente, count(*) AS citas,
+               round(avg(impacto_score)::numeric,2) AS impacto_medio
+        FROM agent_quotes GROUP BY agent_name
+        ORDER BY citas DESC LIMIT 15
+    """)
+    print(top.to_string(index=False))
+
+    sub("eventos del mundo más frecuentes")
+    ev = q("""
+        SELECT left(event_description, 70) AS evento, count(*) AS veces
+        FROM turns WHERE event_description IS NOT NULL AND event_description <> ''
+        GROUP BY evento ORDER BY veces DESC LIMIT 15
+    """)
+    print(ev.to_string(index=False) if len(ev) else "    (sin eventos)")
+
+    sub("arcos narrativos (muestra)")
+    arcos = q("""
+        SELECT agent_name AS agente, tier, left(resumen_arco, 150) AS arco
+        FROM agent_profiles
+        WHERE resumen_arco IS NOT NULL AND resumen_arco <> ''
+        ORDER BY total_respuestas DESC NULLS LAST LIMIT 8
+    """)
+    for _, r in arcos.iterrows():
+        print(f"\n    {r['agente']} (tier {r['tier']})")
+        print(f"      {r['arco']}")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Análisis de los runs de Curiana")
+    ap.add_argument("--koine", action="store_true")
+    ap.add_argument("--lengua", action="store_true")
+    ap.add_argument("--neologismos", action="store_true")
+    ap.add_argument("--agentes", action="store_true")
+    ap.add_argument("--narrativa", action="store_true")
+    ap.add_argument("--todo", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.todo or not any(vars(a).values()):
+        a.koine = a.lengua = a.neologismos = a.agentes = a.narrativa = True
+
+    if a.koine:
+        analizar_koine()
+    if a.lengua:
+        analizar_lengua()
+    if a.neologismos:
+        analizar_neologismos()
+    if a.agentes:
+        analizar_agentes()
+    if a.narrativa:
+        analizar_narrativa()
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/backfill_word_uses.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/backfill_word_uses.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — rellenar `word_uses.source_language` en los runs ya corridos
+======================================================================
+
+`word_source_language()` era un lookup pelado contra `VOCABULARIO_BASE`, así
+que toda forma flexionada se guardó con `source_language = NULL`. Medido sobre
+la base local el 2026-08-06:
+
+    27.641 de 54.936 usos (50,3%) sin lengua
+    y el 100% de ellos, formas morfológicamente complejas
+      18.752 con sufijo de aspecto (-ka/-ni/-da)
+       5.049 otros compuestos con guion
+       3.840 con prefijo posesivo (ta-/pi-/nü-)
+
+O sea: **justo los usos que prueban que los agentes manejan la morfología**
+quedaron fuera de cualquier análisis por lengua. La función ya está arreglada
+(usa `_familia_de_token`), pero los 23 runs históricos siguen con el hueco.
+
+Este script lo rellena **sin volver a correr nada**: recalcula la lengua de
+cada forma distinta y actualiza solo las filas con NULL.
+
+⚠️ Es una migración de datos. Por defecto **no escribe**: enseña qué haría.
+Para aplicarla de verdad hay que pasar `--aplicar`, y conviene tener el
+`supabase db dump` del día antes.
+
+Uso:
+    python backfill_word_uses.py              # simulacro, no toca nada
+    python backfill_word_uses.py --aplicar
+    python backfill_word_uses.py --verificar  # cuenta cuánto queda en NULL
+"""
+
+import argparse
+import io
+import subprocess
+import sys
+
+CONTENEDOR = "supabase_db_curiana_sim"
+
+
+def psql(sql: str, csv: bool = True) -> str:
+    cmd = ["docker", "exec", CONTENEDOR, "psql", "-U", "postgres", "-d", "postgres"]
+    if csv:
+        cmd.append("--csv")
+    cmd += ["-c", sql]
+    out = subprocess.run(cmd, capture_output=True, text=True,
+                         encoding="utf-8", timeout=300)
+    if out.returncode != 0:
+        raise RuntimeError(f"psql falló: {out.stderr.strip()[:400]}")
+    return out.stdout
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def formas_sin_lengua() -> list:
+    salida = psql("SELECT DISTINCT word FROM word_uses WHERE source_language IS NULL;")
+    lineas = [l.strip() for l in salida.splitlines()[1:] if l.strip()]
+    return lineas
+
+
+def resolver(formas: list) -> dict:
+    sys.path.insert(0, __import__("os").path.dirname(__file__))
+    from curiana_database import word_source_language
+    mapa = {}
+    for f in formas:
+        lang = word_source_language(f)
+        if lang:
+            mapa[f] = lang
+    return mapa
+
+
+def _sql_escape(s: str) -> str:
+    return s.replace("'", "''")
+
+
+def construir_update(mapa: dict) -> str:
+    """Un solo UPDATE ... FROM (VALUES ...), que es mucho más rápido que 1016."""
+    vals = ",\n  ".join(
+        f"('{_sql_escape(w)}', '{_sql_escape(l)}')" for w, l in sorted(mapa.items()))
+    return (
+        "UPDATE word_uses AS u SET source_language = v.lang\n"
+        "FROM (VALUES\n  " + vals + "\n) AS v(word, lang)\n"
+        "WHERE u.word = v.word AND u.source_language IS NULL;")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--aplicar", action="store_true",
+                    help="escribe de verdad (por defecto es simulacro)")
+    ap.add_argument("--verificar", action="store_true",
+                    help="solo cuenta cuántos usos siguen sin lengua")
+    args = ap.parse_args(argv)
+
+    if args.verificar:
+        print(psql("""
+            SELECT count(*) FILTER (WHERE source_language IS NULL) AS sin_lengua,
+                   count(*) AS total,
+                   round(100.0*count(*) FILTER (WHERE source_language IS NULL)
+                         / nullif(count(*),0), 2) AS pct_null
+            FROM word_uses;"""))
+        return 0
+
+    formas = formas_sin_lengua()
+    print(f"\n  formas distintas sin lengua: {len(formas)}")
+    if not formas:
+        print("  nada que hacer.")
+        return 0
+
+    mapa = resolver(formas)
+    irresolubles = [f for f in formas if f not in mapa]
+    print(f"  se resuelven: {len(mapa)}")
+    print(f"  siguen sin resolver: {len(irresolubles)}"
+          + (f"  (ej.: {irresolubles[:8]})" if irresolubles else ""))
+
+    from collections import Counter
+    reparto = Counter(mapa.values())
+    print("\n  a qué lengua irían:")
+    for lang, n in reparto.most_common():
+        print(f"     {lang:26} {n:5d} formas")
+
+    filas = psql(
+        "SELECT count(*) FROM word_uses WHERE source_language IS NULL;"
+    ).splitlines()[1].strip()
+    print(f"\n  filas afectadas (usos, no formas): hasta {filas}")
+
+    if not args.aplicar:
+        print("\n  ── SIMULACRO ── no se ha escrito nada.")
+        print("     Para aplicarlo: python backfill_word_uses.py --aplicar")
+        print("     Antes conviene: cd curiana_sim && supabase db dump -f respaldo.sql")
+        return 0
+
+    print("\n  aplicando…")
+    psql(construir_update(mapa), csv=False)
+    print(psql("""
+        SELECT count(*) FILTER (WHERE source_language IS NULL) AS sin_lengua,
+               count(*) AS total
+        FROM word_uses;"""))
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_database.py
@@ -138,11 +138,28 @@ def language_composition(words_used: list[str]) -> dict[str, float]:
 
 
 def word_source_language(word: str) -> Optional[str]:
-    """Devuelve la categoría canónica de lengua para una palabra individual."""
-    from curiana_lexicon import VOCABULARIO_BASE
-    if word in VOCABULARIO_BASE:
-        return normalize_source_language(VOCABULARIO_BASE[word]["fuente"])
-    return None
+    """Categoría canónica de lengua de una palabra ya reconocida como arahuaca.
+
+    Delega en `_familia_de_token()`, que **deshace prefijos posesivos y sufijos
+    de aspecto** antes de buscar en el lexicón. Antes esto era un lookup pelado
+    contra `VOCABULARIO_BASE`, y por eso toda forma flexionada se guardaba con
+    `source_language = NULL`: `wana-ka`, `ta-barsure`, `naba-ni`…
+
+    Medido sobre la base local (2026-08-06): **27.641 de 54.936 usos (50,3%)
+    estaban sin lengua, y el 100% de ellos eran formas morfológicamente
+    complejas** — o sea, justo los usos que prueban que los agentes manejan la
+    morfología que el proyecto quiere modelar. El motor los reconocía para
+    puntuar (`score_linguistico`) y los perdía al persistir.
+
+    Solo se llama con tokens que `score_linguistico()` ya aceptó como arahuacos
+    (`words_used` = `palabras_caquetias`), que es la precondición de
+    `_familia_de_token`: para un neologismo comunitario devuelve "caquetío",
+    que es lo correcto — es lengua propia, no préstamo.
+    """
+    from curiana_lexicon import _familia_de_token
+    if not word:
+        return None
+    return _familia_de_token(word)
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — los guardianes, en un solo comando
+============================================
+
+El proyecto tiene cinco comprobaciones que miden **contra el dato** y no contra
+la documentación. Estaban sueltas, y correrlas dependía de que alguien se
+acordara de las cinco:
+
+    1. tests del motor            pytest curiana_sim/tests/
+    2. la suite rápida            python curiana_sim/test_quick.py
+    3. el grafo del vault         python check_vault_links.py --strict
+    4. el corpus cultural         python curiana_sim/compilar_corpus.py --check
+    5. las polities               python curiana_sim/curiana_polities.py --check
+
+Acordarse de cinco cosas no es un método: es suerte. Esto las corre todas,
+informa en una tabla y sale con código ≠ 0 si alguna falla, para que se pueda
+colgar de un hook o de CI.
+
+Deliberadamente **no** incluye `generar_tablero.py --check`: el tablero se queda
+viejo cada vez que cambia una cifra medida, que es constantemente, y bloquear
+por eso sería ruido. Se regenera, no se vigila.
+
+Uso:
+    python guardianes.py            # los cinco, informe en tabla
+    python guardianes.py --rapido   # salta los tests (los más lentos)
+    python guardianes.py --silencio # solo el veredicto, para hooks
+"""
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+import time
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+PY = sys.executable
+
+# (nombre, comando, cwd, es_lento)
+GUARDIANES = [
+    ("tests del motor",
+     [PY, "-m", "pytest", os.path.join(AQUI, "tests"), "-q", "--no-header"],
+     REPO, True),
+    ("suite rápida (8/8)",
+     [PY, os.path.join(AQUI, "test_quick.py")],
+     AQUI, True),
+    ("grafo del vault",
+     [PY, os.path.join(REPO, "check_vault_links.py"), "--strict"],
+     REPO, False),
+    ("corpus cultural",
+     [PY, os.path.join(AQUI, "compilar_corpus.py"), "--check"],
+     REPO, False),
+    ("polities",
+     [PY, os.path.join(AQUI, "curiana_polities.py"), "--check"],
+     REPO, False),
+]
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def correr(nombre, cmd, cwd):
+    """Corre un guardián. Devuelve (ok, segundos, última línea útil)."""
+    entorno = dict(os.environ, PYTHONIOENCODING="utf-8")
+    t0 = time.time()
+    try:
+        out = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                             encoding="utf-8", errors="replace",
+                             timeout=600, env=entorno)
+    except subprocess.TimeoutExpired:
+        return False, time.time() - t0, "se pasó de 600 s"
+    except FileNotFoundError as e:
+        return False, time.time() - t0, f"no se pudo ejecutar: {e}"
+
+    texto = (out.stdout or "") + (out.stderr or "")
+    lineas = [l.strip() for l in texto.splitlines() if l.strip()]
+    resumen = ""
+    for l in reversed(lineas):
+        if any(m in l for m in ("passed", "failed", "OK", "✓", "✗", "error",
+                                "ERROR", "ROTOS", "válido", "módulos")):
+            resumen = l
+            break
+    if not resumen and lineas:
+        resumen = lineas[-1]
+    return out.returncode == 0, time.time() - t0, resumen[:78]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rapido", action="store_true", help="salta los lentos")
+    ap.add_argument("--silencio", action="store_true", help="solo el veredicto")
+    args = ap.parse_args(argv)
+
+    tareas = [g for g in GUARDIANES if not (args.rapido and g[3])]
+    if not args.silencio:
+        print(f"\n── guardianes ({len(tareas)}) ──\n")
+
+    fallos = []
+    for nombre, cmd, cwd, _ in tareas:
+        ok, seg, resumen = correr(nombre, cmd, cwd)
+        if not ok:
+            fallos.append((nombre, resumen))
+        if not args.silencio:
+            print(f"  {'✓' if ok else '✗'}  {nombre:22} {seg:5.1f}s  {resumen}")
+
+    if fallos:
+        print(f"\n  ✗ {len(fallos)} guardián(es) en rojo:")
+        for nombre, resumen in fallos:
+            print(f"      {nombre}: {resumen}")
+        return 1
+
+    if not args.silencio:
+        print(f"\n  ✓ los {len(tareas)} en verde\n")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_lexicon.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_lexicon.py
@@ -98,3 +98,50 @@ def test_adopcion_repetida_mismo_agente_no_oficializa():
     _neo(lex)
     assert lex.adoptar("kali-dusha", "Shaboro", turno=1, dia=4) is None
     assert lex.adoptar("kali-dusha", "Shaboro", turno=2, dia=4) is None
+
+
+# ── word_source_language debe entender morfología ─────────────────────
+
+def test_word_source_language_resuelve_formas_flexionadas():
+    """Lo que se guarda en `word_uses.source_language` tiene que reconocer las
+    formas con prefijo posesivo y sufijo de aspecto.
+
+    Antes era un lookup pelado contra VOCABULARIO_BASE, así que `wana-ka` o
+    `ta-barsure` se guardaban con NULL. Medido sobre la base local el
+    2026-08-06: **27.641 de 54.936 usos (50,3%) sin lengua, y el 100% de ellos
+    formas morfológicamente complejas** — justo los usos que prueban que los
+    agentes manejan la morfología del proyecto.
+    """
+    from curiana_database import word_source_language
+
+    for forma in ("wana-ka", "naba-ni", "kaa-ni", "ta-barsure", "pi-barsure"):
+        assert word_source_language(forma) is not None, (
+            f"{forma} debería resolver a una lengua, no a None")
+
+
+def test_word_source_language_conserva_la_lengua_hermana():
+    """Descomponer no puede convertirlo todo en caquetío: una palabra wayunaiki
+    o lokono tiene que seguir siendo suya, que es de lo que vive el scoring.
+
+    Se comprueba sobre TODO el lexicón, no sobre una muestra: si una sola
+    entrada cambiara de lengua al pasar por aquí, la composición por lengua de
+    los runs quedaría falseada.
+    """
+    from curiana_database import normalize_source_language, word_source_language
+    from curiana_lexicon import VOCABULARIO_BASE
+
+    discrepantes = []
+    for palabra, entrada in VOCABULARIO_BASE.items():
+        esperada = normalize_source_language(entrada.get("fuente", ""))
+        obtenida = word_source_language(palabra)
+        if obtenida != esperada:
+            discrepantes.append((palabra, esperada, obtenida))
+
+    assert not discrepantes, (
+        f"{len(discrepantes)} entradas cambian de lengua al resolverse; "
+        f"primeras: {discrepantes[:5]}")
+
+
+def test_word_source_language_vacio_es_none():
+    from curiana_database import word_source_language
+    assert word_source_language("") is None


### PR DESCRIPTION
Cuatro encargos de la noche: revisión de arquitectura, rediseño del setup de desarrollo, análisis a fondo de los datos, y prospección de fuentes.

## 1. Los datos — dos bugs y un confusor

**La mitad del corpus estaba sin clasificar.** `word_uses.source_language` venía NULL en **27.641 de 54.936 usos (50,3%)**, y el **100%** eran formas morfológicamente complejas: sufijo de aspecto, prefijo posesivo, compuestos. Cero formas simples. Justo los usos que prueban que los agentes manejan la morfología que el proyecto quiere modelar.

Causa: dos caminos de reconocimiento que no se hablaban. `score_linguistico()` usa `_familia_de_token()`, que descompone; `word_source_language()` —el que persiste— hacía un lookup pelado. El motor reconocía la palabra para puntuar y la perdía al guardarla. Arreglado, con tres tests (uno comprueba sobre las 1413 entradas que ninguna cambia de lengua) y `backfill_word_uses.py` para los 23 runs históricos: 1016 formas resueltas, 0 filas sin lengua.

**🔴 El confusor que obliga a releer todo análisis por agente**: la longitud del `system_prompt` predice negativamente el score. **r = −0.481, p = 0.0046** (Spearman −0.480). Manaure, el diao y centro narrativo, tiene el prompt más largo (834 car.) y el peor score (6.94); Pari-nu tiene 161 y saca 8.54. Cualquier lectura del tipo "el agente X lideró la convergencia" puede ser "a X le escribimos más prompt". Incluye el aparente efecto de género (MW p=0.010, d=0.75), que probablemente es el mismo efecto de lado.

**La koiné**: el brazo normal converge más que la ablación en las tres lecturas; la emergente da Δ=+0.0752, p=7.7e-11, d=1.81, gana 29 de 30 días. Pero el informe deja las reservas escritas: n=1 run por brazo (los días son pseudo-réplicas), y **la brecha no crece** — el mecanismo desplaza de entrada y sostiene, no acumula.

**`pct_caquetio` saturada**, confirmado: 91% de las respuestas en 1.0 (issue #69).

## 2. Arquitectura

Medida leyendo el AST: 30.651 líneas en 50 módulos, de las que **el motor real son ~4.300**. `curiana_lexicon.py` es **87% dato** en 11 dicts anotados — una base de datos disfrazada de módulo, importada por 17 sitios. Ciclo `lexicon ↔ database` que solo funciona porque los imports son locales, y que ya costó el bug de arriba. 1.484 líneas de scripts ya consumidos.

## 3. El harness

Diagnóstico: **no había**. Los 5 comandos de `.claude/` son del stack web; cero skills, hooks o settings compartidos. Todo el rigor dependía de que el agente se acordara.

- **`guardianes.py`**: los cinco en un comando, ~9 s, exit≠0 si falla. Verificado que detecta una rotura real.
- **Skill `minar-fuente`**: ocho minerías destiladas; cada paso está porque saltárselo costó un error nombrado.
- **CLAUDE.md de 19,4 KB → 7,7 KB** sin perder nada (el detalle ya vivía en `2-lengua/`, verificado antes de recortar). Llegaba a decir "las cifras exactas NO van aquí" y listaba veinticinco.
- **`HARNESS.md`** dice también qué **no** montar: subagentes, CI, hooks bloqueantes.

## 4. El horizonte de contacto

**¿Pudo un caquetío contactar con mayas? No.** Pero la conexión material entre los extremos está demostrada geoquímicamente: jadeíta antillana trazada al Motagua guatemalteco. Una persona no hizo ese viaje; un objeto sí, por muchas manos. Con el matiz de que esa jadeíta es saladoide (~250-500 d.C.), mil años antes de la ventana de la simulación.

Prospección marcada como tal: **ninguna fuente nueva entra al repo**. Cinco obras priorizadas, dos con PDF abierto ya localizado.

---

125 tests · los 5 guardianes en verde · todos los wikilinks resuelven · corpus válido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
