### PR TITLE
La bibliografía como clave foránea, y los datos de lengua fuera del código

### DIFF
--- a/.claude/skills/minar-fuente/SKILL.md
+++ b/.claude/skills/minar-fuente/SKILL.md
@@ -5,7 +5,7 @@ description: Minar una fuente documental del proyecto lingüístico caquetío (P
 
 # Minar una fuente
 
-Protocolo destilado de ocho minerías reales. Cada paso está porque **saltárselo
+Protocolo destilado de diez minerías reales. Cada paso está porque **saltárselo
 costó un error concreto** que aquí se nombra.
 
 ## 0. Antes de abrir nada: ¿qué pregunta le haces?
@@ -63,11 +63,46 @@ generoso (`grep -o ".\{300\}PATRÓN.\{400\}"`) y **lee lo que hay alrededor**.
 Localiza la **página impresa**, no la del PDF. Suelen diferir por un desfase
 constante que se calcula una vez (en Antczak: pdf + 130 = impresa).
 
-## 4. Escribir el resultado en la nota de la fuente
+## 4. Repartir el hallazgo por esferas, no solo al lexicón
 
-**El resultado va en `4-fuentes/<slug>.md`, no en un markdown nuevo.** Es regla
-del proyecto (CLAUDE.md). Actualiza también el frontmatter: `estado_minado`,
-`cobertura`, `sostiene`, `verificado`, `minado`.
+**Esta es la parte que se venía haciendo mal.** Medido el 2026-08-06: de 30
+obras, **18 dejan rastro en una sola esfera**. Parte es real —un paper de
+genética no da topónimos— y parte es que se minaba con el lexicón en la cabeza y
+lo demás caía donde cayera.
+
+Antes de escribir nada, pregúntate a **cuál de estas** va cada hallazgo:
+
+| Esfera | Dónde vive | Qué acepta |
+|---|---|---|
+| lengua — léxico | propuesta `lexicon_*.py` | palabras, glosas, afijos |
+| lengua — cognados | `2-lengua/cognados.yaml` | relaciones entre lenguas |
+| lengua — topónimos | `2-lengua/toponimos.yaml`, `morfemas.yaml` | nombres de lugar, formantes |
+| mundo — parentesco | `3-mundo/corpus/parentesco.yaml` | familia, sucesión, linaje |
+| mundo — ecología | `3-mundo/corpus/ecologia.yaml` | medio, fauna, flora, huecos léxicos |
+| mundo — creencia | `3-mundo/corpus/creencia.yaml` | rito, muerte, boratio, cosmos |
+| mundo — transmisión | `3-mundo/corpus/transmision.yaml` | cómo se aprende y se enseña |
+| mundo — geografía política | `geografia_politica.yaml`, `polities-caquetias.md` | territorio, autoridad, polities |
+| experimento | `5-experimento/` | lo que cambia cómo se corre o se mide |
+
+Una fuente buena alimenta **varias**. Oliver cap. 3 dio geografía política,
+guerra, economía y religión en el mismo barrido; Jahn dio parentesco, un mapa de
+polities y una corroboración léxica.
+
+Comprueba después con `python curiana_sim/medir_sostiene.py --esferas`.
+
+## 5. Y escribir la bitácora en la nota de la fuente
+
+La nota (`4-fuentes/<slug>.md`) es la **bitácora**: qué se preguntó, qué se
+halló, qué **no** se halló, qué deuda queda. Ya no es el almacén — el dato vive
+en su esfera y cita la obra por `procedencia.obra`.
+
+Actualiza el frontmatter: `estado_minado`, `cobertura`, `verificado`, `minado`.
+
+⚠️ **`sostiene` no se toca a mano.** Se mantenía así y ha derivado en 17 de 30
+obras. Lo mide `medir_sostiene.py`.
+
+Si la obra es nueva en el repo, regenera la bibliografía para que su id exista
+como clave foránea: `python curiana_sim/generar_bibliografia.py`.
 
 Estructura que funciona:
 
@@ -77,7 +112,7 @@ Estructura que funciona:
 - **Veredicto por entrada** si el encargo era verificar entradas del corpus.
 - **Qué falta**, incluida la deuda documental nueva que la minería genera.
 
-## 5. Las negativas valen tanto como las positivas
+## 6. Las negativas valen tanto como las positivas
 
 Oviedo y Baños fue señalada *"por su cobertura de sucesión cacical"*. Medido: la
 cobertura **no existe** (Manaure aparece 2 veces en 519 páginas). Escribir eso
@@ -86,7 +121,7 @@ ahorra que alguien vuelva a gastar una noche ahí.
 Un hallazgo negativo **bien medido** baja la prioridad de una fuente y eso es
 progreso.
 
-## 6. Propuesta, no fusión
+## 7. Propuesta, no fusión
 
 **No toques `curiana_lexicon.py` ni `3-mundo/corpus/*.yaml` en una minería.**
 
@@ -97,7 +132,7 @@ fuentes sin romper nada.
 ⚠️ Excepción con trampa: `lexicon_zavala.py` **sí** lo importa
 `curiana_lexicon`. Regenerarlo cambia `score_linguistico()`.
 
-## 7. Segundas atestaciones y conflictos
+## 8. Segundas atestaciones y conflictos
 
 Si la fuente confirma algo que ya estaba: eso **sube** una entrada de "una
 fuente" a "dos independientes", que es de lo más valioso que hay.
@@ -109,10 +144,10 @@ del que viene la duda. Una corroboración falsa es peor que ninguna.
 Si contradice al lexicón, **no reescribas la glosa**: añade la evidencia a
 `notas` y levanta/actualiza el issue. Cambiar una glosa mueve canon.
 
-## 8. Cerrar
+## 9. Cerrar
 
 ```bash
-python curiana_sim/guardianes.py     # los cinco en verde
+python curiana_sim/guardianes.py     # los siete en verde
 python curiana_sim/generar_tablero.py
 ```
 

--- a/proyecto-linguistico-caquetío/2-lengua/cognados.yaml
+++ b/proyecto-linguistico-caquetío/2-lengua/cognados.yaml
@@ -1,0 +1,765 @@
+meta:
+  generado_por: curiana_sim/migrar_cognados.py
+  cognados: 51
+  con_procedencia: 16
+  sin_procedencia: 35
+  lenguas_nucleo:
+  - CAIC
+  - CQ
+  - KL
+  - LK
+  - PA
+  - PJ
+  - TN
+  - WY
+  lenguas_comparanda: 25
+  no_son_cognados: 2
+  nota: 'Fusión de arahuaco_comparative.COGNADOS (37, sin procedencia) y cognados_oliver.COGNADOS_OLIVER
+    (16, con página y ancla). Las formas van en un mapa abierto: los códigos en mayúscula son el núcleo
+    con reglas de transducción; los nombres en minúscula son comparanda citada, y son abiertos a propósito.'
+cognados:
+- id: cognado-001
+  glosa: ceniza (y, por extensión colonial, pólvora)
+  formas:
+    PA: '*p-/b-ali-'
+    CQ: barisi
+    WY: palíi
+    LK: bálisi
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 142
+    ancla: the toponym bari-si-ki-meto
+  confianza: alta
+  clave_origen: ceniza
+  nota: 'El documento de 1579 glosa barisi como ''agua turbia/lodosa'' del río (Río Turbio > Barquisimeto).
+    Oliver separa dos morfemas sobre la misma raíz: bari-si ''ceniza'' y bari-ki ''rojizo''. El par CQ
+    barisi : LK bálisi : WY palíi es la evidencia más limpia del capítulo de que el caquetío conserva
+    /b-/ como el lokono, frente al /p-/ guajiro (ver C3).'
+- id: cognado-002
+  glosa: almagre, óxido férrico rojo usado como pintura corporal
+  formas:
+    CQ: bariki
+    achagua: ki-rrayi
+    piapoco: ki-reri
+    otras: ki-lali
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 142
+    ancla: some painted [their bodies] with bariki which is like
+  confianza: baja
+  clave_origen: rojo_almagre
+  duda_del_autor: '"The etymology, however, is not too clear since the dependent segmental morpheme for
+    ''red'' is -ira- or -ila- rather than ki-" (n. 40, p. 143). Oliver propone leer ki- como el prefijo
+    atributivo /kV-/ (''que tiene la cualidad de''), no como el lexema ''rojo''.'
+  nota: 'Ya en el lexicón como `bariki`/`barique` vía Zavala 2015 #35.'
+- id: cognado-003
+  glosa: danta, tapir (Tapirus terrestris)
+  formas:
+    PA: '*-ama / *-Vma-'
+    CQ: kama
+    WY: ama'
+    karro: hema
+    maipure: kiema
+    baré: dehema
+    achagua: emayenesi
+    yavitero: kema
+    baniva: ema
+    cauyarí: ?e.ma
+    piro: xema
+    amarakaeri: keme
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 143
+    ancla: is defined as danta (Spanish) or tapir
+  confianza: alta
+  clave_origen: tapir
+  nota: 'El set más ancho del capítulo: 9 lenguas arahuacas más dos preandinas. Oliver observa que la
+    raíz se reaplicó al ganado europeo donde no había referente americano (WY ama'' ''caballo'').'
+- id: cognado-004
+  glosa: árbol, madera, corteza, piel (la parte por el todo)
+  formas:
+    PA: '*at-/-ada-'
+    CQ: -ada-
+    WY: ata'
+    LK: ada
+    baniva: aáta-pi
+    manao: ata
+    baré: adda
+    wapishana: ata-man
+    maipure: aá
+    terena: m-oto-ru
+    kinikinao: m-oto-ke
+    campa: ota-ki
+    machiguenga: ota-kyi
+    piro: m-ta
+    ipuriná: m-ata
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 144
+    ancla: The Caquetío stem -ada- is characteristic of Maipuran languages
+  confianza: alta
+  clave_origen: arbol
+  duda_del_autor: 'Sobre el par LK ada : WY ata'' ''árbol'' (p. 120): "It is not clear if this is a shift
+    in meaning or whether the recorder was given a term for the part (bark for tree) and interpreted for
+    the whole... For now, I do not count the pair of terms for ''tree'' as cognates." La cognación de
+    la RAÍZ no está en duda; lo que está en duda es contarlos como el mismo ítem léxico en la lexicoestadística.'
+  nota: 'CLAVE: "having the phoneme /d/ rather than /t/ appears to make it closer to Lokono than to Paraujano
+    or Guajiro" (p. 144). Es uno de los tres pilares de la filiación caquetío-lokono. Ver ANCLA_ARCO_NORTENO.'
+- id: cognado-005
+  glosa: auyama, calabaza de botella / calabacín
+  formas:
+    CQ: auyama
+    achagua: uyama
+    guarequena: uiiayama
+    baniva: ui-iama
+    yavitero: oyama
+    maipure: aviama
+    baria: ui-iama
+    mandauaca: ui-iama
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 145
+    ancla: Achagua has the term uyama as cognate of Caquetio's auyama
+  confianza: alta
+  clave_origen: calabaza
+  duda_del_autor: '"has been thoroughly incorporated to modern Venezuelan Spanish" (p. 144) — la forma
+    que conocemos pasó por el español, no la recogió un lingüista.'
+  no_cognado:
+    LK: hihuida
+    WY: kala'pua / wuirru
+    PJ: wüir
+    TN: wíro
+    piapoco: ayi
+  nota: 'Set NEGATIVO valioso: el caquetío se alinea con achagua/alto Negro y NO con lokono ni con el
+    par guajiro-paraujano-taíno (wuirru/wüir/wíro). Contradice parcialmente la tesis lokonoide del propio
+    Oliver: él no lo comenta.'
+- id: cognado-006
+  glosa: espíritu, diablo, duende (topónimo Capubana, Paraguaná)
+  formas:
+    CQ: capú
+    wapishana: capishi
+    baré: capuyo carlene
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 145
+    ancla: Capú is the Caquetío term which, according to a 1579 document
+  confianza: baja
+  clave_origen: espiritu_maligno
+  duda_del_autor: '"There is one caution, however. The Carib speaking Tamanaco have the term capu, /kapu/,
+    for ''sky''; therefore, the possibility of borrowing from Tamanaco (Carib) to Caquetío (Arawak) or
+    vice-versa cannot be discounted" (p. 145).'
+  nota: Oliver apoya la lectura arahuaca en el topónimo Capubana y en una leyenda moderna de duende que
+    él mismo oyó cerca de Santa Ana (Paraguaná) — evidencia etnográfica del s. XX, no filológica del XVI.
+- id: cognado-007
+  glosa: bachaco, hormiga roja grande (Atta sp.)
+  formas:
+    CQ: koke
+    LK: kuse
+    yavitero: hoke
+    maipure: kuki
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 145
+    ancla: The term coque or /koke/ is defined as
+  confianza: media
+  clave_origen: bachaco
+  duda_del_autor: 'El segundo set (mandauaca ko-oue, karru kabirri, baria kute, piapoco kahue, baniva
+    ()uehe) queda fuera: "the second /k/ is not found as in the former set, and the sound change can not
+    be explained (e.g. kabirri : koke)" (p. 146). Y advierte parecidos NO arahuacos: ye''kuana chauke,
+    karina kumako, yaruro kohi.'
+  nota: 'koke : hoke : kuki : kuse es el único subconjunto que Oliver sostiene.'
+- id: cognado-008
+  glosa: señor o cacique principal, al que otros caciques están sujetos
+  formas:
+    CQ: diao
+    LK: dai-yana-ho
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 146
+    ancla: 'DIAO: Lord or cacique of the zaquitios territory'
+  confianza: media
+  clave_origen: senor_diao
+  duda_del_autor: '"From the above I could suggest that Caquetío /d-ia(o)/ is cognate to the stem /d-ai-/
+    of Lokono" — formulación condicional, no afirmación.'
+  nota: 'Análisis de Oliver: /d-/ 1sg + raíz ''palabra/lengua'' (LK dia ''palabra'', adian ''lengua'',
+    wa-(a)dia-ni-wa ''nuestra lengua'') + /-(h)o/ nominalizador solemne. ES UNA ETIMOLOGÍA DISTINTA de
+    la de daitiao. Ver NUDO_DAITIAO.'
+- id: cognado-009
+  glosa: pariente o aliado ritual; el que presta su nombre (intercambio de nombres)
+  formas:
+    PA: '*-atti-'
+    CQ: daitiao
+    LK: da-tti / da-iti
+    TN: daitia-o / waitiao / watiao
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 147
+    ancla: This Taíno term is cognate to Caquetio daitiao
+  confianza: alta
+  clave_origen: pariente_aliado
+  duda_del_autor: 'Sobre datihao (n. 42, p. 146): "I have no absolute certainty that it belongs to a Caquetío
+    language since Oviedo only speaks --at that specific juncture-- of the Indians of Province of Venezuela
+    in general... He could very well have used Taíno to express the relationship". Concluye: "makes me
+    suspect that datihao was equally shared by both Taíno and Caquetío".'
+  nota: 'Morfología explícita: /wa- [gua-]/ = 3.ª persona plural; /da-/ = 1.ª persona singular. Las Casas
+    [1552] 1929 II:291 documenta el rito de intercambio de nombres entre Juan Ponce de León y el cacique
+    Agüeybaná (''se hicieron guaitiaos'').'
+- id: cognado-010
+  glosa: diente
+  formas:
+    PA: '*/a(r/l)i/'
+    CQ: dare
+    WY: t-ali
+    LK: d-ari
+    TN: m-a(h)i-te
+    PJ: t-a()i
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 147
+    ancla: in coastal Falcón we find the term dare for tooth
+  confianza: alta
+  clave_origen: diente
+  duda_del_autor: '"although it is known to just a few individuals in Paraguaná" — dato etnográfico del
+    s. XX recogido por el propio Oliver, no de crónica.'
+  nota: 'EL PAR MÁS PRODUCTIVO DEL CAPÍTULO. Cuatro lenguas con la misma raíz y el prefijo de 1sg contrastando:
+    CQ d- = LK d- ≠ WY t- = PJ t-. Sostiene C1 y falsifica la regla `^d → t` de REGLAS_LK_CQ. El lexicón
+    ya tiene `dare` vía Zavala #103; lo que faltaba era el par.'
+- id: cognado-011
+  glosa: fruto del cardón (pitahaya); lit. 'la hija del cardón'
+  formas:
+    CQ: dato
+    LK: -atti-
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 147
+    ancla: The other fruit is called in their Indian language as dato
+  confianza: media
+  clave_origen: fruto_cardon
+  duda_del_autor: '"Here it seems quite probable that, etymologically..." y "-ato probably relating to
+    Lokono -atti-". Oliver mismo lo llama "to put it tritely".'
+  nota: 'El otro fruto del mismo cardón, caduchi (''breva''), queda SIN etimología en Oliver. Ambos están
+    ya en el lexicón vía Zavala (#105, #55).'
+- id: cognado-012
+  glosa: chamán, piache
+  formas:
+    CQ: boratio
+    LK: -atti- + -hu
+    TN: -atti- + -hu
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 147
+    ancla: The term boratio for 'shaman' again includes the ubiquitous stem
+  confianza: media
+  clave_origen: chaman_boratio
+  nota: 'Descomposición: bor- + /-ati/ (parentesco) + /-(h)o/ nominalizador solemne (/-hu/ en taíno-lokono).
+    El primer segmento queda sin analizar. Distinto de `piache` (< PA *piay), que el proyecto ya tiene
+    en COGNADOS.'
+- id: cognado-013
+  glosa: ser vivo, criatura viviente (NO 'gente propia')
+  formas:
+    PA: '*/kake/i/-thi/-o/'
+    CQ: kaketío
+    LK: kakïtho
+    piro: kaxiti
+    ipuriná: kakiti
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 148
+    ancla: It is obvious that Lokono kakïtho is cognate of the Caquetío term
+  confianza: alta
+  clave_origen: persona_ser_vivo
+  no_cognado:
+    LK_alt: loko / loko-no
+  nota: 'CORRIGE COGNADOS[''persona''] del proyecto, que empareja CQ ''caquetio'' con LK ''lokono'', WY
+    ''wayuu'' y TN ''taino'' como autónimos paralelos con la glosa ''persona arahuaca, gente propia''.
+    Oliver dice tres cosas incompatibles con eso: (1) el cognado de kaketío es kakïtho, no lokono; (2)
+    kakïtho glosa ''ser vivo'' e incluye MÁS que loko; (3) loko-no y kaketío no son cognados entre sí.
+    Correspondencia derivada: CQ /t/ : LK /th/ (ver C4b).'
+- id: cognado-014
+  glosa: canal excavado para riego; presa
+  formas:
+    CQ: buko
+    LK: wáburúkku / wáboróko
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 148
+    ancla: defined the Caquetío term buco /buko/as a channel dug into the earth
+  confianza: media
+  clave_origen: canal_buco
+  duda_del_autor: '"These terms are probably cognate to Caquetío buko" — y el argumento es semántico (''sendero
+    angosto'' ≈ ''canal''), no fonológico.'
+  nota: 'Ballesteros [1550] vía Bécker 1950a. En el lexicón `buco` está etiquetado `caquetío` (no -atestiguado)
+    con la reserva de Alvarado 1921, que lo cree romance. Oliver aporta el lado arahuaco de la disputa:
+    NO la cierra.'
+- id: cognado-015
+  glosa: perro
+  formas:
+    PA: '*Africada-/i/-nV'
+    CQ: auri
+    PJ: -y-eri
+    CAIC: auri / auli
+    maipure: auri
+    achagua: auri
+    piapoco: auri
+    wapishana: a()ri-merak
+    cauyarí: cha-aw()i
+    guarequena: chi-nu/o
+    mandauaca: chi-nu/o
+    baniva: tsinu
+    werekena: tsinu
+    tariana: tsíinu
+    baré: shino
+    campa: o-chi-tu
+    matsigüenga: o-tsi-ti
+    amuesha: oo-che-k
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 151
+    ancla: The term for 'dog' in Caquetío is auri
+  confianza: alta
+  clave_origen: perro
+  duda_del_autor: 'El término lo halló en una lista de vocabulario CUYÓN, no caquetía: "there is little
+    doubt that the Cuyón borrowed the term from the neighboring Caquetío of Barquisimeto" — inferencia
+    por distribución geográfica, no atestación directa en boca caquetía.'
+  nota: 'INNOVACIÓN proto-norteña: auri/auli sustituye a la forma proto-arahuaca *Africada-i-nV, que sobrevive
+    en el Alto Río Negro. Es uno de los tres pilares de la filiación lokonoide del caquetío. El lexicón
+    NO tiene ninguna palabra caquetía para ''perro'' (solo el wayunaiki erü).'
+- id: cognado-016
+  glosa: mar
+  formas:
+    PA: '*para'
+    CQ: para
+    WY: palaa'
+    TN: bara-wa
+  fuente: atestiguado
+  procedencia:
+    obra: oliver-1989-cap2
+    pagina: 150
+    ancla: 'para- for ''sea'' [Guajiro: /palaa''/, Taíno: /bara-wa/]'
+  confianza: alta
+  clave_origen: mar
+  nota: 'Ya está en COGNADOS del proyecto (con LK bara, TN bagua). Oliver aporta TN bara-wa, más cercano
+    a bara que bagua. **Es la excepción a C3**: aquí el caquetío tiene /p/ donde el taíno tiene /b/. Oliver
+    no lo comenta.'
+- id: cognado-017
+  glosa: sol
+  formas:
+    PA: '*kali'
+    CQ: cazi
+    WY: kai
+    LK: adali
+    KL: wiru
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: sol
+- id: cognado-018
+  glosa: luna
+  formas:
+    PA: '*kati'
+    CQ: cati
+    WY: kachi
+    LK: katsi
+    KL: kati
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: luna
+- id: cognado-019
+  glosa: mar, agua extensa
+  formas:
+    PA: '*para'
+    CQ: para
+    WY: palaa
+    LK: bara
+    TN: bagua
+    KL: barana
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: mar
+- id: cognado-020
+  glosa: canoa, embarcación
+  formas:
+    PA: '*kanoa'
+    CQ: canoa
+    LK: kannoa
+    TN: canoa
+    KL: kanawa
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: canoa
+- id: cognado-021
+  glosa: hamaca, cama colgante
+  formas:
+    PA: '*hamaka'
+    CQ: hamaca
+    LK: hamaha
+    TN: hamaca
+    KL: hamaka
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: hamaca
+- id: cognado-022
+  glosa: casabe, pan de yuca
+  formas:
+    PA: '*kasabi'
+    CQ: casabe
+    LK: kasabi
+    TN: casabe
+    KL: kasabi
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: casabe
+- id: cognado-023
+  glosa: chamán, curandero, piache
+  formas:
+    PA: '*piay'
+    CQ: piache
+    LK: piaye
+    TN: bejique
+    KL: buyei
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: chaman
+- id: cognado-024
+  glosa: iguana (Iguana iguana)
+  formas:
+    PA: '*iwana'
+    WY: iwana
+    LK: iwana
+    TN: higuana
+    KL: iwana
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: iguana
+- id: cognado-025
+  glosa: caimán (Caiman crocodilus)
+  formas:
+    PA: '*kaiman'
+    LK: kaiman
+    TN: caiman
+    KL: kaiman
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: caiman
+- id: cognado-026
+  glosa: piedra, roca
+  formas:
+    PA: '*siba'
+    LK: siba
+    TN: siba
+    KL: siba
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: piedra
+- id: cognado-027
+  glosa: isla, cayo
+  formas:
+    PA: '*kairi'
+    CQ: cairi
+    LK: kairi
+    TN: cai
+    KL: kairi
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: isla
+- id: cognado-028
+  glosa: yuca, mandioca (Manihot esculenta)
+  formas:
+    PA: '*yuka'
+    CQ: yuca
+    LK: yuka
+    TN: yuca
+    KL: yuka
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: yuca
+- id: cognado-029
+  glosa: maíz (Zea mays)
+  formas:
+    PA: '*marisi'
+    LK: marisi
+    TN: maisi
+    KL: marisi
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: maiz
+- id: cognado-030
+  glosa: ají, pimienta (Capsicum sp.)
+  formas:
+    PA: '*achi'
+    LK: achi
+    TN: aji
+    KL: achi
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: aji
+- id: cognado-031
+  glosa: tabaco (Nicotiana tabacum)
+  formas:
+    PA: '*iuli'
+    LK: iuli
+    TN: cohiba
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: tabaco
+- id: cognado-032
+  glosa: sabana, llanura
+  formas:
+    PA: '*sallaba'
+    LK: sallaban
+    TN: sabana
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: sabana
+- id: cognado-033
+  glosa: barbacoa, parrilla, lugar de provisiones
+  formas:
+    PA: '*barraha-koa'
+    LK: barrahakoa
+    TN: barbacoa
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: barbacoa
+- id: cognado-034
+  glosa: persona arahuaca, gente propia
+  formas:
+    PA: '*lokono'
+    CQ: caquetio
+    WY: wayuu
+    LK: lokono
+    TN: taino
+    KL: kalinagu
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: persona
+- id: cognado-035
+  glosa: casa, vivienda
+  formas:
+    PA: '*isikoa'
+    LK: sikoa
+    TN: bohio
+    KL: ikoa
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: casa
+- id: cognado-036
+  glosa: agua, río
+  formas:
+    PA: '*tuna'
+    CQ: tuy
+    WY: wuin
+    LK: tuna
+    TN: tuna
+    KL: duna
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: agua_rio
+- id: cognado-037
+  glosa: padre
+  formas:
+    PA: '*itti'
+    CQ: tata
+    LK: itti
+    TN: taita
+    KL: baba
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: padre
+- id: cognado-038
+  glosa: madre
+  formas:
+    PA: '*uju'
+    LK: uju
+    KL: naha
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: madre
+- id: cognado-039
+  glosa: uno, un
+  formas:
+    PA: '*aba'
+    WY: aba
+    LK: abba
+    KL: aban
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: uno
+- id: cognado-040
+  glosa: dos
+  formas:
+    PA: '*biama'
+    LK: biama
+    TN: yamosa
+    KL: biama
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: dos
+- id: cognado-041
+  glosa: mano
+  formas:
+    PA: '*akkabu'
+    LK: akkabu
+    KL: akabi
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: mano
+- id: cognado-042
+  glosa: corazón, centro vital
+  formas:
+    PA: '*ukku'
+    LK: ukku
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: corazon
+- id: cognado-043
+  glosa: arco (arma)
+  formas:
+    PA: '*semaara-haaba'
+    LK: semaara-haaba
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: arco
+- id: cognado-044
+  glosa: flecha
+  formas:
+    PA: '*semaara'
+    LK: semaara
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: flecha
+- id: cognado-045
+  glosa: grande, de gran tamaño
+  formas:
+    PA: '*ipiru'
+    LK: firo
+    KL: firo
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: grande
+- id: cognado-046
+  glosa: no, negación (prefijo)
+  formas:
+    PA: '*ma'
+    WY: ma
+    LK: ma
+    TN: mayani
+    KL: ma
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: negacion
+- id: cognado-047
+  glosa: firmamento, bóveda celeste
+  formas:
+    PA: '*kassaku'
+    WY: siruma
+    LK: kassaku
+    KL: kasaku
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: firmamento
+- id: cognado-048
+  glosa: pez, pescado
+  formas:
+    PA: '*itime'
+    LK: itime
+    KL: pira
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: pez
+- id: cognado-049
+  glosa: fuego
+  formas:
+    PA: '*yuru'
+    WY: yuru
+    KL: iduru
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: fuego
+- id: cognado-050
+  glosa: Caribe, pueblo Kalinago (nombre arahuaco y autónimo)
+  formas:
+    CQ: karibna
+    LK: karibna
+    TN: caribe
+    KL: kalínagu
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: caribe_gente
+- id: cognado-052
+  glosa: persona, ser humano (registro femenino KL)
+  formas:
+    PA: '*hianaru'
+    LK: hianaro
+    KL: hiñaru
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: hombre_KL
+no_son_cognados:
+- id: cognado-051
+  glosa: quiripa, concha-moneda; medio de intercambio costero
+  formas:
+    CQ: quiripa
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: quiripa
+  diagnostico: NO está en VOCABULARIO_BASE — este registro es su única constancia; moverlo al lexicón
+    antes de retirarlo de aquí
+- id: cognado-053
+  glosa: hombre (registro masculino Kalinago, origen caribe)
+  formas:
+    KL: baruwa
+  fuente: reconstruido
+  procedencia: null
+  deuda: sin-procedencia
+  clave_origen: hombre_caribe
+  diagnostico: ya existe en VOCABULARIO_BASE — este registro sobra

--- a/proyecto-linguistico-caquetío/2-lengua/datos-de-lengua.md
+++ b/proyecto-linguistico-caquetío/2-lengua/datos-de-lengua.md
@@ -1,0 +1,152 @@
+---
+tipo: nota
+pregunta: "¿Dónde viven los cognados y los topónimos, y por qué ahí?"
+datos: [cognados.yaml, toponimos.yaml, morfemas.yaml]
+validador: curiana_sim/compilar_lengua.py
+medido: 2026-08-06
+---
+
+# Los datos de lengua — cognados, topónimos, morfemas
+
+> Todo lo de aquí se comprueba con `python curiana_sim/compilar_lengua.py`.
+
+## El cambio de fondo: citar pasa a ser comprobable
+
+Hasta ahora una cita era **texto libre**: `"Oliver 1989, cap. 3, p. 255"`. Nadie
+verificaba que esa obra existiera, ni que dos entradas que citan lo mismo lo
+escribieran igual.
+
+Con [[bibliografia|4-fuentes/bibliografia.yaml]], `procedencia.obra` es una
+**clave foránea** y el validador la comprueba. La cita deja de ser una promesa y
+pasa a ser una comprobación.
+
+```yaml
+procedencia: {obra: oliver-1989-cap2, pagina: 142, ancla: "the toponym bari-si-ki-meto"}
+```
+
+Y cuando no hay fuente, **hay que decirlo**:
+
+```yaml
+procedencia: null
+deuda: sin-procedencia
+```
+
+Un hueco declarado es dato; un hueco callado es una cita que no existe. El
+validador rechaza lo segundo.
+
+## Cognados: había dos almacenes, y el bueno no se usaba
+
+| | `COGNADOS` | `COGNADOS_OLIVER` |
+|---|---|---|
+| entradas | 37 | 16 |
+| procedencia | **ninguna, 0 de 37** | página, ancla, confianza, duda del autor |
+| lo usaba el motor | **sí** | no |
+
+El set que alimentaba `transducir()` y `reconstruir_caquetio()` no citaba nada;
+el que traía la página de Oliver —y hasta un campo para las dudas del propio
+Oliver— solo lo leía su minador. Estaba al revés.
+
+Ahora es uno: `cognados.yaml`, **51 cognados**, 16 con procedencia y 35 con la
+deuda declarada.
+
+### Tres decisiones de forma
+
+1. **Las lenguas son un mapa abierto**, no casillas fijas. Antes había `KL` en
+   un almacén, `PJ`/`CAIC` en el otro, y un dict `otros` como vía de escape para
+   todo lo demás: tres soluciones al mismo problema. Ahora hay una.
+
+   La distinción que sí importa es otra: los **códigos en mayúscula** (PA, CQ,
+   WY, LK, TN, KL, PJ, CAIC) son el núcleo sobre el que existen reglas de
+   transducción, y uno inventado ahí rompería `transducir()` en silencio — el
+   validador los vigila. Los **nombres en minúscula** son comparanda citada
+   (maipure, baré, wapishana, tariana… unas 24 lenguas arahuacas) y son libres a
+   propósito: cerrar esa lista obligaría a tocar el esquema cada vez que una
+   fuente cita una lengua nueva.
+
+2. **El id no es la glosa española.** Antes la clave era la glosa, y por eso
+   existía `rojo_almagre`: un desempate inventado para no chocar con `rojo`.
+
+3. **Lo que no es un cognado, no se llama cognado.** Dos entradas tenían una
+   sola lengua, así que no son relaciones. No se borraron —van a
+   `no_son_cognados` con su diagnóstico— porque no son el mismo caso:
+   - `baruwa` (KL, 'hombre') **ya está en `VOCABULARIO_BASE`**: aquí sobra.
+   - `quiripa` (CQ, concha-moneda) **no está en ninguna otra parte**: este
+     registro es su única constancia en el repo. Retirarlo perdería el dato.
+
+### Lo que queda abierto
+
+**`para` ('mar') estaba en los dos almacenes**, y las dos versiones son
+complementarias, no idénticas:
+
+| | Oliver (`cognado-016`) | curado (`cognado-019`) |
+|---|---|---|
+| aporta | procedencia (p.150), `TN bara-wa` | `LK bara`, `KL barana` |
+| dice del taíno | `bara-wa` | `bagua` |
+
+La propia nota de Oliver lo señala: *"Oliver aporta TN bara-wa, más cercano a
+bara que bagua"*. **Fusionarlas exige decidir cuál forma taína vale**, y eso es
+filología, no script. El validador lo reporta como aviso y ahí se queda.
+
+## Topónimos: el nivel era un campo disfrazado de tres contenedores
+
+`lexicon_toponimos.py` tenía **doce contenedores** para tres entidades y un poco
+de prosa. Para listar todos los topónimos había que unir `NIVEL_A`, `NIVEL_B` y
+`NIVEL_C`; añadir un nivel significaba crear un contenedor.
+
+Ahora: `toponimos.yaml` con **74 topónimos** y `nivel` como campo
+(A=6, B=8, C=13, descartado=47), más `morfemas.yaml` con los 10 formantes.
+
+Dos cosas que salieron al desarmarlo:
+
+- **`ANTROPONIMOS` no contenía antropónimos**: contenía `total`,
+  `con_glosa_descriptiva`, `resueltos`, un `detalle` anidado con los datos y dos
+  campos de prosa (`veredicto`, `consecuencia`). Dato, recuento y opinión en la
+  misma estructura. La prosa se queda en [[toponimia]]; un YAML no es sitio para
+  un veredicto.
+- **`TOTALES` declaraba `nivel_D: 47`** y ningún contenedor se llamaba así. El
+  número era correcto —47 es lo que expande `DESCARTES`—, pero apuntaba a un
+  nombre inexistente. Que la migración reproduzca los totales declarados
+  (74 procesados, 6/8/13/47) confirma que es fiel.
+
+Y el módulo entero, 739 líneas de análisis curado, **no lo importaba nadie**.
+
+## Qué sostiene cada obra, y la asimetría que enseña
+
+`medir_sostiene.py` cuenta el rastro de cada obra en las **cuatro esferas**:
+lexicón, corpus, cognados y topónimos.
+
+| Esferas que alimenta | Obras |
+|---|---|
+| tres | 2 — `oliver-1989-cap2`, `zavala-reyes-2015` |
+| dos | 6 |
+| **una sola** | **18** |
+| ninguna | 4 |
+
+**Dieciocho de treinta obras dejan rastro en una sola esfera.** Parte es real
+—un paper de genética no da topónimos— pero parte es que la minería se hacía
+con el lexicón en la cabeza y lo demás caía donde cayera.
+
+Y el `sostiene` del frontmatter, que se mantiene a mano, **ha derivado en 17 de
+30 obras**. Ejemplos: Alvarado declara 0 entradas de lexicón y se miden 22; van
+Buurt declara 0 y se miden 14; Oliver cap. 2 declara 2 hechos de corpus y se
+miden 16.
+
+> ⚠️ Esas dos columnas se miden por coincidencia del apellido sobre texto libre,
+> así que fallan **en las dos direcciones**: por defecto si la cita está escrita
+> de otra forma, por exceso si el apellido sale en prosa sin ser cita. Son
+> estimación, no cuenta. Cognados y topónimos sí son exactos, porque van por
+> clave foránea — que es justamente el argumento para migrar también corpus y
+> lexicón a `procedencia.obra`.
+
+## Lo que falta
+
+1. **Migrar `corpus` y `lexicón` a `procedencia.obra`.** Es lo que haría exactas
+   las cuatro columnas y cerraría el círculo.
+2. **Cambiar los consumidores.** `arahuaco_comparative.COGNADOS` todavía
+   alimenta `transducir()` desde el Python; el YAML existe pero nadie lo lee aún.
+   Antes de cambiarlo hay que congelar la salida actual con un test.
+3. **Decidir el caso `para`** y qué hacer con `quiripa`.
+
+## Enlaces
+
+[[lexicon]] · [[toponimia]] · [[metodo-comparativo]] · [[oliver-1989-cap2]] · [[ARQUITECTURA]] · [[HARNESS]]

--- a/proyecto-linguistico-caquetío/2-lengua/datos-de-lengua.md
+++ b/proyecto-linguistico-caquetío/2-lengua/datos-de-lengua.md
@@ -138,14 +138,44 @@ miden 16.
 > clave foránea — que es justamente el argumento para migrar también corpus y
 > lexicón a `procedencia.obra`.
 
+## El corpus, a medio migrar — y por qué a medias a propósito
+
+`migrar_corpus_procedencia.py` derivó la obra desde la `referencia` en prosa de
+los 161 hechos. Resultado:
+
+| | n | Qué pasa |
+|---|---|---|
+| citan **una** obra → migrados | **58** | `procedencia: {obra: …}` añadida |
+| citan **varias** → sin decidir | 38 | es la cadena de custodia, ver abajo |
+| sin obra reconocible | 65 | web, analogías, reconstrucciones |
+
+Los 38 ambiguos **no son un fallo del script**: son la cadena de custodia real
+del proyecto. `creencia-001` cita Arcaya, Jahn **y** Oviedo y Valdés porque el
+dato es de Oviedo y llega *vía* los otros dos. Elegir una por frecuencia
+falsearía justo lo que el proyecto más cuida. Necesitan un `procedencia` con
+`obra` + `via`, y decidir cuál es cuál es lectura, no script.
+
+> 📌 **La `referencia` en prosa no se toca, y no es transitorio.** Dice cosas
+> que un id no puede: la página, la cita textual, el «vía tal». Los dos campos
+> conviven — uno es para leer, el otro para comprobar.
+
+⚠️ Nota de método: la primera versión de la migración cargaba y volvía a volcar
+el YAML con `yaml.safe_dump`, y **reformateaba los archivos enteros** — los
+bloques `>` de `contenido` se volvían cadenas entrecomilladas y los comentarios
+de cabecera desaparecían. Sobre datos de investigación curados eso es
+inaceptable. La versión buena inserta el bloque **como texto**: el diff son 58
+inserciones y **cero borrados**.
+
 ## Lo que falta
 
-1. **Migrar `corpus` y `lexicón` a `procedencia.obra`.** Es lo que haría exactas
-   las cuatro columnas y cerraría el círculo.
-2. **Cambiar los consumidores.** `arahuaco_comparative.COGNADOS` todavía
+1. **Los 38 ambiguos**, con un `procedencia` que exprese la cadena
+   (`obra` + `via`).
+2. **El lexicón a `procedencia.obra`.** Es el que más entradas tiene (1413) y
+   el que peor se mide hoy por apellido.
+3. **Cambiar los consumidores.** `arahuaco_comparative.COGNADOS` todavía
    alimenta `transducir()` desde el Python; el YAML existe pero nadie lo lee aún.
    Antes de cambiarlo hay que congelar la salida actual con un test.
-3. **Decidir el caso `para`** y qué hacer con `quiripa`.
+4. **Decidir el caso `para`** y qué hacer con `quiripa`.
 
 ## Enlaces
 

--- a/proyecto-linguistico-caquetío/2-lengua/morfemas.yaml
+++ b/proyecto-linguistico-caquetío/2-lengua/morfemas.yaml
@@ -1,0 +1,157 @@
+meta:
+  generado_por: curiana_sim/migrar_toponimos.py
+  morfemas: 10
+  glosados: 6
+  sin_glosa: 4
+morfemas:
+- id: morfema-001
+  forma: -bacoa
+  glosado: true
+  glosa_inferida: bosque, arboleda; formante toponímico de 'paraje cubierto de'
+  estatus: 'CORROBORADO (no es nuevo: `bacoa` ya está en el lexicón como caquetío-atestiguado). Lo nuevo
+    es su uso SUFIJAL productivo, que REGLAS_ZAVALA no recoge.'
+  apoyos:
+  - adabacoa (Todo arboleda)
+  - guadabacoa (Arboleda)
+  - quibacoas (Bosques pedregosos)
+  - yacarebacoa (Pueblo del bosque)
+  contraejemplos:
+  - sazaribacoa (Río de los maizales) — la glosa no menciona bosque; encaja mejor con la acepción 'sitio
+    fértil' de la misma entrada
+  apoyo_externo:
+  - 'Alvarado 1921, vía van Buurt §10: `-baca` ''grupo, matorral, espesura'' en topónimos venezolanos
+    (Yatu Bacu, Dauguaraubaca)'
+  - 'insular sin glosa: Barbacoa (Aruba), Maniguacoa (Curaçao)'
+  recurrencia: 5
+  veredicto: 'El morfema mejor sostenido de todo el ejercicio: 5 topónimos glosados + apoyo independiente
+    de Alvarado.'
+- id: morfema-002
+  forma: -are
+  glosado: true
+  glosa_inferida: sitio de, paraje de (sufijo locativo)
+  estatus: NUEVO — despejado aquí por primera vez
+  apoyos:
+  - bobare (Sitio de cultivo)
+  - cabudare (sitio de cultivo)
+  - dabudare (Sitio de extracción de barro)
+  - pachacuare (Sitio de palmeras)
+  - taratarare (Hato, conuco — un hato es un lugar)
+  contraejemplos:
+  - guasare (Árbol cactáceo) — no denota lugar
+  - chunare (Mazorca tierna) — no denota lugar
+  recurrencia: 5
+  veredicto: 5 de 7 apariciones en posición final con glosa descriptiva denotan un LUGAR, y las 4 más
+    limpias dicen literalmente 'Sitio de'. `dabudare` es el caso decisivo porque su base `dabuda` 'barro
+    loza' ya está atestiguada.
+  conflicto: ⚠ van Buurt §5 recoge `-ure` (papiamentu -huri/-uri) glosado 'raíz' por Cruz Esteves 1989,
+    y lo declara equivalente al `-ure` continental. La evidencia toponímica dice 'sitio de'. Glosa en
+    disputa — misma situación que `-bana` (el tablero de decisiones D9).
+- id: morfema-003
+  forma: ada-
+  glosado: true
+  glosa_inferida: árbol
+  estatus: NUEVO en el caquetío — pero con cognado arahuaco fuerte
+  apoyos:
+  - adabacoa (Todo arboleda)
+  - guadabacoa (Arboleda)
+  apoyo_externo:
+  - Lokono `ada` 'árbol' (cognado arahuaco directo)
+  - van Buurt §5 documenta `bara`/`bari` 'árbol' (cf. Lokono balli) como OTRA raíz de árbol en el mismo
+    sistema — no compiten
+  recurrencia: 2
+  veredicto: Recurrencia mínima (2) pero con las dos glosas idénticas ('arboleda') y cognado arahuaco
+    de manual. B sólido.
+  advertencia: 'El despeje no es estrictamente forzoso: con `-bacoa` = ''arboleda'' por sí solo, `ada-`
+    podría ser cualquier otra cosa. Lo que lo sostiene es el cognado lokono, no la ecuación.'
+- id: morfema-004
+  forma: bari-
+  glosado: true
+  glosa_inferida: rojizo, turbio (del color del agua o de la tierra)
+  estatus: REAGRUPACIÓN de dos entradas ya existentes
+  apoyos:
+  - barisi (Región de tierras coloradas cerca del mar)
+  - bariquisimeto (Río de aguas turbias)
+  contraejemplos:
+  - el lexicón tiene además `bari` = 'vientre, barriga', homógrafo sin relación
+  recurrencia: 2
+  veredicto: 'Propone unificar `barici` ''agua turbia'' y `bariki` ''tierra colorada'' bajo una raíz `bari-`
+    + formantes. NO propone tocar el lexicón: propone la pregunta.'
+- id: morfema-005
+  forma: yacare
+  glosado: true
+  glosa_inferida: pueblo, poblado
+  estatus: NUEVO
+  apoyos:
+  - yacare (Pueblo. Caimán)
+  - yacarebacoa (Pueblo del bosque)
+  recurrencia: 2
+  veredicto: Cierra la ecuación de `yacarebacoa` sin residuo. Pero ver la advertencia de contaminación
+    tupí en NIVEL_B.
+- id: morfema-006
+  forma: wa-
+  glosado: true
+  glosa_inferida: prefijo de pluralidad / 'tener'
+  estatus: CORROBORADO (van Buurt §6, de Goeje 1928) — nuevo es el apoyo toponímico continental
+  apoyos:
+  - guadabacoa (Arboleda) frente a adabacoa (TODO arboleda)
+  - guamabatriba (Muchas tierras de cultivo)
+  contraejemplos:
+  - muchos topónimos en gua-/wa- sin glosa; el prefijo es demasiado frecuente para probar nada por sí
+    solo
+  recurrencia: 2
+  veredicto: C alto / B bajo. La pareja adabacoa~guadabacoa es elegante pero es UNA pareja.
+- id: morfema-007
+  forma: -shi / -chi
+  glosado: false
+  apariciones: 22
+  ejemplos:
+  - Balashi
+  - Hudishibana
+  - Arashi
+  - Bushiri
+  - Cadushi
+  - Canashito
+  - Cashunti
+  - Catashi
+  - Cudishi
+  - Macoshi
+  - Tibushi
+  - Teishi
+  - Sasarawichi
+  - Angochi
+  - Anamichi
+  nota: '**El formante más frecuente del corpus insular y nadie lo ha glosado.** Ni Gatschet, ni van Buurt,
+    ni Zavala. Es el objetivo nº 1 de cualquier minería futura de toponimia ABC.'
+- id: morfema-008
+  forma: -ari / -ri
+  glosado: false
+  apariciones: 7
+  ejemplos:
+  - Handebirari
+  - Kasiaari
+  - Yabarubari
+  - Arikurari
+  - Cubari
+  - Damari
+  - Kassibari
+  nota: van Buurt glosa `rí` 'fuerte, duro, durable' solo dentro de Casibari. Falta comprobar si vale
+    igual en los otros seis.
+- id: morfema-009
+  forma: -kuri / -curi
+  glosado: false
+  apariciones: 3
+  ejemplos:
+  - Warerukuri
+  - Antikuri
+  - Kamakuri
+  nota: ya señalado en SUFIJOS_NO_CODIFICADOS de lexicon_gatschet.
+- id: morfema-010
+  forma: -bari
+  glosado: false
+  apariciones: 3
+  ejemplos:
+  - Yabarubari
+  - Cubari
+  - Kassibari
+  nota: ⚠ INDICE_FUENTES ya concluyó que **`-bari` no es un afijo**; van Buurt lo explica como `bara`/`bari`
+    'árbol'. Coherente con que aparezca en posición final de topónimos.

--- a/proyecto-linguistico-caquetío/2-lengua/toponimos.yaml
+++ b/proyecto-linguistico-caquetío/2-lengua/toponimos.yaml
@@ -1,0 +1,790 @@
+meta:
+  generado_por: curiana_sim/migrar_toponimos.py
+  toponimos: 74
+  por_nivel:
+    A: 6
+    B: 8
+    C: 13
+    descartado: 47
+  con_procedencia: 14
+  corroboraciones_del_lexicon: 17
+  nota: 'El nivel de confianza es un CAMPO, no un contenedor: antes eran NIVEL_A/B/C separados y para
+    listar todos los topónimos había que unir tres dicts. La prosa (reduplicación, conflictos, veredicto
+    sobre antropónimos) vive en 2-lengua/toponimia.md, no aquí.'
+toponimos:
+- id: toponimo-001
+  forma: jurijurebo
+  nivel: A
+  clase: topónimo
+  glosa_fuente: Paso de los vientos
+  segmentacion: juri~juri + ebo
+  morfemas:
+    juri: 'viento, ventarrón  [lexicón, caquetío-atestiguado, Zavala #178]'
+    ebo: 'camino, paso, senda  [lexicón, caquetío-atestiguado, Zavala #117]'
+  glosa_reconstruida: viento(-viento) + paso = 'paso de los vientos'
+  razon: los dos morfemas ya estaban en el lexicón y la traducción cierra sin residuo. La reduplicación
+    juri~juri explica el PLURAL de la glosa ('los vientos', no 'el viento'); la segunda copia pierde la
+    vocal final por haplología (juri-jur-ebo).
+  observacion: Estaba archivado en TOPONIMOS_ZAVALA como 'glosa incierta' y fuera del habla. Es el caso
+    que originó toda la tarea F11.
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-002
+  forma: yacarebacoa
+  nivel: A
+  clase: topónimo
+  glosa_fuente: Pueblo del bosque
+  segmentacion: yacare + bacoa
+  morfemas:
+    yacare: pueblo  [despejado — ver MORFEMAS_DESPEJADOS]
+    bacoa: bosque, lugar, paraje, sitio fértil  [lexicón, caquetío-atestiguado]
+  glosa_reconstruida: pueblo + bosque = 'pueblo del bosque'
+  razon: '`yacare` aparece en el propio corpus de Zavala con glosa ''Pueblo. Caimán''; `bacoa` está en
+    el lexicón. La ecuación cierra pieza por pieza y en el mismo orden.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-003
+  forma: quibacoas
+  nivel: A
+  clase: topónimo
+  glosa_fuente: Bosques pedregosos
+  segmentacion: quiba + (b)acoa   [haplología de la sílaba -ba-]
+  morfemas:
+    quiba: piedra, roca  [lexicón `quiva`/`cuiva`; van Buurt §8 'siba or quiba means stone or rock']
+    bacoa: bosque, lugar, paraje, sitio fértil  [lexicón, caquetío-atestiguado]
+  glosa_reconstruida: piedra + bosque = 'bosques pedregosos'
+  razon: la `-s` final es plural castellano de Zavala, no caquetío. Resuelto, corrobora las dos piezas
+    a la vez.
+  observacion: '⚠ Resuelve un problema del lexicón: hay una entrada `quiba` = ''ayuda'' (Zavala #203)
+    y otra `quiva`/`cuiva` = ''piedra''. El topónimo, con glosa ''pedregosos'', confirma ''piedra'' —
+    y coincide con van Buurt. Ver CONFLICTOS.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-004
+  forma: cumarebo
+  nivel: A
+  clase: topónimo
+  glosa_fuente: Camino del cacique Cumare
+  segmentacion: Cumare + ebo
+  morfemas:
+    Cumare: antropónimo — la propia fuente lo identifica como el nombre del cacique
+    ebo: camino, paso, senda  [lexicón, caquetío-atestiguado]
+  glosa_reconstruida: Cumare + camino = 'camino de Cumare'
+  razon: 'la glosa NOMBRA su propia clave: Zavala dice de quién es el camino. El único morfema léxico
+    es `ebo`, y encaja. Segunda atestación independiente de `ebo` (la otra es `jurijurebo`).'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-005
+  forma: guacaubana
+  nivel: A
+  clase: topónimo
+  glosa_fuente: Río escondido
+  segmentacion: guaca/waka + -ubana
+  morfemas:
+    waka: subterráneo, bajo tierra  [van Buurt §6, vía Oliver 1989; sostiene `sawaka` 'inframundo']
+    -ubana: 'desinencia  [AFIJOS_ZAVALA, Zavala #265, sin valor precisado por la fuente]'
+  glosa_reconstruida: bajo tierra + (desinencia) = 'río escondido'
+  razon: '''escondido'' ← waka ''bajo tierra'' es una alineación limpia, y el compuesto recurre en la
+    isla: **Wakubana / Wacobana** (Aruba, mapa de 1825; Gatschet 1885 lo registra igual). Dos atestaciones
+    separadas por el mar y por 130 años.'
+  observacion: '⚠ A con reserva: `-ubana` sigue sin glosa, así que la parte ''río'' de la traducción NO
+    queda explicada por ningún morfema. La ecuación cierra a medias.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-006
+  forma: barisi
+  nivel: A
+  clase: topónimo
+  subtipo: identidad — corrobora, no descompone
+  glosa_fuente: Región de tierras coloradas cerca del mar
+  segmentacion: barisi (= `barici` del lexicón, misma forma)
+  morfemas:
+    barici: agua turbia, tierras coloradas rojizas  [lexicón, caquetío-atestiguado]
+  glosa_reconstruida: '''tierras coloradas'' ← barici, literal'
+  razon: 'no hay composición que resolver: el topónimo ES la palabra. Pero la coincidencia de glosa entre
+    la entrada del glosario y la del listado toponímico es corroboración interna, y no estaba registrada.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-007
+  forma: adabacoa
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Todo arboleda
+  segmentacion: ada + bacoa
+  despeja: ada
+  razon: con `bacoa` = 'bosque' ya puesto, el resto tiene que valer 'árbol'. Recurre en `guadabacoa` 'Arboleda'
+    (wa-ada-bacoa).
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-008
+  forma: guadabacoa
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Arboleda
+  segmentacion: wa- + ada + bacoa   [haplología de -a-]
+  despeja: ada
+  razon: segunda aparición de `ada`, con la misma glosa que la primera. El `wa-` inicial es el prefijo
+    de pluralidad de van Buurt §6 (de Goeje 1928), lo que explica que Zavala glose `adabacoa` 'TODO arboleda'
+    y este simplemente 'arboleda'.
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-009
+  forma: bobare
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Sitio de cultivo
+  segmentacion: bob(o) + -are
+  despeja: -are
+  razon: cuatro topónimos en -are glosados 'Sitio de X'.
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-010
+  forma: cabudare
+  nivel: B
+  clase: topónimo
+  glosa_fuente: sitio de cultivo
+  segmentacion: cabud- + -are
+  despeja: -are
+  razon: ídem.
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-011
+  forma: dabudare
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Sitio de extracción de barro
+  segmentacion: dabuda + -re
+  despeja: -are
+  razon: 'el mejor de los cuatro: `dabuda` = ''barro loza'' YA está en el lexicón como caquetío-atestiguado,
+    así que la ecuación deja el sufijo despejado contra un morfema conocido, no contra un hueco.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-012
+  forma: pachacuare
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Sitio de palmeras
+  segmentacion: pachacu + -are
+  despeja: -are
+  razon: ídem.
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-013
+  forma: bariquisimeto
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Río de aguas turbias
+  segmentacion: bari- + -quisimeto
+  despeja: bari-
+  razon: 'junto con `barisi` ''tierras coloradas'', dos topónimos donde `bari-` cubre el color rojizo/turbio.
+    El lexicón ya tiene `barici` ''agua turbia'' y `bariki` ''tierra colorada'': el par toponímico sugiere
+    que son **variantes de una misma raíz** `bari-`, no dos palabras.'
+  observacion: 'El residuo `-quisimeto` queda sin explicar y sin recurrencia: la parte ''río'' de la glosa
+    no se reconstruye.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-014
+  forma: yacare
+  nivel: B
+  clase: topónimo
+  glosa_fuente: Pueblo. Caimán
+  segmentacion: yacare (sin composición)
+  despeja: yacare
+  razon: la propia entrada glosa 'Pueblo', y `yacarebacoa` 'Pueblo del bosque' lo confirma en composición.
+    Dos apoyos.
+  observacion: '⚠ La glosa doble ''Pueblo. Caimán'' es sospechosa: *yacaré* ''caimán'' es un tupí-guaraní
+    panamericano que entró al español general. Puede haber contaminación de la glosa. El valor ''pueblo''
+    se apoya en `yacarebacoa`; el valor ''caimán'' NO se usa aquí.'
+  procedencia:
+    obra: zavala-reyes-2015
+- id: toponimo-015
+  forma: alaurima
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Río blanco o claro
+  segmentacion: alaur- + -ima
+  razon: '`-ima` ''humedad, quebrada'' (AFIJOS_ZAVALA #165, confirmado independientemente por van Buurt
+    §10 vía Onima) alinea con ''río''. `alaur-` = ''blanco/claro'' no recurre en ningún otro topónimo
+    del corpus: conjetura.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-016
+  forma: capadare
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Diente de tigre
+  segmentacion: capa- + dare
+  razon: '`dare` = ''diente'' está en el lexicón y alinea. `capa-` = ''tigre/jaguar'' cerraría la ecuación,
+    pero no recurre. Además el lexicón no tiene ninguna palabra para felino, así que no hay con qué contrastarlo.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-017
+  forma: sazaribacoa
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Río de los maizales
+  segmentacion: sazari- + bacoa
+  razon: '`sazari-` = ''maíz'' sería el despeje natural, pero no recurre y el lexicón no tiene la palabra
+    (solo derivados: `buriche` chicha de maíz, `amaca` sitio de moler maíz). Además la glosa no menciona
+    bosque, lo que tensiona el valor de `-bacoa`.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-018
+  forma: paraguana
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Rodeada del mar
+  segmentacion: para(gua) + -na
+  razon: corrobora `para`/`paragua` = 'mar' del lexicón. Pero 'rodeada' no queda explicada y `-na` es
+    demasiado frecuente (34 formas del corpus) para significar nada demostrable.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-019
+  forma: guamabatriba
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Muchas tierras de cultivo
+  segmentacion: wa- + mabatriba
+  razon: '`wa-` plural alinea con ''muchas''; el resto es un bloque de nueve caracteres sin recurrencia
+    ni paralelo. Se registra por el prefijo, no por el resto.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-020
+  forma: turijerebo
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Lugar de descanso
+  segmentacion: turije- + ebo
+  razon: tercera aparición de `-ebo`, pero con glosa 'lugar' y no 'camino'. Compatible por extensión ('paso'
+    → 'lugar de paso'), no demostrable.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-021
+  forma: guacurebo
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Quebrada que crece
+  segmentacion: guacu- + -rebo
+  razon: '**contraejemplo útil**: si `-ebo` fuera ''camino'', esta glosa no encaja. Registrado para que
+    la corroboración de `ebo` no se cuente más limpia de lo que es: 2 aciertos, 2 dudosos.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-022
+  forma: taratarare
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Hato, conuco
+  segmentacion: tara~tara (reduplicación) + -are
+  razon: 'reduplicación exacta clara + el sufijo locativo `-are`. La base `tara` no se puede fijar: el
+    lexicón dice ''venado'' y Zavala #238 dice ''langosta, mariposa'' — conflicto ya registrado en INDICE_FUENTES.'
+  eco_insular: 'van Buurt §8: Taratata / Tatarata (Aruba) y, en Falcón, Taratara, Taratare y Tatatarare
+    (Cruz Esteves 1989). **Cinco variantes reduplicadas del mismo tema.**'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-023
+  forma: poapao
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Serranía de Coro
+  segmentacion: poa~pao
+  razon: reduplicación parcial evidente; la glosa es un identificador geográfico, no una traducción, así
+    que no hay qué despejar.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-024
+  forma: jadicuar
+  nivel: C
+  clase: topónimo
+  glosa_fuente: Sitio donde abunda jajato. Salicornia fructuosa
+  segmentacion: jadi- + -cuar
+  razon: '`jajato` está en el lexicón (''chloris radiata, yerba forrajera, lugar de arena'') y `jadi-`~`jaja-`
+    podría ser la misma raíz, pero la correspondencia d~j no está documentada en ninguna de las tres ortografías.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-025
+  forma: chunare
+  nivel: C
+  clase: antropónimo
+  glosa_fuente: Apellido. Mazorca tierna
+  segmentacion: chu- + -nare
+  razon: '**el único antropónimo del corpus con glosa descriptiva.** No resuelve: ni `chu-` ni `-nare`
+    recurren con esa semántica, y ''mazorca'' no es un lugar, así que el `-are` locativo no aplica.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-026
+  forma: Casibari
+  nivel: C
+  clase: topónimo (Aruba)
+  glosa_fuente: '''there are hard rocks'''
+  segmentacion: ca- + siba + rí
+  razon: '**prueba de humo del método, no hallazgo**: van Buurt ya publicó esta etimología y de ella salieron
+    los morfemas del inventario. Que el segmentador la reproduzca valida el procedimiento; no aporta información
+    nueva.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-027
+  forma: Hudishibana
+  nivel: C
+  clase: topónimo (Aruba)
+  glosa_fuente: '''windy plain'''
+  segmentacion: hudi + -shi- + bana
+  razon: 'ídem. Interés adicional: `hudi` ''viento'' es la misma raíz que el `juri` continental de `jurijurebo`.
+    **La palabra para ''viento'' aparece en un topónimo del Golfete y en otro de Aruba, en dos ortografías
+    distintas.**'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-028
+  forma: baracoica (Cacique de Curazao)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-029
+  forma: huay (Nombre propio)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-030
+  forma: quiceraguru
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-031
+  forma: quiceroaboa
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-032
+  forma: quiceromata
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-033
+  forma: quiciroata
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-034
+  forma: quiquiba
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-035
+  forma: tamani
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-036
+  forma: timaure (Apellido)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-037
+  forma: tumarure (Apellido de un cacique)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-038
+  forma: xaraguamari (Cacique de Yaracuy)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-039
+  forma: yarosabana (Cacique de los Guaragua)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-040
+  forma: dabajuro (Población de Falcón)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-041
+  forma: doaca (Asiento indígena)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-042
+  forma: iboa (Comunidad indígena)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-043
+  forma: parotaima (Indígena del Yaracuy)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-044
+  forma: tabicure (Indio caquetío del valle de las Damas)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-045
+  forma: todarahuato (Indígena de la Vela)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-046
+  forma: yaracuy (Indígena del Valle de las Damas)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-047
+  forma: caquetio (Buena gente — etnónimo, no descripción del lugar)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-048
+  forma: xirahara (Población indígena vecina)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-049
+  forma: yaruca (Indígena caquetío)
+  nivel: descartado
+  clase: topónimo
+  razon: 'la glosa IDENTIFICA al referente (quién es, dónde queda) sin traducirlo. No hay ecuación bilingüe:
+    no hay significado que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-050
+  forma: cemirucos → 'Semerucos'
+  nivel: descartado
+  clase: topónimo
+  razon: la 'traducción' es el propio topónimo castellanizado. No aporta significado.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-051
+  forma: aruba → 'Oruba. Oruma. Oirubae'
+  nivel: descartado
+  clase: topónimo
+  razon: la 'traducción' es el propio topónimo castellanizado. No aporta significado.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-052
+  forma: coroque → 'Árbol de ¿?'
+  nivel: descartado
+  clase: topónimo
+  razon: Zavala deja la glosa incompleta; no hay con qué alinear.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-053
+  forma: zamurano ← esp. *zamuro* + -ano
+  nivel: descartado
+  clase: topónimo
+  razon: formación española sobre base indígena o no; la terminación delata la creación en español.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-054
+  forma: aburi (aguas de un río lleno de arena)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-055
+  forma: acatute (Pueblo entre valles)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-056
+  forma: alcaboa (Tierras solas o desiertas)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-057
+  forma: aricula (Punto de tierra)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-058
+  forma: guanajo (Cardón muy lanoso)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-059
+  forma: guasare (Árbol cactáceo)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-060
+  forma: siguruba (Salvar. Caserío)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-061
+  forma: tarai (Garipial o caripial)
+  nivel: descartado
+  clase: topónimo
+  razon: la glosa es descriptiva y utilizable, pero ninguna segmentación reconstruye nada. Son los que
+    quedan para una pasada futura con más morfemas en el inventario.
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-062
+  forma: Adicoura
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-063
+  forma: Amboïna
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-064
+  forma: Arashi
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-065
+  forma: Burubunu
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-066
+  forma: Buynari
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-067
+  forma: Curaçao
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-068
+  forma: Macuarima
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-069
+  forma: Matividiri
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-070
+  forma: Taratata
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-071
+  forma: Yatu Bacu
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-072
+  forma: Balashi
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-073
+  forma: Onima
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+- id: toponimo-074
+  forma: Cariatávo
+  nivel: descartado
+  clase: topónimo
+  razon: 'el comentario del autor es histórico o anecdótico, no etimológico: no hay glosa que despejar.'
+  procedencia: null
+  deuda: sin-procedencia
+corroboraciones_lexicon:
+- palabra: bacoa
+  glosa_lexicon: bosque, lugar, paraje, sitio fértil
+  toponimos:
+  - adabacoa
+  - guadabacoa
+  - quibacoas
+  - yacarebacoa
+  independencia: alta
+- palabra: ebo
+  glosa_lexicon: camino, paso, senda
+  toponimos:
+  - cumarebo
+  - jurijurebo
+  independencia: alta
+  nota: 'dos contraejemplos con glosa divergente: guacurebo, turijerebo'
+- palabra: juri
+  glosa_lexicon: viento, ventarrón
+  toponimos:
+  - jurijurebo
+  independencia: alta
+  nota: y eco insular en Hudishibana 'windy plain' (van Buurt)
+- palabra: quiva/quiba
+  glosa_lexicon: piedra
+  toponimos:
+  - quibacoas
+  independencia: alta
+  nota: ⚠ desambigua contra la entrada homógrafa `quiba` = 'ayuda'
+- palabra: barici
+  glosa_lexicon: agua turbia, tierras coloradas rojizas
+  toponimos:
+  - barisi
+  independencia: alta
+- palabra: bariki
+  glosa_lexicon: tierra colorada
+  toponimos:
+  - bariquisimeto
+  independencia: media
+- palabra: dabuda
+  glosa_lexicon: barro loza
+  toponimos:
+  - dabudare
+  independencia: alta
+- palabra: dare
+  glosa_lexicon: diente; hijo
+  toponimos:
+  - capadare
+  independencia: alta
+- palabra: para/paragua
+  glosa_lexicon: mar, agua extensa
+  toponimos:
+  - paraguana
+  independencia: alta
+- palabra: gua
+  glosa_lexicon: conuco, heredad, terreno cercado cultivado
+  toponimos:
+  - guamabatriba
+  independencia: media
+  nota: compite con el prefijo gua-/wa- de pluralidad
+- palabra: siba
+  glosa_lexicon: piedra, roca
+  toponimos:
+  - Casibari
+  independencia: NULA — van Buurt derivó el morfema DE este topónimo
+- palabra: ka-
+  glosa_lexicon: localizador 'hay'
+  toponimos:
+  - Casibari
+  independencia: NULA — ídem
+- palabra: rí
+  glosa_lexicon: fuerte, duro
+  toponimos:
+  - Casibari
+  independencia: NULA — ídem
+- palabra: bana
+  glosa_lexicon: ancho, llano
+  toponimos:
+  - Hudishibana
+  independencia: NULA — ídem
+- palabra: cari
+  glosa_lexicon: costa, orilla
+  toponimos:
+  - Cariatávo
+  independencia: NULA — ídem
+- palabra: bala
+  glosa_lexicon: el mar
+  toponimos:
+  - Balashi
+  independencia: NULA — ídem
+- palabra: -ima
+  glosa_lexicon: humedad, quebrada
+  toponimos:
+  - alaurima
+  - Onima
+  independencia: media
+  nota: '`alaurima` SÍ es independiente (Zavala); `Onima` no'

--- a/proyecto-linguistico-caquetío/3-mundo/corpus/creencia.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/creencia.yaml
@@ -50,6 +50,7 @@
     donde se cura.
   fuente: reconstruido
   referencia: "Perrin 1995, chamanismo wayuu (oütsü); analogía arahuaca"
+  procedencia: {obra: perrin-1992-1995}
   dominios: [creencia, medicina]
   agentes_relacionados: [Shaboro, Buio-sha]
   implicacion_simulacion: >
@@ -134,6 +135,7 @@
     parece al mal lo cura.
   fuente: reconstruido
   referencia: "Paz Reverol 2017 (ayülee vs wanülüü; homología wayuu)"
+  procedencia: {obra: paz-reverol-2017-2018}
   dominios: [creencia, medicina]
   agentes_relacionados: [Paugis-sha, Shaboro, Buio-sha]
   implicacion_simulacion: >
@@ -151,6 +153,7 @@
     mismo muerto es amenaza y guardián según se lo atienda.
   fuente: reconstruido
   referencia: "Paz Reverol 2017 (yoluja wayuu, ambivalentes)"
+  procedencia: {obra: paz-reverol-2017-2018}
   dominios: [creencia, muerte]
   agentes_relacionados: [Bana-mana, Paugis-sha, Shaboro]
   implicacion_simulacion: >
@@ -165,6 +168,7 @@
     o recorriendo el bosque y la sabana.
   fuente: atestiguado
   referencia: "Arcaya 1920:104-108 (indios de Coro/Falcón, síntesis de crónicas)"
+  procedencia: {obra: arcaya-1920}
   dominios: [creencia, muerte]
   agentes_relacionados: [Shaboro, Bana-mana]
   implicacion_simulacion: >
@@ -180,6 +184,7 @@
     en la otra vida".
   fuente: atestiguado
   referencia: "Arcaya 1920:103,110,117 (indios de Coro/Falcón)"
+  procedencia: {obra: arcaya-1920}
   dominios: [creencia, muerte]
   agentes_relacionados: [Shaboro]
   implicacion_simulacion: >
@@ -270,6 +275,7 @@
     o ancianos, por su relación con las fuerzas de la muerte y la sequía.
   fuente: reconstruido
   referencia: "Paz Reverol 2018 (exhumadora wayuu ligada a Pulowi; tabúes)"
+  procedencia: {obra: paz-reverol-2017-2018}
   dominios: [creencia, muerte]
   agentes_relacionados: [Paugis-sha, Sha-corie, Bana-mana]
   implicacion_simulacion: >
@@ -283,6 +289,7 @@
     lluvia que hace germinar la semilla.
   fuente: reconstruido
   referencia: "Paz Reverol 2018 citando Civrieux 1980 (cumanagotos); analogía regional"
+  procedencia: {obra: paz-reverol-2017-2018}
   dominios: [creencia, muerte, calendario]
   agentes_relacionados: [Corie-ko, Bana-mana, Shaboro]
   implicacion_simulacion: >
@@ -313,6 +320,7 @@
     ceremonias y transmisión oral.
   fuente: reconstruido
   referencia: "canon §2; Jahn 1927:384 (Bajada del Ches en enero, pueblos vecinos, como paralelo de rito estacional)"
+  procedencia: {obra: jahn-1927}
   dominios: [creencia, calendario]
   agentes_relacionados: [Shaboro, Manaure, Bana-mana]
   implicacion_simulacion: >
@@ -337,6 +345,7 @@
     oficial.
   fuente: retro-abstraido
   referencia: "Ferrándiz 1999 (Sorte); traza compatible con los 'espíritus dueños' del canon"
+  procedencia: {obra: maria-lionza-culto}
   dominios: [creencia]
   agentes_relacionados: [Shaboro, Manaure]
   implicacion_simulacion: >
@@ -352,6 +361,7 @@
     presencia caquetía en el valle.
   fuente: atestiguado
   referencia: "Zavala Reyes 2015, entradas 232 y 284 (Boletín Antropológico Nº 89, ULA)"
+  procedencia: {obra: zavala-reyes-2015}
   dominios: [creencia, geografia, lengua]
   agentes_relacionados: [Shaboro, Bana-mana]
   implicacion_simulacion: >
@@ -384,6 +394,7 @@
     del sustrato.
   fuente: retro-abstraido
   referencia: "Ferrándiz 1999; Fernández Quintana 2016; Pollak-Eltz 1972 (Corte India, invención s. XX)"
+  procedencia: {obra: maria-lionza-culto}
   dominios: [creencia, poder]
   agentes_relacionados: [Manaure]
   implicacion_simulacion: >
@@ -399,6 +410,7 @@
     candidatas a retro-abstracción del sustrato caquetío.
   fuente: retro-abstraido
   referencia: "Ferrándiz 1999; Clarac de Briceño 1970; Fernández Quintana 2016"
+  procedencia: {obra: maria-lionza-culto}
   dominios: [creencia]
   agentes_relacionados: []
   implicacion_simulacion: >

--- a/proyecto-linguistico-caquetío/3-mundo/corpus/ecologia.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/ecologia.yaml
@@ -34,6 +34,7 @@ entradas:
       arena que une Paraguaná al continente y separa el Golfete del Caribe abierto).
     fuente: atestiguado
     referencia: "Camacho et al. 2011, pp. 8–10"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia]
     agentes_relacionados: []
     palabra_lexicon: null
@@ -48,6 +49,7 @@ entradas:
       Parque Nacional Médanos de Coro.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, pp. 16–17"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia]
     agentes_relacionados: []
     palabra_lexicon: null
@@ -66,6 +68,7 @@ entradas:
       de arena móvil.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, pp. 10–11"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia]
     agentes_relacionados: []
     palabra_lexicon: null
@@ -79,6 +82,7 @@ entradas:
       que cualquier habitante haría a diario.
     fuente: reconstruido
     referencia: "Camacho et al. 2011, pp. 10–11, 16"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia]
     agentes_relacionados: [Suba-ko, Dara-bana]
     palabra_lexicon: null
@@ -96,6 +100,7 @@ entradas:
       evaporación potencial supera con mucho a la lluvia casi todo el año.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, pp. 8–9 (estación Coro); datos climáticos de Coro"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, clima]
     agentes_relacionados: []
     palabra_lexicon: joutai
@@ -109,6 +114,7 @@ entradas:
       del cielo, NO por la temperatura, que apenas se mueve.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, p. 9 (tablas de precipitación y temperatura, estación Coro)"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, clima]
     agentes_relacionados: [Shaboro, Corie-ko]
     palabra_lexicon: kaya
@@ -127,6 +133,7 @@ entradas:
       secan el resto del año. No hay un gran río perenne.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, p. 17 (Tabla 7); hidrología de Falcón / río Mitare"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, hidrologia]
     agentes_relacionados: []
     palabra_lexicon: bara
@@ -141,6 +148,7 @@ entradas:
       captura en el pulso húmedo y la administra durante la seca.
     fuente: reconstruido
     referencia: "Camacho et al. 2011 (clima/hidrología); lexicón atestiguado (buko, jaguey, jacuque)"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, hidrologia, agricultura]
     agentes_relacionados: [Buco-ko, Corie-ko, Ita-ko, Wari-ko]
     palabra_lexicon: buco
@@ -175,6 +183,7 @@ entradas:
       permite la gran cosecha de sal. En lluvias el salinar no produce.
     fuente: reconstruido
     referencia: "Camacho et al. 2011 (viento/clima); proceso evaporítico de Las Cumaraguas"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, salinas, clima]
     agentes_relacionados: [Biro-ko, Manaure, Watapana]
     palabra_lexicon: borojo
@@ -303,6 +312,7 @@ entradas:
       madera dura y medicina.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, p. 16 (flora de las dunas); lexicón caquetío atestiguado"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, flora, recoleccion]
     agentes_relacionados: [Suba-ko, Dara-ko, Paugis-sha]
     palabra_lexicon: watapana
@@ -331,6 +341,7 @@ entradas:
       hace navegable y peligroso el Golfete, y sostiene el eje insular.
     fuente: atestiguado
     referencia: "Camacho et al. 2011, pp. 9, 15 (viento ENE dominante todo el año)"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, clima, navegacion]
     agentes_relacionados: [Bagre-ko, Dara-bana, Watapana, Tari-ko]
     palabra_lexicon: joutai
@@ -523,6 +534,7 @@ entradas:
       de bosques de galería en los cauces, de la sierra, o por intercambio.
     fuente: reconstruido
     referencia: "Cruce entre maderas de canoa atestiguadas y la flora xerófila de Coro (Camacho et al. 2011; PN Médanos)"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, navegacion, comercio, oficios]
     agentes_relacionados: [Dara-ko, Nabaraka, Watapana, Tari-ko]
     palabra_lexicon: kuru
@@ -658,6 +670,7 @@ entradas:
       devastada desde 1500. El escenario es constante; el elenco no.
     fuente: reconstruido
     referencia: "Síntesis de Camacho et al. 2011 (geomorfología/clima) + historia ecológica del Caribe (s. XVI–XX)"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, fauna, metodo]
     agentes_relacionados: []
     palabra_lexicon: null
@@ -801,6 +814,7 @@ huecos_lexicos:
       tienen nombre.
     fuente: reconstruido
     referencia: "Camacho et al. 2011 (dunas); ausencia verificada en curiana_lexicon.py"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia]
     agentes_relacionados: [Suba-ko, Dara-bana]
     palabra_lexicon: null
@@ -832,6 +846,7 @@ huecos_lexicos:
       otro aire.
     fuente: reconstruido
     referencia: "Camacho et al. 2011 (viento ENE); ausencia verificada en curiana_lexicon.py"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, clima, navegacion]
     agentes_relacionados: [Dara-bana, Bagre-ko, Watapana]
     palabra_lexicon: null
@@ -888,6 +903,7 @@ huecos_lexicos:
       mangle y la distinción mangle rojo / negro quedan bajo el genérico mankaba.
     fuente: reconstruido
     referencia: "Camacho et al. 2011 (istmo); ausencia verificada en curiana_lexicon.py"
+    procedencia: {obra: camacho-2011}
     dominios: [ecologia, geografia, manglar]
     agentes_relacionados: [Dara-bana, Suba-ko]
     palabra_lexicon: null

--- a/proyecto-linguistico-caquetío/3-mundo/corpus/geografia_politica.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/geografia_politica.yaml
@@ -13,6 +13,7 @@
     préstamos léxicos caquetíos que sobreviven en el papiamento.
   fuente: atestiguado
   referencia: "Van Buurt, Gerard (2014), \"Caquetío Indians on Curaçao during colonial times and Caquetío words in the Papiamentu language\" (VanBuurt_2014_CaquetioWords_Papiamentu.txt, ya en fuentes_caquetios/)"
+  procedencia: {obra: van-buurt-2014}
   dominios: [politica, geografia, comercio]
   agentes_relacionados: [Kadushi, Watapana]
   implicacion_simulacion: >
@@ -117,6 +118,7 @@
     asentados los caquetíos" — no el nombre de un asentamiento puntual conocido.
   fuente: atestiguado
   referencia: "Zavala Reyes 2015, nota al pie (4): \"Curiana: territorio donde estaban asentados los caquetíos\""
+  procedencia: {obra: zavala-reyes-2015}
   dominios: [politica, geografia, lenguaje]
   agentes_relacionados: []
   implicacion_simulacion: >
@@ -136,6 +138,7 @@
     "managuanare" y "managuarire".
   fuente: atestiguado
   referencia: "González, Carlos, estudio histórico del PLINCODE, p. 23, citado en Zavala Reyes 2015, nota al pie (2)"
+  procedencia: {obra: zavala-reyes-2015}
   dominios: [politica, lenguaje]
   agentes_relacionados: [Manaure]
   implicacion_simulacion: >

--- a/proyecto-linguistico-caquetío/3-mundo/corpus/parentesco.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/parentesco.yaml
@@ -74,6 +74,7 @@
     percibido como en declive en 1927.
   fuente: reconstruido
   referencia: "analogía wayuu: Jahn 1927, p. 172 (\"la herencia del nombre y nacionalidad materno constituían un definido matriarcado\")"
+  procedencia: {obra: jahn-1927}
   dominios: [parentesco]
   agentes_relacionados: [Nubiri-sha]
   implicacion_simulacion: >
@@ -112,6 +113,7 @@
     (linaje) distinta a la del marido.
   fuente: reconstruido
   referencia: "analogía wayuu: Jahn 1927, p. 172 (\"ley de matrimonio exógamo... la mujer había de ser de una parcialidad distinta a la del marido\")"
+  procedencia: {obra: jahn-1927}
   dominios: [parentesco]
   agentes_relacionados: []
   implicacion_simulacion: >
@@ -125,6 +127,7 @@
     levirato distinto y complementario al caso de la viuda de Manaure documentado por Oliver.
   fuente: reconstruido
   referencia: "analogía wayuu: Jahn 1927, pp. 172-173"
+  procedencia: {obra: jahn-1927}
   dominios: [parentesco]
   agentes_relacionados: []
   implicacion_simulacion: >
@@ -138,6 +141,7 @@
     vínculo avuncular.
   fuente: reconstruido
   referencia: "analogía wayuu: Jahn 1927, p. 171"
+  procedencia: {obra: jahn-1927}
   dominios: [parentesco, cosmos]
   agentes_relacionados: [Chiriguare, Chiri-ko]
   implicacion_simulacion: >
@@ -152,6 +156,7 @@
     cargada que el hermano del padre.
   fuente: reconstruido
   referencia: "analogía wayuu: Jahn 1927, pp. 438-439 (patrón estructural; formas léxicas exactas no reconstruidas por desalineación de la extracción del PDF, ver hoja de fuentes)"
+  procedencia: {obra: jahn-1927}
   dominios: [parentesco, lenguaje]
   agentes_relacionados: []
   implicacion_simulacion: >
@@ -177,6 +182,7 @@
     de Coro sobre instituciones familiares caquetías.
   fuente: atestiguado
   referencia: "Arcaya 1920, p. 128"
+  procedencia: {obra: arcaya-1920}
   dominios: [parentesco]
   agentes_relacionados: [Manaure]
   implicacion_simulacion: >
@@ -190,6 +196,7 @@
     intuición sin desarrollar de la historiografía venezolana temprana.
   fuente: atestiguado
   referencia: "Arcaya 1920, p. 127 (\"es posible que las diferencias del tatuage correspondiesen más bien a distinciones de clanes\")"
+  procedencia: {obra: arcaya-1920}
   dominios: [parentesco]
   agentes_relacionados: []
   implicacion_simulacion: >
@@ -268,6 +275,7 @@
     debate historiográfico temprano.
   fuente: atestiguado
   referencia: "Arcaya 1920, p. 119, citando a Salas, \"Tierra Firme\""
+  procedencia: {obra: arcaya-1920}
   dominios: [parentesco]
   agentes_relacionados: [Nabaraka, Raka-bi, Chorota]
   implicacion_simulacion: >
@@ -378,6 +386,7 @@
     que el linaje de la madre de sus hijos les diera derecho por cuenta propia.
   fuente: reconstruido
   referencia: "analogía taína: Keegan 1989, The Evolution of Avunculocal Chiefdoms, American Anthropologist 91(3) — identificado vía búsqueda web, no consultado en texto completo (ver hoja de fuentes)"
+  procedencia: {obra: keegan-1989}
   dominios: [parentesco, politica]
   agentes_relacionados: [Manaure, Nubiri-sha]
   implicacion_simulacion: >
@@ -418,6 +427,7 @@
     ajena.
   fuente: reconstruido
   referencia: "analogía kalinago: Adam 1879 (en fuentes_caquetios/), pp. 275-302, citando Breton 1665 y Labat; corroborado por literatura etnohistórica secundaria sobre la expansión caribe del s. XIV en las Antillas Menores (ver hoja de fuentes). Dato sobre los kalinago, no sobre los caquetíos"
+  procedencia: {obra: adam-1879}
   dominios: [parentesco, lenguaje, politica]
   agentes_relacionados: [Marokoto-ni, Chiriguare]
   implicacion_simulacion: >
@@ -553,6 +563,7 @@
     a nivel de facción/linaje dentro de un asentamiento, no de todo un asentamiento o territorio.
   fuente: atestiguado
   referencia: "Zavala Reyes 2015, p.65 (glosario, entrada 12: \"Apopo (AM): Nombre de jefe de parcialidad pequeña\")"
+  procedencia: {obra: zavala-reyes-2015}
   dominios: [parentesco, politica, lenguaje]
   agentes_relacionados: [Corie-ko, Chiriguare, Paugis-sha, Sha-corie]
   implicacion_simulacion: >
@@ -625,6 +636,7 @@
     hijos.
   fuente: hipotetico
   referencia: "síntesis de esta sesión sobre comparanda ashanti (consejo de ancianos elige/puede destituir entre candidatos matrilineales elegibles) y Keegan 1989 sobre política de élite taína (ver hoja de fuentes 05); no hay dato caquetío directo sobre pluralidad de candidatos"
+  procedencia: {obra: keegan-1989}
   dominios: [parentesco, politica]
   agentes_relacionados: [Manaure]
   implicacion_simulacion: >

--- a/proyecto-linguistico-caquetío/3-mundo/corpus/transmision.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/corpus/transmision.yaml
@@ -326,6 +326,7 @@
     cacique" — genealogía política cantada ante toda la comunidad.
   fuente: atestiguado
   referencia: "Anglería, Fuentes Históricas sobre Colón y América (1892 [c.1530]), vol. 4, p. 236"
+  procedencia: {obra: angleria-1892}
   dominios: [transmision, genealogia, cancion]
   agentes_relacionados: [Bana-mana, Manaure]
   forma_transmision: genealogia_recitada
@@ -346,6 +347,7 @@
     ley sin código escrito, aplicada caso por caso por los mayores.
   fuente: atestiguado
   referencia: "Jahn (1927), Los aborígenes del occidente de Venezuela, pp. 205-207"
+  procedencia: {obra: jahn-1927}
   dominios: [transmision, derecho_consuetudinario, matrilinealidad]
   agentes_relacionados: [Sha-corie, Paugis-sha, Nubiri-sha]
   forma_transmision: consejo
@@ -370,6 +372,7 @@
     presentación pública, el ajuitis.
   fuente: atestiguado
   referencia: "Jahn (1927), Los aborígenes del occidente de Venezuela, pp. 208-211"
+  procedencia: {obra: jahn-1927}
   dominios: [transmision, genero, iniciacion, comparanda_wayuu]
   agentes_relacionados: [Buio-sha, Sha, Sha-corie, Paugis-sha]
   forma_transmision: iniciacion
@@ -391,6 +394,7 @@
     españoles bautismales en el trato cotidiano.
   fuente: atestiguado
   referencia: "Jahn (1927), Los aborígenes del occidente de Venezuela, p. 206"
+  procedencia: {obra: jahn-1927}
   dominios: [transmision, lengua, tabu, cosmologia]
   agentes_relacionados: [Bana-mana]
   forma_transmision: genealogia_recitada
@@ -410,6 +414,7 @@
     resiste la deriva; la segunda se parafrasea con cada repetición.
   fuente: reconstruido
   referencia: "Vansina, Jan (1985), Oral Tradition as History, Univ. of Wisconsin Press"
+  procedencia: {obra: vansina-ong}
   dominios: [transmision, teoria]
   agentes_relacionados: []
   forma_transmision: cancion
@@ -483,6 +488,7 @@
     enseña sobre sus antepasados, guerras, orígenes".
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), Las pautas de crianza del pueblo wayuu, UNICEF, p. 40 (cita a González 1973)"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, curriculo_edad, genero, comparanda_wayuu]
   agentes_relacionados: [Nubi, Buco, Daru, Dare-nu, Piri]
   forma_transmision: aprendizaje_oficio
@@ -502,6 +508,7 @@
     biológico: tiene nombre, y cambiar de etapa es cambiar de palabra.
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), pp. 23-24"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, curriculo_edad, lengua, comparanda_wayuu]
   agentes_relacionados: []
   forma_transmision: consejo
@@ -523,6 +530,7 @@
     todo cuando se trata del tío o la tía maternos".
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), pp. 40-41"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, matrilinealidad, curriculo_edad, comparanda_wayuu]
   agentes_relacionados: [Chiriguare, Chiri-ko, Nabaraka, Raka-bi]
   forma_transmision: aprendizaje_oficio
@@ -546,6 +554,7 @@
     las madres de cuidar bien el encierro de las hijas".
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), pp. 44-45, 49-51; converge con Jahn (1927), pp. 208-211"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, genero, iniciacion, comparanda_wayuu]
   agentes_relacionados: [Sha, Tawi, Kori, Sha-corie, Paugis-sha]
   forma_transmision: iniciacion
@@ -569,6 +578,7 @@
     conozcan las cadenas completas de parientes maternos y paternos.
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), pp. 40, 42-43, 45"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, ritual, genealogia, comparanda_wayuu]
   agentes_relacionados: [Bana-mana, Sha-corie, Wama-sha, Sha, Nubi, Tawi, Buco, Piru]
   forma_transmision: genealogia_recitada
@@ -592,6 +602,7 @@
     incluido el cambio de identidad.
   fuente: atestiguado
   referencia: "Amodio y Pérez (2006), pp. 41-42 (cita versión de María Manuela de Cora, 1972)"
+  procedencia: {obra: amodio-perez-2006}
   dominios: [transmision, piazgo, cosmologia, comparanda_wayuu]
   agentes_relacionados: [Shaboro, Buio-sha]
   forma_transmision: iniciacion
@@ -622,6 +633,7 @@
     Inmaterial de la Humanidad (UNESCO, 2010).
   fuente: atestiguado
   referencia: "Mincultura Colombia, cuadernillo Pütchipü'üi (investigación de Guerra Curvelo 2002); UNESCO ICH 00435; fuentes_caquetios/GuerraCurvelo_ref_2023_Cuadernillo_Sistema_Normativo_Wayuu_Palabrero.pdf"
+  procedencia: {obra: guerra-curvelo-palabrero}
   dominios: [transmision, derecho_consuetudinario, lengua, comparanda_wayuu]
   agentes_relacionados: [Manaure, Nubiri-sha]
   forma_transmision: consejo
@@ -650,6 +662,7 @@
     que el palabrero dibuja símbolos en la tierra mientras escucha.
   fuente: atestiguado
   referencia: "Mincultura Colombia, cuadernillo Pütchipü'üi (Guerra Curvelo 2002)"
+  procedencia: {obra: guerra-curvelo-palabrero}
   dominios: [transmision, derecho_consuetudinario, cosmologia, comparanda_wayuu]
   agentes_relacionados: [Nubiri-sha, Sha-corie]
   forma_transmision: consejo
@@ -678,6 +691,7 @@
     colectiva frágil".
   fuente: atestiguado
   referencia: "Mincultura Colombia, cuadernillo Pütchipü'üi (Guerra Curvelo 2002)"
+  procedencia: {obra: guerra-curvelo-palabrero}
   dominios: [transmision, piazgo, cosmologia, genero, comparanda_wayuu]
   agentes_relacionados: [Shaboro, Buio-sha, Paugis-sha]
   forma_transmision: relato
@@ -705,6 +719,7 @@
     reconciliar) pero desde la autoridad, no desde la neutralidad.
   fuente: reconstruido
   referencia: "Contraste estructural: cuadernillo Mincultura (Guerra Curvelo 2002) vs. CULTURA_CAQUETIA.md §6 (cacicazgo); Castellanos c.1589 sobre el Manaure histórico"
+  procedencia: {obra: guerra-curvelo-palabrero}
   dominios: [transmision, derecho_consuetudinario, politica, comparanda_wayuu]
   agentes_relacionados: [Manaure, Shaboro, Nubiri-sha]
   forma_transmision: consejo

--- a/proyecto-linguistico-caquetío/3-mundo/cronista.md
+++ b/proyecto-linguistico-caquetío/3-mundo/cronista.md
@@ -1,0 +1,114 @@
+---
+tipo: nota
+pregunta: "¿Se puede contar esto desde dentro sin inventarlo?"
+motor: curiana_sim/curiana_cronista.py
+sustituciones: 8
+medido: 2026-08-06
+---
+
+# El cronista — contar desde dentro sin inventar
+
+> `python curiana_sim/curiana_cronista.py --glosario` · `--check` verifica la
+> tabla contra el lexicón y la bibliografía.
+
+## El problema, y no es ideológico
+
+Todo lo que sabemos del caquetío llega en la lengua y las categorías de quien
+vino a conquistarlo. Eso no es una queja: es medible, y este proyecto ya se lo
+venía encontrando de frente sin llamarlo por su nombre.
+
+- **Oviedo y Valdés describe la cura del boratio y llama truco al paso final**
+  (*"sin que ninguno lo vea"*, *"para hacerlo creer al enfermo"*). La extracción
+  del objeto patógeno está documentada en medio continente. El dato del rito es
+  utilizable; **el juicio sobre el rito, no** — eso ya estaba escrito en
+  [[arcaya-1920]] antes de que existiera esta nota.
+- **Oliver compara Barquisimeto con el *Big Man* melanesio**, y él mismo rechaza
+  el "Cacicazgo Teocrático" de Steward y Faron porque *"blurs the differences
+  that make a difference"*: una tipología occidental aplanando lo que quería
+  describir.
+- **Las palabras mismas.** `piache` es voz cháima y tamanaca que difundieron los
+  españoles ([[jahn-1927]] n.28, corroborando a [[alvarado-1921]]); `cacique` es
+  taína. Ninguna de las dos es caquetía. Las suyas son `boratio`, `diao`,
+  `apopo` — y el proyecto ya las tenía.
+- **Y las glosas del propio lexicón arrastran el marco**: `capu` se glosa como
+  *"demonio"*, que es la palabra de Oviedo; `buio` como *"diablo, dios del mal"*,
+  que son categorías cristianas.
+
+Ese último punto es el que más dice: **guardábamos las palabras correctas y las
+explicábamos con el vocabulario del colonizador.**
+
+## Lo que este cronista NO es
+
+**No recupera la voz caquetía.** No se puede: la lengua está extinta y no existe
+un solo texto escrito por un caquetío. Lo que hay es lo que escribieron sus
+conquistadores. Cualquiera que diga que entrega "la mirada caquetía" está
+fabricando, y este proyecto no hace eso — es justo lo que lo separa de la
+fanfiction.
+
+## Lo que sí hace, y es comprobable
+
+1. **Nombrar con sus palabras** donde las tenemos atestiguadas.
+2. **Quitar el juicio del observador** y quedarse con lo observado.
+3. **Poner en el centro sus preguntas** —la lluvia, la sal, el agua, el linaje
+   de la madre, dónde queda el `barsure` de los muertos— en vez de las del
+   cronista español: el oro, la sumisión, la idolatría.
+4. **Decir cuándo no sabemos.** «No sé», «se cuenta que» y «los viejos dicen»
+   significan tres cosas distintas, y el cronista las distingue.
+
+Y una cosa más, que es la única continuidad real que existe: **Paraguaná**. No
+es la voz de ellos, pero es la misma tierra, el mismo mar, y voces que
+sobrevivieron en el habla de la región. Ver
+[[02_protocolo_habla_paraguanera]].
+
+## La tabla, que es lo operativo
+
+Ocho sustituciones, cada una con de dónde viene la palabra ajena y quién lo
+dice. **`--check` verifica que la palabra propuesta exista en el lexicón, que la
+ajena no esté en el habla activa como caquetía, y que la obra citada esté en la
+bibliografía.** Sin esa verificación sería una opinión; con ella es una
+afirmación sobre el dato que se cae sola si el dato cambia.
+
+| La fuente dice | Nosotros decimos | Por qué |
+|---|---|---|
+| piache | **boratio** | voz cháima y tamanaca, difundida por los españoles |
+| cacique | **diao** (y `apopo`) | voz taína; «cacique» aplana dos cargos en uno |
+| demonio | **capu** | categoría cristiana. Y le dieron ese nombre **a los españoles también** |
+| hechicero, brujería | **boratio** | juicio del cronista sobre un oficio de médico y adivino |
+| ídolo, idolatría | *(no hay)* | Arcaya mismo anota que no había culto comunal ni templos |
+| tribu, cacicazgo teocrático | **polity** (4) | tipología de Steward y Faron que Oliver rechaza |
+| vasallo, súbdito | *(no hay)* | a Manaure lo llevaban «en hombros de caciques»: señores, no criados |
+| el desierto, la tierra estéril | **biro · para · duna** | veredicto agrícola español. Para quien vive de la sal y del mar, esa costa es rica |
+
+La última fila es la que más rinde narrativamente: **la pobreza estaba en los
+ojos de quien buscaba trigo.**
+
+## El límite duro
+
+> **Lo que el cronista dice NUNCA es un dato.** Es una lectura. No entra al
+> corpus, no se cita como fuente, no asciende de etiqueta.
+
+Si algo que dijo el cronista acaba en `3-mundo/corpus/` como `atestiguado`, el
+proyecto pierde lo que lo hacía investigación. Hay tests que fijan esa regla en
+el prompt, incluido uno que comprueba que **no promete recuperar la voz
+caquetía**.
+
+Y una prohibición más, que no es epistémica sino de tono: **no romantizar**. Hay
+hambre, hay raids que se llevan mujeres, hay muertos. Contar desde dentro no es
+contar bonito — es la misma regla anti-romantización que ya tenía
+[[CULTURA_CAQUETIA]] §7.
+
+## Por dónde seguir
+
+1. **Cablearlo al motor.** Hoy el prompt existe y nadie lo invoca; el sitio
+   natural es un reporte de fin de run que cuente el año desde dentro, al lado
+   del reporte analítico que ya existe.
+2. **Ampliar la tabla** conforme aparezcan más marcos importados. Candidatos que
+   ya se han visto: «naboria», «provincia», «señor de vasallos».
+3. **Limpiar las glosas del lexicón.** `capu` = "demonio" y `buio` = "diablo,
+   dios del mal" siguen escritas en el marco ajeno. Es una decisión de canon,
+   porque toca 1413 entradas y el scoring.
+4. **La sesión de Paraguaná**, que es la continuidad real y sigue pendiente.
+
+## Enlaces
+
+[[CULTURA_CAQUETIA]] · [[polities-caquetias]] · [[arcaya-1920]] · [[jahn-1927]] · [[02_protocolo_habla_paraguanera]] · [[mapa-creencia]]

--- a/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
+++ b/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
@@ -1,0 +1,389 @@
+meta:
+  generado_por: curiana_sim/generar_bibliografia.py
+  obras: 30
+  en_repo: 24
+  solo_citadas: 6
+  nota: 'Generado desde el frontmatter de 4-fuentes/*.md. No editar a mano: se edita la nota y se regenera.
+    El `id` es la clave que citan el corpus, el lexicón, los cognados y los topónimos.'
+obras:
+- id: adam-1879
+  obra: Du parler des hommes et du parler des femmes dans la langue caraïbe
+  autor: Adam, Lucien
+  anio: 1879
+  publicacion: Revue de Linguistique et de Philologie Comparée XII, fasc. 3, pp. 275-304
+  genero: linguistica-comparativa
+  local:
+  - fuentes_caquetios/Adam_1879_Parler_hommes_femmes_langue_caraibe.pdf
+  paginas: 27
+  aliases:
+  - Adam 1879
+  en_repo: true
+- id: alvarado-1921
+  obra: Glosario de voces indígenas de Venezuela
+  autor: Alvarado, Lisandro
+  anio: 1921
+  genero: glosario
+  local:
+  - fuentes_caquetios/Alvarado_1921_Glosario_Voces_Indigenas_Venezuela.pdf
+  paginas: 354
+  aliases:
+  - Alvarado 1921
+  - Glosario de voces indígenas
+  en_repo: true
+- id: amodio-perez-2006
+  obra: Las pautas de crianza del pueblo wayuu de Venezuela
+  autor: Amodio, Emanuele y Pérez, Luis Adolfo
+  anio: 2006
+  publicacion: UNICEF / Ministerio de Educación y Deportes, Caracas
+  genero: etnografia
+  paginas: ~10 (monografía)
+  acceso: PDF público (guao.org) — descargado y leído completo en la sesión 4; NO archivado en el repo
+  aliases:
+  - Amodio y Pérez 2006
+  - Pautas de crianza wayuu
+  en_repo: false
+- id: angleria-1892
+  obra: Fuentes Históricas sobre Colón y América (Décadas del Nuevo Mundo), vols. 1 y 4
+  autor: Anglería, Pedro Mártir de
+  anio: 1892 [c. 1530]
+  genero: cronica
+  local:
+  - fuentes_caquetios/Angleria_1892_Fuentes_Historicas_Colon_America_vol1.pdf
+  - fuentes_caquetios/Angleria_1892_Fuentes_Historicas_Colon_America_vol4.pdf
+  paginas: 460 + 492
+  aliases:
+  - Anglería 1892
+  - Pedro Mártir
+  - Décadas
+  en_repo: true
+- id: antczak-2015-las-aves
+  obra: 'Las Aves: arqueología del archipiélago (navegación insular, botuto, tortugas)'
+  autor: Antczak, Andrzej T. y Antczak, Maria Magdalena
+  anio: 2015
+  genero: arqueologia
+  local:
+  - fuentes_caquetios/Antczak_Antczak_2015_Las_Aves_Arqueologia.pdf
+  paginas: 38
+  aliases:
+  - Antczak & Antczak 2015
+  - Las Aves
+  en_repo: true
+- id: antczak-2017-cariban
+  obra: Re-thinking the Migration of Cariban-Speakers from the Middle Orinoco River to North-Central Venezuela
+    (AD 800)
+  autor: Antczak, Andrzej; Urbani, Bernardo; Antczak, Maria Magdalena
+  anio: 2017
+  publicacion: Journal of World Prehistory 30:131-175 (open access)
+  genero: arqueo-linguistica
+  local:
+  - fuentes_caquetios/Antczak_et_al_2017_Cariban_Migration_Orinoco.pdf
+  paginas: 45
+  aliases:
+  - Antczak et al. 2017
+  - Cariban Migration
+  en_repo: true
+- id: arcaya-1920
+  obra: Historia del Estado Falcón, tomo I
+  autor: Arcaya, Pedro Manuel
+  anio: 1920
+  genero: cronica-historia-regional
+  local:
+  - fuentes_caquetios/Arcaya_1920_Historia_Estado_Falcon.pdf
+  paginas: 348
+  aliases:
+  - Arcaya 1920
+  - Historia del Estado Falcón
+  en_repo: true
+- id: brinton-1871
+  obra: The Arawack Language of Guiana in its Linguistic and Ethnological Relations
+  autor: Brinton, Daniel G.
+  anio: 1871
+  genero: linguistica-comparativa
+  local:
+  - fuentes_caquetios/Brinton_1871_texto.txt
+  - fuentes_caquetios/Brinton_1871_Arawack_Language_Guiana.pdf (0 bytes)
+  paginas: —
+  aliases:
+  - Brinton 1871
+  en_repo: true
+- id: camacho-2011
+  obra: Dunas y médanos del estado Falcón (geomorfología del Istmo de los Médanos)
+  autor: Camacho, R. et al.
+  anio: 2011
+  genero: ciencia-natural
+  local:
+  - fuentes_caquetios/Camacho_et_al_2011_Dunas_Medanos_Falcon.pdf
+  paginas: 13
+  aliases:
+  - Camacho et al. 2011
+  - Camacho 2011
+  en_repo: true
+- id: fernandes-2020
+  obra: A genetic history of the pre-contact Caribbean
+  autor: Fernandes, Daniel M. et al.
+  anio: 2020
+  publicacion: Nature 590 (2021), publicado online 2020
+  genero: genetica
+  local:
+  - fuentes_caquetios/Fernandes_et_al_2020_Nature_Genetic_History_Caribbean.pdf
+  paginas: — (archivo vacío)
+  aliases:
+  - Fernandes et al. 2020
+  en_repo: true
+- id: gatschet-1885
+  obra: The Aruba Language and the Papiamento Jargon
+  autor: Gatschet, Albert S. (material recogido por Alphonse L. Pinart, 1882)
+  anio: 1885
+  publicacion: Proceedings of the American Philosophical Society XXII(120), pp. 299-305 (leído el 18 de
+    julio de 1884)
+  genero: vocabulario
+  local:
+  - fuentes_caquetios/Gatschet_1885_Aruba_texto.txt
+  - fuentes_caquetios/Gatschet_1885_biostor_texto.txt
+  paginas: 7 (pp. 299-305; dos OCR del mismo artículo)
+  aliases:
+  - Gatschet 1885
+  - Pinart 1882
+  - The Aruba Language
+  en_repo: true
+- id: gilij-1780-1783
+  obra: Saggio di Storia Americana, vols. 1, 3 y 4
+  autor: Gilij, Filippo Salvatore
+  anio: 1780, 1782, 1783
+  genero: etnografia-misionera
+  local:
+  - fuentes_caquetios/Gilij_1780_Saggio_Storia_Americana_vol1.pdf
+  - fuentes_caquetios/Gilij_1782_Saggio_Storia_Americana_vol3.pdf
+  - fuentes_caquetios/Gilij_1783_Saggio_Storia_Americana_vol4.pdf
+  paginas: 414 + 457 + 452 = 1323
+  aliases:
+  - Gilij
+  - Saggio di Storia Americana
+  en_repo: true
+- id: guerra-curvelo-palabrero
+  obra: Pütchipü'üi, Palabrero Wayuu (cuadernillo, serie Patrimonio Cultural Inmaterial)
+  autor: Ministerio de Cultura de Colombia — basado en Guerra Curvelo, W., *La disputa y la palabra* (2002)
+  anio: 2023
+  genero: etnografia-normativa
+  local:
+  - fuentes_caquetios/GuerraCurvelo_ref_2023_Cuadernillo_Sistema_Normativo_Wayuu_Palabrero.pdf
+  paginas: 22
+  aliases:
+  - cuadernillo del palabrero
+  - Guerra Curvelo
+  - Pütchipü'üi
+  en_repo: true
+- id: jahn-1927
+  obra: Los aborígenes del occidente de Venezuela
+  autor: Jahn, Alfredo
+  anio: 1927
+  genero: etnografia-vocabularios
+  local:
+  - fuentes_caquetios/Jahn_1927_Aborigenes_Occidente_Venezuela.pdf
+  paginas: 510
+  aliases:
+  - Jahn 1927
+  - Los aborígenes del occidente de Venezuela
+  en_repo: true
+- id: keegan-1989
+  obra: 'The Evolution of Avunculocal Chiefdoms: A Reconstruction of Taino Kinship and Politics'
+  autor: Keegan, William F.
+  anio: 1989
+  publicacion: American Anthropologist 91(3)
+  genero: academico
+  acceso: NO consultado en texto completo — identificado vía resúmenes de búsqueda
+  aliases:
+  - Keegan 1989
+  en_repo: false
+- id: las-casas-1875
+  obra: Historia de las Indias, tomo I
+  autor: Las Casas, Bartolomé de
+  anio: 1875 [c. 1561]
+  genero: cronica
+  local:
+  - fuentes_caquetios/Las_Casas_1875_Historia_Indias_vol1.pdf
+  paginas: 613
+  aliases:
+  - Las Casas 1875
+  - Historia de las Indias
+  en_repo: true
+- id: maria-lionza-culto
+  obra: Bibliografía del culto de María Lionza — Ferrándiz 1999 · Fernández Quintana 2016 · Pollak-Eltz
+    1972 · Barreto 1987/1989-90 · Clarac de Briceño 1970
+  autor: varios
+  anio: 1970-2016
+  genero: antropologia-religion
+  acceso: Ferrándiz 1999 y Fernández Quintana 2016 leídos íntegros (PDF en Redalyc); Pollak-Eltz y Barreto
+    solo vía sus citas
+  aliases:
+  - María Lionza
+  - Ferrándiz 1999
+  - Fernández Quintana 2016
+  - Pollak-Eltz
+  en_repo: false
+- id: moreno-mayar-2018
+  obra: Early human dispersals within the Americas
+  autor: Moreno-Mayar, J. V. et al. (53 autores)
+  anio: 2018
+  publicacion: Science 362(6419), eaav2621
+  genero: genetica
+  local:
+  - fuentes_caquetios/MorenoMayar_et_al_2018_Science_Early_Human_Dispersals.pdf
+  paginas: 14
+  aliases:
+  - Moreno-Mayar 2018
+  - Schroeder 2018
+  en_repo: true
+- id: oliver-1989-cap2
+  obra: 'Chapter 2: Arawakan Historical Linguistics'
+  autor: Oliver, José R.
+  anio: 1989
+  genero: linguistica-comparativa
+  local:
+  - fuentes_caquetios/Chapter 2 Linguistics- Oliver 1989.pdf
+  paginas: 109
+  aliases:
+  - Oliver 1989 cap. 2
+  - Oliver cap. 2
+  - Linguistics
+  en_repo: true
+- id: oliver-1989-cap3
+  obra: 'Chapter 3: XVI Century Ethnic Boundaries and the Nature of Caquetío Polities (en *The Archaeological,
+    Linguistic and Ethnohistorical Evidence for the Expansion of Arawakan into Northwestern Venezuela*)'
+  autor: Oliver, José R.
+  anio: 1989
+  genero: academico
+  local:
+  - fuentes_caquetios/Chapter 3 Ethnohistory.DOC-comprimido.pdf
+  paginas: 113
+  aliases:
+  - Oliver 1989 cap. 3
+  - Oliver cap. 3
+  - Ethnohistory
+  en_repo: true
+- id: oviedo-y-banos
+  obra: Historia de la conquista y población de la provincia de Venezuela
+  autor: Oviedo y Baños, José de
+  anio: 1885 [1723]
+  edicion_del_ejemplar: Biblioteca Ayacucho n.º 175 (la cita del corpus es a la edición de 1855 — paginación
+    sin cotejar)
+  genero: cronica
+  local:
+  - fuentes_caquetios/Oviedo_Banhos_Conquista_Poblacion_Venezuela.pdf (519 pp., ÚTIL)
+  paginas: 519
+  aliases:
+  - Oviedo y Baños
+  - Oviedo Baños 1885
+  en_repo: true
+- id: oviedo-y-valdes-1851
+  obra: Historia general y natural de las Indias, vol. I
+  autor: Fernández de Oviedo y Valdés, Gonzalo
+  anio: 1851 [s. XVI]
+  genero: cronica
+  local:
+  - fuentes_caquetios/Oviedo_Valdes_1851_Historia_General_Indias_vol1.pdf
+  paginas: — (no legible)
+  aliases:
+  - Oviedo y Valdés
+  - Oviedo 1851
+  - Historia general y natural
+  en_repo: true
+- id: paz-reverol-2017-2018
+  obra: «Hacer los sueños». Una perspectiva wayuu (2017) · Los ritos de muerte y dobles enterramientos
+    en el pueblo wayuu (2018)
+  autor: Paz Reverol, Carmen Laura
+  anio: 2017, 2018
+  publicacion: EntreDiversidades, pp. 277-288 · Interacción y Perspectiva 8(1), pp. 67-92
+  genero: etnografia
+  acceso: PDF completo en Dialnet (artículos 6236107 y 6329268) — leídos íntegros en la sesión 3; NO archivados
+    en el repo
+  aliases:
+  - Paz Reverol 2017
+  - Paz Reverol 2018
+  en_repo: false
+- id: perea-alonso-1942
+  obra: Filología comparada de las lenguas y dialectos arawak, tomo I
+  autor: Perea y Alonso, Sigfrido
+  anio: 1942
+  genero: gramatica
+  local:
+  - fuentes_caquetios/Perea_Alonso_1942_Filologia_Comparada_Arawak_TomoI.pdf (926 pp., ÚTIL)
+  paginas: 926
+  aliases:
+  - Perea Alonso 1942
+  - Filología comparada arawak
+  en_repo: true
+- id: perrin-1992-1995
+  obra: El camino de los indios muertos (1992) · Los practicantes del sueño. El chamanismo wayuu (1995)
+  autor: Perrin, Michel
+  anio: 1992, 1995
+  publicacion: Monte Ávila, Caracas
+  genero: etnografia
+  acceso: NO consultado directamente — se usa vía las citas de [[paz-reverol-2017-2018]]
+  aliases:
+  - Perrin 1992
+  - Perrin 1995
+  en_repo: false
+- id: ramos-perez-1978
+  obra: Reseña (Persée)
+  autor: Ramos Pérez, Demetrio
+  anio: 1978
+  genero: resenia
+  local:
+  - fuentes_caquetios/Ramos_Perez_1978_resenia_Persee.pdf
+  paginas: — (archivo vacío)
+  aliases:
+  - Ramos Pérez 1978
+  - Ramos 1978
+  en_repo: true
+- id: rouse-cruxent-1963
+  obra: Venezuelan Archaeology
+  autor: Rouse, Irving y Cruxent, José María
+  anio: 1963
+  genero: arqueologia
+  local:
+  - fuentes_caquetios/Rouse_Cruxent_1963_Venezuelan_Archaeology.pdf
+  paginas: — (archivo vacío)
+  aliases:
+  - Rouse & Cruxent 1963
+  - Venezuelan Archaeology
+  en_repo: true
+- id: van-buurt-2014
+  obra: Caquetío Indians on Curaçao during colonial times and Caquetío words in the Papiamentu Language
+    — Some names of Animals and Plants in Papiamentu
+  autor: van Buurt, Gerard
+  anio: 2014
+  publicacion: Edición propia, Curaçao (ISBN 978-99904-2-348-8); base en van Buurt & Joubert, *Stemmen
+    uit het Verleden*, 1997
+  genero: glosario-etnohistoria
+  local:
+  - fuentes_caquetios/VanBuurt_2014_CaquetioWords_Papiamentu.txt
+  paginas: 48
+  aliases:
+  - Van Buurt 2014
+  - Caquetío words in Papiamentu
+  en_repo: true
+- id: vansina-ong
+  obra: Oral Tradition as History (Vansina 1985) · Orality and Literacy (Ong 1982)
+  autor: Vansina, Jan · Ong, Walter J.
+  anio: 1985, 1982
+  genero: marco-teorico
+  acceso: NO leídos — síntesis de reseñas y resúmenes de búsqueda
+  aliases:
+  - Vansina 1985
+  - Ong 1982
+  en_repo: false
+- id: zavala-reyes-2015
+  obra: 'Palabras vivas de una lengua muerta: legado arawak-caquetío'
+  autor: Zavala Reyes, Miguel Enrique
+  anio: 2015
+  publicacion: Boletín Antropológico 33(89), enero-junio, pp. 58-76. Universidad de Los Andes, Mérida
+  genero: glosario
+  local:
+  - fuentes_caquetios/Palabras Vivas de una Lengua Muerta.pdf
+  paginas: 20
+  aliases:
+  - Zavala 2015
+  - Zavala Reyes 2015
+  - Palabras Vivas
+  en_repo: true

--- a/proyecto-linguistico-caquetío/CLAUDE.md
+++ b/proyecto-linguistico-caquetío/CLAUDE.md
@@ -29,12 +29,18 @@ cura y se publica en Curiana Radio (`/simulador`).
    la nota de la fuente.
 6. **Un cero hay que verificarlo.** Un `grep` sin resultados mide tu consulta,
    no la fuente. Ver la skill `minar-fuente` §2 — pasó tres veces en una noche.
-7. **El resultado de minar va en `4-fuentes/<obra>.md`**, no en un markdown
-   nuevo.
-8. **Nunca secretos en archivos del proyecto** — ni gitignored: el repo
+7. **Minar alimenta la esfera que toque, no solo el lexicón.** Lengua (léxico,
+   cognados, topónimos) y mundo (parentesco, ecología, creencia, transmisión,
+   geografía política). La nota de `4-fuentes/` es la **bitácora** —qué se
+   preguntó, qué se halló, qué no—, no el almacén. Medido: 18 de 30 obras
+   dejan rastro en una sola esfera. Ver `medir_sostiene.py --esferas`.
+8. **Citar es una clave foránea, no prosa.** `procedencia.obra` apunta a
+   `4-fuentes/bibliografia.yaml` y el validador lo comprueba. Si no hay fuente,
+   se declara `deuda: sin-procedencia`: el hueco se admite, **callarlo no**.
+9. **Nunca secretos en archivos del proyecto** — ni gitignored: el repo
    sincroniza a OneDrive.
-9. **Las decisiones viven en el tablero de GitHub** (label `decision`), no en
-   markdown. `DECISIONES_ABIERTAS.md` se retiró el 2026-08-06.
+10. **Las decisiones viven en el tablero de GitHub** (label `decision`), no en
+    markdown. `DECISIONES_ABIERTAS.md` se retiró el 2026-08-06.
 
 ---
 
@@ -60,8 +66,14 @@ cura y se publica en Curiana Radio (`/simulador`).
 cd curiana_sim
 pip install -r requirements.txt
 
-python guardianes.py              # los 5 en verde antes de cerrar nada
+python guardianes.py              # los 7 en verde antes de cerrar nada
 python guardianes.py --rapido     # sin los tests (más rápido)
+
+# Los datos de lengua y la bibliografía
+python generar_bibliografia.py    # 4-fuentes/bibliografia.yaml (generado)
+python compilar_lengua.py         # valida cognados, topónimos, morfemas
+python compilar_lengua.py --deuda # qué no cita a nadie todavía
+python medir_sostiene.py --esferas  # qué esfera alimenta cada obra
 
 python generar_tablero.py         # reescribe TABLERO.md (medido)
 python generar_tablero.py --gh    # + decisiones del tablero (usa red)
@@ -93,6 +105,7 @@ INDICE.md          la puerta del vault
 TABLERO.md         el estado medido (generado — no se edita a mano)
 1-plan/            ¿qué hacemos y qué falta?
 2-lengua/          ¿cómo es el caquetío?  lexicon · morfologia · toponimia · metodo-comparativo
+                   datos: cognados.yaml · toponimos.yaml · morfemas.yaml (ver datos-de-lengua)
 3-mundo/           ¿cómo era ese pueblo?  5 mapas · polities-caquetias · corpus/ · ensayos/
 4-fuentes/         ¿de dónde lo sabemos?  una nota por obra + INDICE_FUENTES
 5-experimento/     ¿qué probamos?  mapa-motor · ARQUITECTURA · DISENO_KOINE · analisis/

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -49,6 +49,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 | [[mapa-geografia-politica]] | ¿Cuál era el mundo de Manaure? | 8 |
 | [[polities-caquetias]] | ¿Cuántos caquetíos había, y cuál simulamos? | 4 polities |
 | [[horizonte-de-contacto]] | ¿Hasta dónde llegaba su mundo? ¿Tocó a los mayas? | prospección |
+| [[cronista]] | ¿Se puede contar desde dentro sin inventarlo? | 8 sustituciones |
 | [[mapa-motor]] | El código, los tests y los runs | — |
 
 ## Las notas de trabajo

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -60,6 +60,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 - ⚖️ [Decisiones abiertas](https://github.com/miguelgilurbina/curiana-radio/issues?q=is%3Aissue+label%3Adecision) — lo que solo Miguel puede decidir, en el
   tablero de GitHub. Cada una lleva su argumento y su evidencia dentro; ya no
   hay nota en el repo que las duplique.
+- 🔤 [[datos-de-lengua]] — cognados, topónimos y morfemas: dónde viven y por qué.
 - 🔧 [[HARNESS]] — cómo se trabaja aquí y por qué; los guardianes.
 - 🏗️ [[ARQUITECTURA]] — el motor medido: 50 módulos, dónde va a doler.
 - 📚 [[INDICE_FUENTES]] — estado **medido** de las obras: qué se puede leer, qué

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-08 02:46**.
+<!--GENERADO--> Generado el **2026-08-08 02:52**.
 
 ## ¿Vamos bien?
 
@@ -256,7 +256,7 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 774 en 188 notas indexadas | 🟢 0 rotos |
+| Wikilinks | 774 en 189 notas indexadas | 🟢 0 rotos |
 | Tests (`curiana_sim/tests/`) | 149 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-06 23:23**.
+<!--GENERADO--> Generado el **2026-08-08 02:46**.
 
 ## ¿Vamos bien?
 
@@ -21,7 +21,7 @@ editar_a_mano: no
 |---|---|---|---|
 | Entradas del lexicón **sin cita** | **3** | 82 (2026-07-21) | 🟢 −79 |
 | Hechos del corpus **con referencia** | **161 / 161** | — | 🟢 |
-| Tests del motor | **125 en verde** | 0 rojos | 🟢 |
+| Tests del motor | **149 en verde** | 0 rojos | 🟢 |
 | Gate para reanudar simulaciones | **2 de 9** condiciones | faltan 7 | 🔴 |
 | Decisiones esperando a Miguel | **12 abiertas** | 0 resueltas | 🟡 |
 
@@ -256,8 +256,8 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 765 en 177 notas indexadas | 🟢 0 rotos |
-| Tests (`curiana_sim/tests/`) | 125 passed, 0 failed | 🟢 |
+| Wikilinks | 774 en 188 notas indexadas | 🟢 0 rotos |
+| Tests (`curiana_sim/tests/`) | 149 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 
 **Avisos de `curiana_polities.py::coherencia_del_canon()`:**

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-08 02:52**.
+<!--GENERADO--> Generado el **2026-08-08 12:59**.
 
 ## ¿Vamos bien?
 
@@ -21,7 +21,7 @@ editar_a_mano: no
 |---|---|---|---|
 | Entradas del lexicón **sin cita** | **3** | 82 (2026-07-21) | 🟢 −79 |
 | Hechos del corpus **con referencia** | **161 / 161** | — | 🟢 |
-| Tests del motor | **149 en verde** | 0 rojos | 🟢 |
+| Tests del motor | **165 en verde** | 0 rojos | 🟢 |
 | Gate para reanudar simulaciones | **2 de 9** condiciones | faltan 7 | 🔴 |
 | Decisiones esperando a Miguel | **12 abiertas** | 0 resueltas | 🟡 |
 
@@ -256,8 +256,8 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 774 en 189 notas indexadas | 🟢 0 rotos |
-| Tests (`curiana_sim/tests/`) | 149 passed, 0 failed | 🟢 |
+| Wikilinks | 786 en 192 notas indexadas | 🟢 0 rotos |
+| Tests (`curiana_sim/tests/`) | 165 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 
 **Avisos de `curiana_polities.py::coherencia_del_canon()`:**

--- a/proyecto-linguistico-caquetío/curiana_sim/compilar_corpus.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/compilar_corpus.py
@@ -358,6 +358,53 @@ def validar_referencias_cruzadas(hechos: list) -> list:
     return problemas
 
 
+def _obras_de_la_bibliografia():
+    """Los ids de `4-fuentes/bibliografia.yaml`, o None si no existe."""
+    ruta = os.path.join(_AQUI, "..", "4-fuentes", "bibliografia.yaml")
+    if not os.path.exists(ruta):
+        return None
+    with open(ruta, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+    return {o["id"] for o in doc.get("obras", []) if o.get("id")}
+
+
+def validar_procedencia(hechos: list, obras) -> list:
+    """`procedencia.obra` es una clave foránea contra la bibliografía.
+
+    El campo es **opcional** todavía: 58 de los 161 hechos lo tienen (los que
+    citaban una sola obra de forma inequívoca). Los demás siguen con la
+    `referencia` en prosa, que no se toca — dice cosas que un id no puede
+    (página, cita textual, "vía tal").
+
+    Lo que sí se comprueba es que, cuando está, apunte a una obra real. Sin
+    esto, migrar el corpus a ids habría cambiado un texto libre por otro.
+    """
+    problemas = []
+    if obras is None:
+        return [_aviso("sin-bibliografia", "4-fuentes/bibliografia.yaml",
+                       "no existe: las citas del corpus no se pueden comprobar. "
+                       "Genérala con `python curiana_sim/generar_bibliografia.py`")]
+
+    for hecho in hechos:
+        proc = hecho.get("procedencia")
+        if proc is None:
+            continue
+        donde = _donde(hecho)
+        if not isinstance(proc, dict):
+            problemas.append(_error("procedencia-mal-formada", donde,
+                                    f"es {type(proc).__name__}, se esperaba dict"))
+            continue
+        obra = proc.get("obra")
+        if not obra:
+            problemas.append(_error("procedencia-sin-obra", donde,
+                                    "`procedencia` sin campo `obra`"))
+        elif obra not in obras:
+            problemas.append(_error(
+                "obra-fantasma", donde,
+                f"cita la obra `{obra}`, que no está en la bibliografía"))
+    return problemas
+
+
 def validar_rutas(hechos: list) -> list:
     """Nadie puede citar `curiana_sim/cultura/`: ya no existe."""
     problemas = []
@@ -511,6 +558,7 @@ def compilar(directorio: str = CORPUS_DIR, universo=None):
     problemas += validar_etiquetas(hechos)
     problemas += validar_referencias_cruzadas(hechos)
     problemas += validar_rutas(hechos)
+    problemas += validar_procedencia(hechos, _obras_de_la_bibliografia())
     if agentes:
         problemas += validar_agentes(hechos, agentes, fondo)
         problemas += validar_genealogia(genealogia, agentes)

--- a/proyecto-linguistico-caquetío/curiana_sim/compilar_lengua.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/compilar_lengua.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — validador de los datos de lengua
+==========================================
+
+El hermano de `compilar_corpus.py` para `2-lengua/`: cognados, topónimos y
+morfemas. Misma disciplina — valida y emite, nunca modifica.
+
+LO QUE DE VERDAD APORTA: INTEGRIDAD REFERENCIAL
+-----------------------------------------------
+Hasta ahora una cita era **texto libre**: `"Oliver 1989, cap. 3, p. 255"`. Nadie
+comprobaba que esa obra existiera, ni que el id fuera consistente entre dos
+hechos que citan lo mismo.
+
+Con `4-fuentes/bibliografia.yaml`, `procedencia.obra` pasa a ser una **clave
+foránea**, y este validador la comprueba. La cita deja de ser una promesa.
+
+QUÉ VALIDA
+----------
+1. **Estructura** — campos obligatorios, `id` con forma `<tipo>-NNN` y único.
+2. **Procedencia** — si la hay, su `obra` existe en la bibliografía. Si no la
+   hay, la entrada debe declararlo con `deuda: sin-procedencia`: el hueco se
+   admite, **pero no en silencio**.
+3. **Cognados** — al menos dos lenguas (una relación de una sola lengua no es
+   un cognado), códigos de lengua conocidos, y ninguna forma repetida entre dos
+   cognados distintos sin marcar.
+4. **Topónimos** — `nivel` legal (A/B/C/descartado), y que los morfemas citados
+   en `morfemas` existan como entrada del lexicón o como morfema despejado.
+5. **Corroboraciones** — la palabra corroborada existe en `VOCABULARIO_BASE`.
+
+Uso:
+    python compilar_lengua.py            # informe
+    python compilar_lengua.py --check    # exit 1 si hay errores
+    python compilar_lengua.py --deuda    # solo el listado de lo que no cita
+"""
+
+import argparse
+import io
+import os
+import sys
+from collections import Counter, defaultdict
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+DIR_LENGUA = os.path.join(REPO, "2-lengua")
+BIBLIOGRAFIA = os.path.join(REPO, "4-fuentes", "bibliografia.yaml")
+
+NIVELES_TOPONIMO = ("A", "B", "C", "descartado")
+
+# Dos clases de lengua, y la distinción no es cosmética:
+#
+# - **Núcleo** (mayúsculas, 2-4 letras): las lenguas sobre las que hay reglas de
+#   transducción (`REGLAS_WY_CQ` y compañía). Un código en mayúsculas fuera de
+#   este set es un typo, porque el motor va a intentar transducir con él.
+# - **Comparanda** (minúsculas, nombre completo): las ~24 lenguas arahuacas que
+#   Oliver cita para situar una forma en la familia — maipure, baré, wapishana,
+#   tariana… No tienen reglas ni las necesitan: son cita, no maquinaria.
+#
+# Por eso el mapa de formas es abierto: cerrar la lista de comparanda obligaría
+# a tocar el esquema cada vez que una fuente cita una lengua nueva.
+LENGUAS_NUCLEO = {"PA", "CQ", "WY", "LK", "TN", "KL", "PJ", "CAIC"}
+
+
+class Problema:
+    def __init__(self, nivel, codigo, donde, mensaje):
+        self.nivel, self.codigo, self.donde, self.mensaje = nivel, codigo, donde, mensaje
+
+    def __repr__(self):
+        return f"{self.nivel.upper()} [{self.codigo}] {self.donde}: {self.mensaje}"
+
+
+def _err(c, d, m):
+    return Problema("error", c, d, m)
+
+
+def _avi(c, d, m):
+    return Problema("aviso", c, d, m)
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def cargar(ruta):
+    if not os.path.exists(ruta):
+        return None
+    with open(ruta, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def obras_conocidas():
+    """Los ids de la bibliografía. Sin esto no hay integridad referencial."""
+    doc = cargar(BIBLIOGRAFIA)
+    if not doc:
+        return None
+    return {o["id"] for o in doc.get("obras", []) if o.get("id")}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# VALIDACIONES
+# ══════════════════════════════════════════════════════════════════════
+
+def validar_procedencia(registros, obras, etiqueta):
+    """La regla que hace que citar signifique algo."""
+    problemas = []
+    for r in registros:
+        donde = f"{etiqueta}#{r.get('id', '?')}"
+        proc = r.get("procedencia")
+
+        if proc is None:
+            # Se admite no tener fuente, pero hay que decirlo. Un hueco
+            # declarado es dato; un hueco callado es una cita que no existe.
+            if r.get("deuda") != "sin-procedencia":
+                problemas.append(_err(
+                    "procedencia-callada", donde,
+                    "sin `procedencia` y sin `deuda: sin-procedencia` — "
+                    "el hueco se admite, pero declarado"))
+            continue
+
+        if not isinstance(proc, dict):
+            problemas.append(_err("procedencia-mal-formada", donde,
+                                  f"es {type(proc).__name__}, se esperaba dict"))
+            continue
+
+        obra = proc.get("obra")
+        if not obra:
+            problemas.append(_err("procedencia-sin-obra", donde,
+                                  "`procedencia` sin campo `obra`"))
+        elif obras is not None and obra not in obras:
+            problemas.append(_err(
+                "obra-fantasma", donde,
+                f"cita la obra `{obra}`, que no está en la bibliografía"))
+    return problemas
+
+
+def validar_ids(registros, prefijo, etiqueta):
+    problemas = []
+    vistos = Counter()
+    import re
+    patron = re.compile(rf"^{prefijo}-\d{{3}}$")
+    for r in registros:
+        rid = r.get("id")
+        donde = f"{etiqueta}#{rid or '(sin id)'}"
+        if not rid:
+            problemas.append(_err("sin-id", etiqueta, "registro sin `id`"))
+            continue
+        vistos[rid] += 1
+        if not patron.match(str(rid)):
+            problemas.append(_err("id-malformado", donde,
+                                  f"no tiene la forma {prefijo}-NNN"))
+    for rid, n in vistos.items():
+        if n > 1:
+            problemas.append(_err("id-duplicado", f"{etiqueta}#{rid}",
+                                  f"aparece {n} veces"))
+    return problemas
+
+
+def validar_cognados(doc, obras):
+    problemas = []
+    if not doc:
+        return [_avi("cognados-ausente", "2-lengua/cognados.yaml", "no existe")]
+    regs = doc.get("cognados", [])
+    problemas += validar_ids(regs, "cognado", "cognados")
+    problemas += validar_procedencia(regs, obras, "cognados")
+
+    formas_vistas = defaultdict(list)
+    for r in regs:
+        donde = f"cognados#{r.get('id')}"
+        formas = r.get("formas") or {}
+        if not isinstance(formas, dict):
+            problemas.append(_err("formas-mal-formadas", donde, "`formas` no es un mapa"))
+            continue
+        if len(formas) < 2:
+            problemas.append(_err(
+                "no-es-un-cognado", donde,
+                f"solo {len(formas)} lengua(s) — «{r.get('glosa', '')[:40]}». "
+                "Un cognado es una relación entre lenguas; una entrada de una "
+                "sola pertenece al lexicón, no aquí"))
+        for lengua, forma in formas.items():
+            # Solo se vigilan los códigos del núcleo: son los que el motor va a
+            # usar para transducir. Los nombres en minúscula son comparanda
+            # citada y el mapa es abierto a propósito.
+            if lengua.isupper() and lengua not in LENGUAS_NUCLEO:
+                problemas.append(_err(
+                    "codigo-de-lengua-desconocido", donde,
+                    f"`{lengua}` parece código del núcleo pero no lo es "
+                    f"(núcleo: {', '.join(sorted(LENGUAS_NUCLEO))})"))
+            elif not str(lengua).strip():
+                problemas.append(_err("lengua-vacia", donde, "clave de lengua vacía"))
+            formas_vistas[(lengua, str(forma).lower())].append(r.get("id"))
+        if not r.get("glosa"):
+            problemas.append(_err("sin-glosa", donde, "sin `glosa`"))
+
+    for (lengua, forma), ids in formas_vistas.items():
+        if len(ids) > 1:
+            problemas.append(_avi(
+                "forma-repetida", f"cognados#{ids[0]}",
+                f"{lengua} «{forma}» aparece también en {', '.join(ids[1:])} — "
+                "¿son el mismo cognado?"))
+    return problemas
+
+
+def validar_toponimos(doc, obras, lexico, morfemas_ids):
+    problemas = []
+    if not doc:
+        return [_avi("toponimos-ausente", "2-lengua/toponimos.yaml", "no existe")]
+    regs = doc.get("toponimos", [])
+    problemas += validar_ids(regs, "toponimo", "toponimos")
+    problemas += validar_procedencia(regs, obras, "toponimos")
+
+    for r in regs:
+        donde = f"toponimos#{r.get('id')}"
+        if not r.get("forma"):
+            problemas.append(_err("sin-forma", donde, "sin `forma`"))
+        nivel = r.get("nivel")
+        if nivel not in NIVELES_TOPONIMO:
+            problemas.append(_err(
+                "nivel-ilegal", donde,
+                f"`nivel: {nivel}` no es legal "
+                f"(legales: {', '.join(NIVELES_TOPONIMO)})"))
+
+    if lexico:
+        for c in doc.get("corroboraciones_lexicon", []):
+            palabra = c.get("palabra")
+            if not palabra:
+                continue
+            # La clave no siempre es un lema suelto: hay pares de variantes
+            # («quiva/quiba», «para/paragua») y afijos («ka-», «-ima»). Basta
+            # con que UNA de las lecturas resuelva.
+            candidatos = {palabra}
+            candidatos |= {p.strip() for p in str(palabra).split("/")}
+            candidatos |= {p.strip("-") for p in list(candidatos)}
+            if not (candidatos & lexico):
+                problemas.append(_avi(
+                    "corrobora-fuera-del-lexicon", f"corroboraciones#{palabra}",
+                    "ninguna lectura resuelve en VOCABULARIO_BASE — puede ser "
+                    "un afijo o una forma que salió del habla"))
+    return problemas
+
+
+def validar_morfemas(doc, obras):
+    problemas = []
+    if not doc:
+        return [_avi("morfemas-ausente", "2-lengua/morfemas.yaml", "no existe")]
+    regs = doc.get("morfemas", [])
+    problemas += validar_ids(regs, "morfema", "morfemas")
+    for r in regs:
+        if not r.get("forma"):
+            problemas.append(_err("sin-forma", f"morfemas#{r.get('id')}", "sin `forma`"))
+    return problemas
+
+
+def compilar():
+    obras = obras_conocidas()
+    problemas = []
+    if obras is None:
+        problemas.append(_err(
+            "sin-bibliografia", "4-fuentes/bibliografia.yaml",
+            "no existe: sin ella no se puede comprobar ninguna cita. "
+            "Genérala con `python curiana_sim/generar_bibliografia.py`"))
+
+    try:
+        sys.path.insert(0, AQUI)
+        from curiana_lexicon import VOCABULARIO_BASE
+        lexico = set(VOCABULARIO_BASE)
+    except Exception as e:                                   # noqa: BLE001
+        problemas.append(_avi("lexicon-no-importable", "curiana_lexicon",
+                              f"no se pudo leer ({e})"))
+        lexico = None
+
+    cog = cargar(os.path.join(DIR_LENGUA, "cognados.yaml"))
+    top = cargar(os.path.join(DIR_LENGUA, "toponimos.yaml"))
+    mor = cargar(os.path.join(DIR_LENGUA, "morfemas.yaml"))
+
+    morfemas_ids = {m.get("forma") for m in (mor or {}).get("morfemas", [])}
+    problemas += validar_cognados(cog, obras)
+    problemas += validar_toponimos(top, obras, lexico, morfemas_ids)
+    problemas += validar_morfemas(mor, obras)
+    return {"cognados": cog, "toponimos": top, "morfemas": mor}, problemas
+
+
+def informe(datos, problemas):
+    cog, top, mor = datos["cognados"], datos["toponimos"], datos["morfemas"]
+
+    print("\n── Datos de lengua ──")
+    if cog:
+        m = cog.get("meta", {})
+        print(f"  cognados   {m.get('cognados', '?'):>4}   "
+              f"con procedencia {m.get('con_procedencia', '?')}  "
+              f"sin {m.get('sin_procedencia', '?')}")
+    if top:
+        m = top.get("meta", {})
+        print(f"  topónimos  {m.get('toponimos', '?'):>4}   {m.get('por_nivel', {})}")
+    if mor:
+        m = mor.get("meta", {})
+        print(f"  morfemas   {m.get('morfemas', '?'):>4}   "
+              f"glosados {m.get('glosados', '?')}")
+
+    errores = [p for p in problemas if p.nivel == "error"]
+    avisos = [p for p in problemas if p.nivel == "aviso"]
+
+    for titulo, lista in (("ERRORES", errores), ("Avisos", avisos)):
+        if not lista:
+            continue
+        print(f"\n── {titulo}: {len(lista)} ──")
+        por = defaultdict(list)
+        for p in lista:
+            por[p.codigo].append(p)
+        for codigo, items in sorted(por.items()):
+            print(f"  [{codigo}] × {len(items)}")
+            for p in items[:6]:
+                print(f"     {p.donde}: {p.mensaje}")
+            if len(items) > 6:
+                print(f"     … y {len(items) - 6} más")
+
+    print("\n" + "=" * 60)
+    if errores:
+        print(f"  ✗ {len(errores)} error(es), {len(avisos)} aviso(s)")
+    else:
+        print(f"  ✓ datos de lengua válidos — {len(avisos)} aviso(s)")
+    print("=" * 60)
+
+
+def informe_deuda(datos):
+    print("\n── Lo que todavía no cita a nadie ──")
+    for etiqueta, doc, clave in (("cognados", datos["cognados"], "cognados"),
+                                 ("topónimos", datos["toponimos"], "toponimos")):
+        if not doc:
+            continue
+        sin = [r for r in doc.get(clave, []) if not r.get("procedencia")]
+        total = len(doc.get(clave, []))
+        print(f"\n  {etiqueta}: {len(sin)}/{total} sin procedencia")
+        for r in sin[:10]:
+            print(f"     {r.get('id')}  {r.get('glosa') or r.get('forma')}")
+        if len(sin) > 10:
+            print(f"     … y {len(sin) - 10} más")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--deuda", action="store_true")
+    args = ap.parse_args(argv)
+
+    datos, problemas = compilar()
+    if args.deuda:
+        informe_deuda(datos)
+        return 0
+    informe(datos, problemas)
+    if args.check and any(p.nivel == "error" for p in problemas):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_cronista.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_cronista.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — el cronista: contar desde dentro, sin inventar
+=========================================================
+
+Un agente que lee el corpus y lo cuenta **desde la Curiana**, no desde fuera.
+
+EL PROBLEMA QUE RESUELVE
+------------------------
+Todo lo que sabemos del caquetío llega en la lengua y las categorías de quien
+vino a conquistarlo. No es una queja ideológica: es un hecho medible, y este
+proyecto ya se lo venía encontrando de frente.
+
+- Oviedo y Valdés describe la cura del boratio y llama **truco** al paso final
+  (*"sin que ninguno lo vea"*, *"para hacerlo creer al enfermo"*). La extracción
+  del objeto patógeno está documentada en medio continente; el dato del rito es
+  utilizable, **el juicio sobre el rito no**.
+- Oliver compara la jefatura de Barquisimeto con el *Big Man* melanesio, y él
+  mismo rechaza el "Cacicazgo Teocrático" de Steward y Faron porque *"blurs the
+  differences that make a difference"*: una tipología occidental aplanando lo
+  que quería describir.
+- **Las palabras mismas**: `piache` es voz cháima y tamanaca que los españoles
+  difundieron (Jahn 1927 n.28, corroborando a Alvarado); `cacique` es taína.
+  Ninguna de las dos es caquetía. Las suyas son `boratio`, `diao`, `apopo`.
+- Y las glosas del propio lexicón arrastran el marco: `capu` se glosa como
+  *"demonio"* —palabra de Oviedo, no de ellos— y `buio` como *"diablo, dios del
+  mal"*, que son categorías cristianas.
+
+QUÉ NO ES ESTE MÓDULO
+---------------------
+**No recupera la voz caquetía.** No se puede: la lengua está extinta y no hay
+un solo texto escrito por un caquetío. Cualquiera que diga que entrega "la
+mirada caquetía" está fabricando, y este proyecto no hace eso.
+
+Lo que sí se puede hacer, y es trabajo comprobable:
+
+1. **Nombrar con sus palabras** donde las tenemos atestiguadas.
+2. **Quitar el juicio del observador** y quedarse con lo observado.
+3. **Poner en el centro las preguntas que a ellos les importaban** —la sal, el
+   agua, el mar, el linaje de la madre— en vez de las que le importaban al
+   cronista español (el oro, la sumisión, la idolatría).
+4. **Decir cuándo no sabemos.** Un cronista honesto marca el hueco.
+
+Y una cuarta cosa que sí es autóctona de verdad: **Paraguaná**. No es la voz
+caquetía, pero es la continuidad más cercana que existe — la misma tierra, el
+mismo mar, y voces que sobrevivieron en el habla regional.
+
+LA REGLA DURA
+-------------
+**Lo que el cronista dice NUNCA es un dato.** Es una lectura. No entra al
+corpus, no se cita como fuente, no asciende de etiqueta. Si algo que dijo el
+cronista acaba en `3-mundo/corpus/` como `atestiguado`, el proyecto entero
+pierde lo que lo hacía investigación.
+
+Uso:
+    python curiana_cronista.py --prompt      # el system prompt compuesto
+    python curiana_cronista.py --glosario    # la tabla de descolonización
+    python curiana_cronista.py --check       # verifica contra el lexicón
+"""
+
+import argparse
+import io
+import os
+import sys
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# LA TABLA: cómo lo nombró la fuente, cómo lo nombraban ellos
+# ══════════════════════════════════════════════════════════════════════
+#
+# Cada fila es comprobable: `suyo` tiene que existir en VOCABULARIO_BASE, y
+# `ajeno` no debe estar en el habla activa (o estar marcado como préstamo).
+# `--check` lo verifica.
+
+DESCOLONIZAR = [
+    {
+        "ajeno": "piache",
+        "suyo": "boratio",
+        "de_donde_viene": "voz cháima y tamanaca (caribe), difundida por los españoles",
+        "fuente": "jahn-1927",
+        "nota": "Jahn n.28 lo dice explícito, corroborando a Alvarado p.248. "
+                "Salió del habla activa del proyecto en D10.",
+    },
+    {
+        "ajeno": "cacique",
+        "suyo": "diao",
+        "de_donde_viene": "voz taína, trasplantada por los españoles a toda América",
+        "fuente": "jahn-1927",
+        "nota": "El caquetío distingue `diao` (señor principal) de `apopo` "
+                "(cabeza de parcialidad). «Cacique» aplana los dos en uno.",
+    },
+    {
+        "ajeno": "demonio",
+        "suyo": "capu",
+        "de_donde_viene": "categoría cristiana con que Oviedo traduce lo que el boratio invoca",
+        "fuente": "oliver-1989-cap3",
+        "nota": "El documento de 1579 lo marca como caquetío, y añade que le "
+                "dieron ese mismo nombre A LOS ESPAÑOLES. Nombrar es de ida y "
+                "vuelta: ellos también nombraron al extraño.",
+    },
+    {
+        "ajeno": "hechicero, brujería",
+        "suyo": "boratio",
+        "de_donde_viene": "juicio del cronista sobre un oficio de médico y adivino",
+        "fuente": "arcaya-1920",
+        "nota": "Oviedo describe la cura y llama truco al paso final. La "
+                "extracción del objeto patógeno es un rasgo chamánico americano "
+                "documentado; el dato sirve, el juicio no.",
+    },
+    {
+        "ajeno": "ídolo, idolatría",
+        "suyo": "—",
+        "de_donde_viene": "categoría de la polémica religiosa europea",
+        "fuente": "arcaya-1920",
+        "nota": "Arcaya mismo anota que NO había culto comunal de ídolos ni "
+                "templos: los invocaban especialistas, no la tribu. La palabra "
+                "describe una acusación, no una práctica.",
+    },
+    {
+        "ajeno": "tribu, cacicazgo teocrático",
+        "suyo": "polity — costera, Barquisimeto, Yaracuy, Llanos",
+        "de_donde_viene": "tipología antropológica occidental (Steward y Faron 1959)",
+        "fuente": "oliver-1989-cap3",
+        "nota": "Oliver la rechaza: «blurs the differences that make a "
+                "difference». Eran cuatro formaciones distintas, no una.",
+    },
+    {
+        "ajeno": "vasallo, súbdito",
+        "suyo": "—",
+        "de_donde_viene": "vocabulario feudal castellano aplicado a otra cosa",
+        "fuente": "oviedo-y-banos",
+        "nota": "Oviedo y Baños escribe que Manaure venía «cargado en hombros "
+                "de caciques»: quienes lo llevaban eran señores, no criados. "
+                "La relación no era de vasallaje feudal.",
+    },
+    {
+        "ajeno": "el desierto, la tierra estéril",
+        "suyo": "biro · para · duna",
+        "de_donde_viene": "el juicio de quien buscaba tierra de labor",
+        "fuente": "oviedo-y-banos",
+        "nota": "«Terreno arenoso y falto de aguas» es un veredicto agrícola "
+                "español. Para quien vive de la sal (`biro`) y del mar "
+                "(`para`), esa costa es rica. La pobreza estaba en los ojos.",
+    },
+]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# EL PROMPT
+# ══════════════════════════════════════════════════════════════════════
+
+STANCE = """\
+Eres el cronista de la Curiana: el asentamiento caquetío del Golfete de Coro,
+en la costa que hoy llaman Falcón, en los años anteriores a que llegara nadie de
+fuera.
+
+No eres un antropólogo visitando. Eres de aquí. Cuentas lo que se hace y lo que
+se sabe como se cuenta entre nosotros, no como se explica a un forastero.
+
+CÓMO HABLAS
+
+- **Nombras las cosas con nuestras palabras.** El que llama y adivina es el
+  `boratio`. El señor principal es el `diao`; el que manda una parcialidad es un
+  `apopo`. Lo que el boratio invoca es `capu`. El alma es `barsure`. La sal es
+  `biro`, el mar es `para`.
+- **No usas las palabras que trajeron otros**: «piache» es voz caribe, «cacique»
+  es taína. Si no tenemos palabra para algo, lo dices así — no la inventas.
+- **No juzgas lo que describes.** No dices que la cura es un truco ni que el
+  entierro es superstición. Dices qué se hace, quién lo hace y qué se espera de
+  ello.
+- **Tu tierra no es pobre.** Quien la llamó estéril buscaba trigo. Aquí hay sal,
+  hay mar, hay caminos de agua a las islas. La riqueza está donde uno sepa
+  mirar.
+- **Cuentas por la línea de la madre.** El linaje, el nombre y la herencia pasan
+  por ella; el hermano de tu madre tiene autoridad sobre ti que tu padre no
+  tiene.
+
+QUÉ TE IMPORTA
+
+Te importa si va a llover, si el año será seco o abundante, si conviene ir a la
+guerra. Te importan las rutas de la sal y quién controla el paso a las islas.
+Te importa de qué fuego es cada quien y quién hereda de quién. Te importan los
+muertos y dónde queda su barsure.
+
+No te importan el oro ni la sumisión ni la idolatría: esas son preguntas de
+otros.
+
+LO QUE NO PUEDES HACER
+
+- **No inventes datos.** Si el corpus no lo dice, no lo sabes. Puedes decir «no
+  sé», «se cuenta que», «los viejos dicen» — y esas tres cosas significan cosas
+  distintas.
+- **Lo que dices es una lectura, no una fuente.** Nada de lo que cuentes vale
+  como evidencia ni entra en el corpus.
+- **No romantices.** Hay hambre, hay raids que se llevan mujeres, hay muertos.
+  Contar desde dentro no es contar bonito.
+"""
+
+LIMITE = """\
+NOTA HONESTA SOBRE ESTA VOZ
+
+Esta perspectiva es **construida**, no recuperada. La lengua caquetía está
+extinta y no existe un solo texto escrito por un caquetío. Lo que hay es lo que
+escribieron sus conquistadores.
+
+Lo que esta voz hace es retirar el marco del observador —sus palabras, sus
+juicios, sus preguntas— y quedarse con lo observado. Eso es defendible. Decir
+que es «la mirada caquetía» no lo sería.
+
+Lo más cercano a una continuidad real es **Paraguaná**: la misma tierra, el
+mismo mar, y voces que sobrevivieron en el habla de la región. No es la voz de
+ellos, pero es lo que quedó.
+"""
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def glosario_prompt() -> str:
+    """El bloque de sustituciones, para inyectar en el prompt."""
+    lineas = ["PALABRAS QUE NO SON NUESTRAS, Y LAS QUE SÍ:", ""]
+    for fila in DESCOLONIZAR:
+        suyo = fila["suyo"]
+        if suyo == "—":
+            lineas.append(f"- «{fila['ajeno']}» — no tenemos esa palabra porque "
+                          f"no es una cosa nuestra. {fila['nota']}")
+        else:
+            lineas.append(f"- «{fila['ajeno']}» → **{suyo}**  "
+                          f"({fila['de_donde_viene']})")
+    return "\n".join(lineas)
+
+
+def prompt_cronista(incluir_limite: bool = False) -> str:
+    """El system prompt completo.
+
+    `incluir_limite` añade la nota honesta sobre qué es esta voz. Va aparte
+    porque en el prompt del agente estorbaría —un cronista no se explica a sí
+    mismo— pero tiene que estar donde la lea un humano.
+    """
+    partes = [STANCE, "", glosario_prompt()]
+    if incluir_limite:
+        partes += ["", "─" * 60, "", LIMITE]
+    return "\n".join(partes)
+
+
+def verificar() -> list:
+    """Cada palabra `suyo` existe en el lexicón; cada `ajeno` no está activa.
+
+    Sin esto la tabla sería una opinión. Con esto es una afirmación sobre el
+    dato, y se cae sola si alguien cambia el lexicón.
+    """
+    sys.path.insert(0, AQUI)
+    from curiana_lexicon import VOCABULARIO_BASE
+
+    problemas = []
+    obras = None
+    ruta_bib = os.path.join(REPO, "4-fuentes", "bibliografia.yaml")
+    if os.path.exists(ruta_bib):
+        import yaml
+        with open(ruta_bib, encoding="utf-8") as fh:
+            obras = {o["id"] for o in (yaml.safe_load(fh) or {}).get("obras", [])}
+
+    for fila in DESCOLONIZAR:
+        ajeno = fila["ajeno"]
+        for palabra in str(fila["suyo"]).replace("·", " ").split():
+            palabra = palabra.strip(",")
+            if palabra in ("—", "polity", "costera", "Barquisimeto", "Yaracuy",
+                           "Llanos"):
+                continue
+            if palabra not in VOCABULARIO_BASE:
+                problemas.append(
+                    f"«{ajeno}» propone `{palabra}`, que no está en el lexicón")
+
+        # La palabra ajena no debería estar en el habla activa como caquetía.
+        entrada = VOCABULARIO_BASE.get(ajeno.split(",")[0].strip())
+        if entrada and "caquet" in str(entrada.get("fuente", "")).lower():
+            problemas.append(
+                f"«{ajeno}» sigue en el habla activa marcada como caquetía "
+                f"({entrada['fuente']}) — o la tabla se equivoca, o el lexicón")
+
+        if obras is not None and fila.get("fuente") not in obras:
+            problemas.append(
+                f"«{ajeno}» cita la obra `{fila.get('fuente')}`, "
+                f"que no está en la bibliografía")
+    return problemas
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--prompt", action="store_true")
+    ap.add_argument("--glosario", action="store_true")
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.glosario:
+        print(f"\n── Cómo lo nombró la fuente, cómo lo nombraban ellos ──\n")
+        for fila in DESCOLONIZAR:
+            print(f"  «{fila['ajeno']}»  →  {fila['suyo']}")
+            print(f"     viene de: {fila['de_donde_viene']}")
+            print(f"     fuente:   {fila['fuente']}")
+            print(f"     {fila['nota']}\n")
+        return 0
+
+    if args.check:
+        problemas = verificar()
+        if problemas:
+            print(f"\n  ✗ {len(problemas)} problema(s):")
+            for p in problemas:
+                print(f"     {p}")
+            return 1
+        print(f"\n  ✓ las {len(DESCOLONIZAR)} sustituciones se sostienen "
+              f"contra el lexicón y la bibliografía")
+        return 0
+
+    print(prompt_cronista(incluir_limite=True))
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/generar_bibliografia.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/generar_bibliografia.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — la bibliografía, generada desde las notas de fuente
+=============================================================
+
+Emite `4-fuentes/bibliografia.yaml`: **un registro por obra**, con su id
+estable, y nada más que lo que hace falta para citarla.
+
+POR QUÉ
+-------
+Hasta ahora las notas de `4-fuentes/` eran dos cosas a la vez: la ficha de la
+obra **y** el almacén de todo lo que se le había sacado. Eso ordena el
+conocimiento por *de dónde vino* en lugar de por *de qué trata*, y tiene dos
+consecuencias feas:
+
+1. Un hallazgo de ecología acaba viviendo en `oliver-1989-cap3.md` en vez de en
+   ecología, así que para saber qué sabemos de ecología hay que leer las 30
+   notas.
+2. No hay forma de comprobar que una cita apunta a una obra que existe: la
+   `referencia` es texto libre.
+
+Con la bibliografía separada, **`obra` pasa a ser una clave foránea**: cada
+hecho del corpus, cada entrada del lexicón, cada cognado y cada topónimo pueden
+citar un id, y el validador comprueba que resuelva. La cita deja de ser una
+promesa y pasa a ser una comprobación.
+
+QUÉ NO HACE
+-----------
+No borra ni adelgaza las notas. Se genera **desde** su frontmatter, así que no
+inventa nada y no se pierde nada. Las notas siguen siendo la bitácora de la
+minería —qué se preguntó, qué se halló, qué no— que es prosa y debe seguir
+siéndolo.
+
+`sostiene` **no se copia**: es un campo que se mantenía a mano y derivaba.
+Lo calcula `medir_sostiene.py` contando lo que cada obra cita de verdad.
+
+Uso:
+    python generar_bibliografia.py            # escribe el YAML
+    python generar_bibliografia.py --stdout
+    python generar_bibliografia.py --check    # exit 1 si el de disco está viejo
+"""
+
+import argparse
+import io
+import os
+import re
+import sys
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+FUENTES = os.path.join(REPO, "4-fuentes")
+SALIDA = os.path.join(FUENTES, "bibliografia.yaml")
+
+_FM = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
+
+# Lo que se copia de la nota, en este orden. Todo lo demás —cobertura, tareas,
+# prioridad, estado de minado— es *estado de trabajo*, no cita, y se queda en
+# la nota.
+CAMPOS_CITA = ("obra", "autor", "anio", "publicacion", "edicion_del_ejemplar",
+               "genero", "local", "paginas", "acceso", "aliases")
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def frontmatter(path):
+    with open(path, encoding="utf-8") as fh:
+        m = _FM.match(fh.read())
+    if not m:
+        return {}
+    datos = yaml.safe_load(m.group(1))
+    return datos if isinstance(datos, dict) else {}
+
+
+def recolectar():
+    """Un registro por nota con `tipo: fuente`, ordenados por id."""
+    obras = []
+    for nombre in sorted(os.listdir(FUENTES)):
+        if not nombre.endswith(".md") or nombre == "INDICE_FUENTES.md":
+            continue
+        fm = frontmatter(os.path.join(FUENTES, nombre))
+        if fm.get("tipo") != "fuente":
+            continue
+
+        registro = {"id": nombre[:-3]}
+        for campo in CAMPOS_CITA:
+            if campo in fm and fm[campo] not in (None, "", []):
+                registro[campo] = fm[campo]
+
+        # `local` puede ser cadena o lista; se normaliza a lista para que el
+        # consumidor no tenga que preguntarse cuál de las dos le tocó.
+        if "local" in registro and isinstance(registro["local"], str):
+            registro["local"] = [registro["local"]]
+
+        # Una obra sin archivo en el repo es una obra citable igual: se marca
+        # en vez de omitirla, porque 27 hechos del corpus dependen de esas.
+        registro["en_repo"] = bool(registro.get("local"))
+        obras.append(registro)
+    return obras
+
+
+def documento(obras):
+    return {
+        "meta": {
+            "generado_por": "curiana_sim/generar_bibliografia.py",
+            "obras": len(obras),
+            "en_repo": sum(1 for o in obras if o["en_repo"]),
+            "solo_citadas": sum(1 for o in obras if not o["en_repo"]),
+            "nota": ("Generado desde el frontmatter de 4-fuentes/*.md. No editar "
+                     "a mano: se edita la nota y se regenera. El `id` es la clave "
+                     "que citan el corpus, el lexicón, los cognados y los topónimos."),
+        },
+        "obras": obras,
+    }
+
+
+def volcar(doc) -> str:
+    return yaml.safe_dump(doc, allow_unicode=True, sort_keys=False,
+                          default_flow_style=False, width=100)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stdout", action="store_true")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 si el archivo de disco no coincide")
+    args = ap.parse_args(argv)
+
+    obras = recolectar()
+    texto = volcar(documento(obras))
+
+    if args.stdout:
+        print(texto)
+        return 0
+
+    if args.check:
+        if not os.path.exists(SALIDA):
+            print("  ✗ bibliografia.yaml no existe")
+            return 1
+        with open(SALIDA, encoding="utf-8") as fh:
+            if fh.read() != texto:
+                print("  ✗ bibliografia.yaml está viejo — regenéralo")
+                return 1
+        print(f"  ✓ bibliografia.yaml al día ({len(obras)} obras)")
+        return 0
+
+    with open(SALIDA, "w", encoding="utf-8") as fh:
+        fh.write(texto)
+    en_repo = sum(1 for o in obras if o["en_repo"])
+    print(f"  → {os.path.relpath(SALIDA, REPO)}: {len(obras)} obras "
+          f"({en_repo} con archivo, {len(obras) - en_repo} solo citadas)")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
@@ -4,17 +4,19 @@
 CURIANA — los guardianes, en un solo comando
 ============================================
 
-El proyecto tiene cinco comprobaciones que miden **contra el dato** y no contra
+El proyecto tiene siete comprobaciones que miden **contra el dato** y no contra
 la documentación. Estaban sueltas, y correrlas dependía de que alguien se
-acordara de las cinco:
+acordara de todas:
 
     1. tests del motor            pytest curiana_sim/tests/
     2. la suite rápida            python curiana_sim/test_quick.py
     3. el grafo del vault         python check_vault_links.py --strict
     4. el corpus cultural         python curiana_sim/compilar_corpus.py --check
     5. las polities               python curiana_sim/curiana_polities.py --check
+    6. la bibliografía al día     python curiana_sim/generar_bibliografia.py --check
+    7. los datos de lengua        python curiana_sim/compilar_lengua.py --check
 
-Acordarse de cinco cosas no es un método: es suerte. Esto las corre todas,
+Acordarse de siete cosas no es un método: es suerte. Esto las corre todas,
 informa en una tabla y sale con código ≠ 0 si alguna falla, para que se pueda
 colgar de un hook o de CI.
 
@@ -55,6 +57,12 @@ GUARDIANES = [
      REPO, False),
     ("polities",
      [PY, os.path.join(AQUI, "curiana_polities.py"), "--check"],
+     REPO, False),
+    ("bibliografía al día",
+     [PY, os.path.join(AQUI, "generar_bibliografia.py"), "--check"],
+     REPO, False),
+    ("datos de lengua",
+     [PY, os.path.join(AQUI, "compilar_lengua.py"), "--check"],
      REPO, False),
 ]
 

--- a/proyecto-linguistico-caquetío/curiana_sim/medir_sostiene.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/medir_sostiene.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — qué sostiene de verdad cada obra, medido
+==================================================
+
+El frontmatter de las 30 notas de fuente lleva un campo `sostiene`
+(`{hechos_corpus: 15, entradas_lexicon: 2}`) que **se mantiene a mano**. Como
+toda cifra a mano en este proyecto, deriva: se mina una fuente, se olvida
+actualizar el número, y el tablero informa de un estado que ya no es.
+
+Esto lo cuenta contra el dato, en las **cuatro esferas** donde una obra puede
+dejar rastro:
+
+    lexicón     entradas de VOCABULARIO_BASE que la citan en `notas`
+    corpus      hechos de 3-mundo/corpus/ que la citan en `referencia`
+    cognados    2-lengua/cognados.yaml, vía `procedencia.obra`
+    topónimos   2-lengua/toponimos.yaml, vía `procedencia.obra`
+
+POR QUÉ IMPORTA MÁS DE LO QUE PARECE
+------------------------------------
+Una minería no debería alimentar solo el lexicón. Oliver cap. 3 dio geografía
+política, guerra, economía y religión; Jahn dio parentesco y un mapa de
+polities. Si la única cuenta que llevamos es «entradas del lexicón», el trabajo
+que va a las otras esferas **no se ve**, y lo que no se ve no se prioriza.
+
+Este informe hace visible esa asimetría: qué obras alimentan varias esferas y
+cuáles solo una.
+
+⚠️ **Dos calidades de medida, y conviene no confundirlas.**
+
+Cognados y topónimos se miden por **clave foránea** (`procedencia.obra`): es
+exacto. Lexicón y corpus se miden por **coincidencia del apellido del autor**
+sobre campos de texto libre, y eso falla en las dos direcciones:
+
+- **por defecto**, si la cita está escrita de otra forma («vía Zavala p.60» sí,
+  pero «Boletín Antropológico 89» no);
+- **por exceso**, si el apellido aparece en prosa sin ser una cita.
+
+O sea: los números de esas dos columnas son una **estimación**, no una cuenta.
+Sirven para ver desfases grandes y para ordenar por magnitud, no para escribir
+«esta obra sostiene exactamente N entradas».
+
+Esa ambigüedad es precisamente el argumento para migrar corpus y lexicón a
+`procedencia.obra`, como ya están cognados y topónimos: entonces la cuenta sería
+exacta en las cuatro esferas.
+
+Uso:
+    python medir_sostiene.py             # tabla por obra
+    python medir_sostiene.py --esferas   # qué esfera alimenta cada obra
+    python medir_sostiene.py --desfase   # frontmatter declarado vs. medido
+"""
+
+import argparse
+import io
+import os
+import re
+import sys
+from collections import defaultdict
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+FUENTES = os.path.join(REPO, "4-fuentes")
+
+_FM = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def cargar_yaml(ruta):
+    if not os.path.exists(ruta):
+        return None
+    with open(ruta, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def obras():
+    """id → {patrones de búsqueda, declarado}. Los patrones salen de la propia
+    nota (`autor` + `aliases`), no de una lista cableada."""
+    doc = cargar_yaml(os.path.join(FUENTES, "bibliografia.yaml"))
+    if not doc:
+        raise RuntimeError("falta 4-fuentes/bibliografia.yaml — genérala primero")
+
+    salida = {}
+    for o in doc["obras"]:
+        claves = set()
+        apellido = str(o.get("autor", "")).split(",")[0].strip()
+        if len(apellido) >= 4 and apellido.lower() != "varios":
+            claves.add(apellido)
+        for alias in o.get("aliases") or []:
+            if len(str(alias).strip()) >= 5:
+                claves.add(str(alias).strip())
+        salida[o["id"]] = {"claves": claves, "obra": o.get("obra", "")}
+
+    # El `sostiene` declarado, para poder medir el desfase.
+    for nombre in os.listdir(FUENTES):
+        if not nombre.endswith(".md"):
+            continue
+        with open(os.path.join(FUENTES, nombre), encoding="utf-8") as fh:
+            m = _FM.match(fh.read())
+        if not m:
+            continue
+        fm = yaml.safe_load(m.group(1)) or {}
+        if fm.get("tipo") == "fuente" and nombre[:-3] in salida:
+            salida[nombre[:-3]]["declarado"] = fm.get("sostiene") or {}
+    return salida
+
+
+def _cita(texto: str, claves) -> bool:
+    return any(k.lower() in texto.lower() for k in claves)
+
+
+def medir():
+    datos = obras()
+    cuenta = {oid: defaultdict(int) for oid in datos}
+
+    # ── lexicón (texto libre: cota inferior) ───────────────────────────
+    sys.path.insert(0, AQUI)
+    try:
+        from curiana_lexicon import VOCABULARIO_BASE
+        for entrada in VOCABULARIO_BASE.values():
+            notas = str(entrada.get("notas", "")) + str(entrada.get("glosa_fuente", ""))
+            if not notas.strip():
+                continue
+            for oid, d in datos.items():
+                if d["claves"] and _cita(notas, d["claves"]):
+                    cuenta[oid]["lexicon"] += 1
+    except Exception as e:                                   # noqa: BLE001
+        print(f"  ⚠ no se pudo leer el lexicón: {e}")
+
+    # ── corpus (texto libre: cota inferior) ────────────────────────────
+    try:
+        from compilar_corpus import compilar as compilar_corpus
+        hechos, _, _ = compilar_corpus()
+        for h in hechos:
+            texto = " ".join(str(h.get(c, "")) for c in
+                             ("referencia", "contenido", "implicacion_simulacion"))
+            for oid, d in datos.items():
+                if d["claves"] and _cita(texto, d["claves"]):
+                    cuenta[oid]["corpus"] += 1
+    except Exception as e:                                   # noqa: BLE001
+        print(f"  ⚠ no se pudo leer el corpus: {e}")
+
+    # ── cognados y topónimos (clave foránea: exacto) ───────────────────
+    for archivo, seccion, esfera in (
+            ("cognados.yaml", "cognados", "cognados"),
+            ("toponimos.yaml", "toponimos", "toponimos")):
+        doc = cargar_yaml(os.path.join(REPO, "2-lengua", archivo))
+        for r in (doc or {}).get(seccion, []):
+            obra = (r.get("procedencia") or {}).get("obra")
+            if obra in cuenta:
+                cuenta[obra][esfera] += 1
+
+    return datos, cuenta
+
+
+ESFERAS = ("lexicon", "corpus", "cognados", "toponimos")
+
+
+def informe(datos, cuenta):
+    print("\n── Qué sostiene cada obra, medido ──")
+    print(f"  {'obra':28} {'lex':>5} {'corp':>5} {'cogn':>5} {'topo':>5}  esferas")
+    filas = sorted(datos, key=lambda o: -sum(cuenta[o].values()))
+    for oid in filas:
+        c = cuenta[oid]
+        total = sum(c.values())
+        if not total:
+            continue
+        n_esf = sum(1 for e in ESFERAS if c[e])
+        print(f"  {oid:28} {c['lexicon']:>5} {c['corpus']:>5} "
+              f"{c['cognados']:>5} {c['toponimos']:>5}  {'●' * n_esf}")
+
+    mudas = [o for o in datos if not sum(cuenta[o].values())]
+    if mudas:
+        print(f"\n  sin rastro medible ({len(mudas)}): {', '.join(sorted(mudas))}")
+        print("  (puede ser que no se haya minado, o que su cita esté escrita")
+        print("   de una forma que la búsqueda por apellido no atrapa)")
+
+
+def informe_esferas(datos, cuenta):
+    print("\n── Cuántas esferas alimenta cada obra ──")
+    print("  Una minería que solo toca el lexicón está desaprovechando la fuente.\n")
+    por_n = defaultdict(list)
+    for oid in datos:
+        n = sum(1 for e in ESFERAS if cuenta[oid][e])
+        por_n[n].append(oid)
+    for n in sorted(por_n, reverse=True):
+        etiqueta = {0: "ninguna", 1: "una sola", 2: "dos", 3: "tres", 4: "las cuatro"}[n]
+        print(f"  {etiqueta:12} ({len(por_n[n]):2d}): {', '.join(sorted(por_n[n])[:6])}"
+              + (" …" if len(por_n[n]) > 6 else ""))
+
+
+def informe_desfase(datos, cuenta):
+    print("\n── Declarado en el frontmatter vs. medido ──")
+    print("  `sostiene` se mantiene a mano; esto enseña cuánto ha derivado.\n")
+    hay = False
+    for oid, d in sorted(datos.items()):
+        dec = d.get("declarado") or {}
+        dl = dec.get("hechos_corpus")
+        dx = dec.get("entradas_lexicon")
+        ml, mx = cuenta[oid]["corpus"], cuenta[oid]["lexicon"]
+        if dl is None and dx is None:
+            continue
+        if (dl is not None and dl != ml) or (dx is not None and dx != mx):
+            hay = True
+            print(f"  {oid:28} corpus dec={dl} med={ml}   lexicón dec={dx} med={mx}")
+    if not hay:
+        print("  sin desfases detectables.")
+    print("\n  ⚠ Lexicón y corpus se miden por coincidencia del apellido sobre")
+    print("    texto libre, y eso falla en las DOS direcciones: por defecto si")
+    print("    la cita está escrita de otra forma, y por exceso si el apellido")
+    print("    aparece en prosa sin ser cita. Son estimación, no cuenta.")
+    print("    Cognados y topónimos sí son exactos: van por clave foránea.")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--esferas", action="store_true")
+    ap.add_argument("--desfase", action="store_true")
+    args = ap.parse_args(argv)
+
+    datos, cuenta = medir()
+    if args.esferas:
+        informe_esferas(datos, cuenta)
+    elif args.desfase:
+        informe_desfase(datos, cuenta)
+    else:
+        informe(datos, cuenta)
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/medir_sostiene.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/medir_sostiene.py
@@ -136,16 +136,30 @@ def medir():
     except Exception as e:                                   # noqa: BLE001
         print(f"  ⚠ no se pudo leer el lexicón: {e}")
 
-    # ── corpus (texto libre: cota inferior) ────────────────────────────
+    # ── corpus ─────────────────────────────────────────────────────────
+    # Mixto a propósito: si el hecho ya tiene `procedencia.obra`, se usa esa
+    # (exacta) y no se adivina por apellido. Los 58 migrados cuentan bien; los
+    # 103 que aún citan en prosa siguen siendo estimación. Conforme avance la
+    # migración, esta columna se vuelve exacta sola.
+    exactos = 0
     try:
         from compilar_corpus import compilar as compilar_corpus
         hechos, _, _ = compilar_corpus()
         for h in hechos:
+            obra = (h.get("procedencia") or {}).get("obra")
+            if obra:
+                if obra in cuenta:
+                    cuenta[obra]["corpus"] += 1
+                    exactos += 1
+                continue
             texto = " ".join(str(h.get(c, "")) for c in
                              ("referencia", "contenido", "implicacion_simulacion"))
             for oid, d in datos.items():
                 if d["claves"] and _cita(texto, d["claves"]):
                     cuenta[oid]["corpus"] += 1
+        if hechos:
+            print(f"  ({exactos}/{len(hechos)} hechos del corpus se cuentan por "
+                  f"clave foránea; el resto, por apellido)")
     except Exception as e:                                   # noqa: BLE001
         print(f"  ⚠ no se pudo leer el corpus: {e}")
 

--- a/proyecto-linguistico-caquetío/curiana_sim/migrar_cognados.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/migrar_cognados.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — fusionar los dos almacenes de cognados en `2-lengua/cognados.yaml`
+============================================================================
+
+Había dos, con esquemas distintos, y ninguno de los dos sabía del otro:
+
+| | `COGNADOS` (arahuaco_comparative) | `COGNADOS_OLIVER` |
+|---|---|---|
+| entradas | 37 | 16 |
+| lenguas | CQ WY LK TN PA **KL** | CQ WY LK TN PA **PJ CAIC** |
+| procedencia | **ninguna, 0 de 37** | página, ancla, confianza, duda del autor |
+| lo usa el motor | sí (`transducir`, `reconstruir_caquetio`) | no |
+
+Lo de la procedencia es lo grave: el set que alimenta la reconstrucción no cita
+nada, y el que sí cita —con la página de Oliver y hasta un campo para las dudas
+del propio Oliver— solo lo lee su minador.
+
+QUÉ HACE ESTA MIGRACIÓN
+-----------------------
+Un solo archivo, con la forma que un cognado **es**: una relación entre lenguas
+con procedencia.
+
+- **Las lenguas son un mapa abierto**, no casillas fijas. Así `KL`, `PJ`,
+  `CAIC` y el escape hatch `otros` dejan de ser tres soluciones al mismo
+  problema: si mañana aparece achagua, entra sin tocar el esquema.
+- **El id es estable y no es la glosa española.** Antes la clave era la glosa,
+  y por eso existía `rojo_almagre`: un desempate inventado para no chocar con
+  `rojo`. Ahora `cognado-NNN` y la glosa es un campo.
+- **A las 37 sin procedencia NO se les inventa una.** Van con
+  `procedencia: null` y `deuda: sin-procedencia`, para que el validador las
+  cuente y la deuda se vea en el tablero en lugar de esconderse en el código.
+
+⚠️ `arahuaco_comparative.COGNADOS` alimenta `transducir()` y
+`reconstruir_caquetio()`. Esta migración **no lo borra**: solo emite el YAML.
+Cambiar el consumidor es un paso aparte, y antes hay que congelar la salida
+actual con un test (ver `tests/test_cognados.py`).
+
+Uso:
+    python migrar_cognados.py            # escribe 2-lengua/cognados.yaml
+    python migrar_cognados.py --stdout
+"""
+
+import argparse
+import io
+import os
+import sys
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+SALIDA = os.path.join(REPO, "2-lengua", "cognados.yaml")
+
+# Códigos de lengua → el id de la lengua tal como lo usa el resto del proyecto.
+# Se deja el código corto como clave porque es el que usan las reglas de
+# transducción (REGLAS_WY_CQ, etc.) y cambiarlo sería un refactor aparte.
+LENGUAS = {
+    "PA": "proto-arahuaco",
+    "CQ": "caquetío",
+    "WY": "wayunaiki",
+    "LK": "lokono",
+    "TN": "taíno",
+    "KL": "kalinago",
+    "PJ": "paraujano",
+    "CAIC": "caicetío",
+}
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def _formas(entrada: dict) -> dict:
+    """Las formas por lengua, saltando los nulos y el escape hatch."""
+    salida = {}
+    for codigo in LENGUAS:
+        valor = entrada.get(codigo)
+        if valor:
+            salida[codigo] = valor
+    # `otros` era la vía de escape para lenguas sin casilla. Ahora que el mapa
+    # es abierto, sus claves entran como cualquier otra.
+    for lengua, forma in (entrada.get("otros") or {}).items():
+        if forma:
+            salida[lengua] = forma
+    return salida
+
+
+def construir():
+    sys.path.insert(0, AQUI)
+    import arahuaco_comparative as A
+    import cognados_oliver as O
+
+    registros = []
+    n = 0
+
+    # ── Los 16 de Oliver primero: son los que traen procedencia ────────
+    for clave, e in O.COGNADOS_OLIVER.items():
+        n += 1
+        reg = {
+            "id": f"cognado-{n:03d}",
+            "glosa": e.get("es") or clave,
+            "formas": _formas(e),
+            "fuente": "atestiguado",
+            "procedencia": {
+                "obra": "oliver-1989-cap2",
+                "pagina": e.get("pagina"),
+                "ancla": e.get("ancla"),
+            },
+            "confianza": e.get("confianza"),
+            "clave_origen": clave,
+        }
+        if e.get("oliver_duda"):
+            reg["duda_del_autor"] = e["oliver_duda"]
+        if e.get("no_cognado"):
+            reg["no_cognado"] = e["no_cognado"]
+        if e.get("nota"):
+            reg["nota"] = e["nota"]
+        registros.append(reg)
+
+    # ── Los 37 del set curado: sin procedencia, y se dice ──────────────
+    for clave, e in A.COGNADOS.items():
+        n += 1
+        registros.append({
+            "id": f"cognado-{n:03d}",
+            "glosa": e.get("es") or clave,
+            "formas": _formas(e),
+            "fuente": "reconstruido",
+            "procedencia": None,
+            "deuda": "sin-procedencia",
+            "clave_origen": clave,
+        })
+
+    return registros
+
+
+def separar_no_cognados(registros):
+    """Aparta las entradas con una sola lengua.
+
+    Un cognado es una relación **entre** lenguas: una entrada con una sola
+    forma es una palabra suelta que acabó en el sitio equivocado. Hay dos en el
+    set curado, y no son el mismo caso:
+
+    - `baruwa` (KL, 'hombre') **ya está en `VOCABULARIO_BASE`** con la misma
+      glosa, así que aquí sobra.
+    - `quiripa` (CQ, concha-moneda) **no está en ninguna otra parte**: este
+      registro es su única constancia en el repo. Borrarlo perdería el dato.
+
+    Por eso no se borran ni se emiten como cognados: van a una sección propia
+    con el diagnóstico, y qué hacer con cada uno es decisión aparte.
+    """
+    sys.path.insert(0, AQUI)
+    try:
+        from curiana_lexicon import VOCABULARIO_BASE
+        lexico = set(VOCABULARIO_BASE)
+    except Exception:                                        # noqa: BLE001
+        lexico = set()
+
+    cognados, sueltos = [], []
+    for r in registros:
+        if len(r.get("formas") or {}) >= 2:
+            cognados.append(r)
+            continue
+        forma = next(iter(r["formas"].values()), None)
+        r["diagnostico"] = (
+            "ya existe en VOCABULARIO_BASE — este registro sobra"
+            if forma in lexico else
+            "NO está en VOCABULARIO_BASE — este registro es su única "
+            "constancia; moverlo al lexicón antes de retirarlo de aquí")
+        sueltos.append(r)
+    return cognados, sueltos
+
+
+def duplicados(registros):
+    """Mismo par (lengua, forma) en dos cognados distintos.
+
+    `para` ('mar') estaba en los dos almacenes con la misma glosa. No se fusiona
+    automáticamente —decidir que dos entradas son la misma es criterio, no
+    script— pero sí se reporta.
+    """
+    vistos = {}
+    choques = []
+    for r in registros:
+        for lengua, forma in r["formas"].items():
+            clave = (lengua, str(forma).lower())
+            if clave in vistos:
+                choques.append((lengua, forma, vistos[clave], r["id"]))
+            else:
+                vistos[clave] = r["id"]
+    return choques
+
+
+def documento(registros, sueltos):
+    con = sum(1 for r in registros if r.get("procedencia"))
+    lenguas = sorted({l for r in registros for l in r["formas"]})
+    nucleo = sorted(l for l in lenguas if l.isupper())
+    return {
+        "meta": {
+            "generado_por": "curiana_sim/migrar_cognados.py",
+            "cognados": len(registros),
+            "con_procedencia": con,
+            "sin_procedencia": len(registros) - con,
+            "lenguas_nucleo": nucleo,
+            "lenguas_comparanda": len(lenguas) - len(nucleo),
+            "no_son_cognados": len(sueltos),
+            "nota": ("Fusión de arahuaco_comparative.COGNADOS (37, sin procedencia) "
+                     "y cognados_oliver.COGNADOS_OLIVER (16, con página y ancla). "
+                     "Las formas van en un mapa abierto: los códigos en mayúscula "
+                     "son el núcleo con reglas de transducción; los nombres en "
+                     "minúscula son comparanda citada, y son abiertos a propósito."),
+        },
+        "cognados": registros,
+        "no_son_cognados": sueltos,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stdout", action="store_true")
+    args = ap.parse_args(argv)
+
+    registros, sueltos = separar_no_cognados(construir())
+    choques = duplicados(registros)
+
+    texto = yaml.safe_dump(documento(registros, sueltos), allow_unicode=True,
+                           sort_keys=False, default_flow_style=False, width=100)
+    if args.stdout:
+        print(texto)
+        return 0
+
+    os.makedirs(os.path.dirname(SALIDA), exist_ok=True)
+    with open(SALIDA, "w", encoding="utf-8") as fh:
+        fh.write(texto)
+
+    con = sum(1 for r in registros if r.get("procedencia"))
+    print(f"  → {os.path.relpath(SALIDA, REPO)}: {len(registros)} cognados")
+    print(f"     con procedencia: {con}   sin procedencia: {len(registros) - con}")
+    if sueltos:
+        print(f"\n  ⚠ {len(sueltos)} entrada(s) apartada(s) por tener una sola lengua:")
+        for r in sueltos:
+            print(f"     {r['id']}  {list(r['formas'].items())}")
+            print(f"        {r['diagnostico']}")
+    if choques:
+        print(f"\n  ⚠ {len(choques)} forma(s) repetida(s) entre cognados distintos:")
+        for lengua, forma, a, b in choques:
+            print(f"     {lengua} «{forma}»  en {a} y en {b}")
+        print("     No se fusionan solas: decidir que dos entradas son la misma")
+        print("     es criterio humano. Quedan reportadas.")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/migrar_corpus_procedencia.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/migrar_corpus_procedencia.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — llevar el corpus de `referencia` en prosa a `procedencia.obra`
+========================================================================
+
+Los 161 hechos de `3-mundo/corpus/` citan su fuente en un campo de **texto
+libre**:
+
+    referencia: "Oliver 1989, cap. 3, pp. 255-256, 268 (\"the office of chief…\")"
+
+Eso no se puede comprobar. Cognados y topónimos ya usan `procedencia.obra`, una
+clave foránea contra `4-fuentes/bibliografia.yaml`, y el validador la verifica.
+El corpus es la esfera grande que falta.
+
+CÓMO LO DEDUCE, Y POR QUÉ NO SE FÍA
+-----------------------------------
+Busca en la `referencia` los patrones de cada obra (apellido del autor + sus
+`aliases`, tomados de la bibliografía). Y entonces:
+
+- **exactamente una obra coincide** → propone `procedencia: {obra: <id>}`
+- **varias coinciden** → NO decide. Una referencia como *"Oviedo y Baños 1855:27,
+  vía Zavala Reyes 2015 p.60"* cita dos obras con papeles distintos (la fuente
+  última y el intermediario), y elegir por frecuencia sería inventar.
+- **ninguna coincide** → lo deja y lo cuenta
+
+**El campo `referencia` no se toca.** La prosa dice cosas que un id no puede
+—página, cita textual, "vía tal"— y se conserva entera. `procedencia` se añade
+al lado: uno es para leer, el otro para comprobar.
+
+Uso:
+    python migrar_corpus_procedencia.py            # simulacro
+    python migrar_corpus_procedencia.py --aplicar
+    python migrar_corpus_procedencia.py --ambiguos # los que citan varias obras
+"""
+
+import argparse
+import io
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+CORPUS = os.path.join(REPO, "3-mundo", "corpus")
+BIBLIOGRAFIA = os.path.join(REPO, "4-fuentes", "bibliografia.yaml")
+
+# Un patrón de menos de 5 caracteres engancha con cualquier cosa. Medido: con
+# umbral 4, "Adam" aparecía dentro de otras palabras.
+MIN_PATRON = 5
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def patrones_por_obra():
+    with open(BIBLIOGRAFIA, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    salida = {}
+    for o in doc["obras"]:
+        claves = set()
+        apellido = str(o.get("autor", "")).split(",")[0].strip()
+        if len(apellido) >= MIN_PATRON and apellido.lower() != "varios":
+            claves.add(apellido)
+        for alias in o.get("aliases") or []:
+            alias = str(alias).strip()
+            if len(alias) >= MIN_PATRON:
+                claves.add(alias)
+        if claves:
+            salida[o["id"]] = claves
+    return salida
+
+
+def obras_citadas(texto: str, patrones) -> list:
+    if not texto:
+        return []
+    bajo = texto.lower()
+    return sorted(oid for oid, claves in patrones.items()
+                  if any(k.lower() in bajo for k in claves))
+
+
+def recorrer(datos):
+    """Genera (contenedor, indice, hecho) para cualquier forma de raíz."""
+    if isinstance(datos, list):
+        for i, h in enumerate(datos):
+            if isinstance(h, dict):
+                yield datos, i, h
+    elif isinstance(datos, dict):
+        for valor in datos.values():
+            if isinstance(valor, list):
+                for i, h in enumerate(valor):
+                    if isinstance(h, dict):
+                        yield valor, i, h
+
+
+def analizar():
+    patrones = patrones_por_obra()
+    resultado = defaultdict(list)   # archivo -> [(id, obras_citadas)]
+    for nombre in sorted(os.listdir(CORPUS)):
+        if not nombre.endswith(".yaml") or nombre == "genealogia.yaml":
+            continue
+        with open(os.path.join(CORPUS, nombre), encoding="utf-8") as fh:
+            datos = yaml.safe_load(fh)
+        for _, _, h in recorrer(datos):
+            if "fuente" not in h:
+                continue
+            citadas = obras_citadas(str(h.get("referencia", "")), patrones)
+            resultado[nombre].append((h.get("id"), citadas, h.get("procedencia")))
+    return resultado
+
+
+# Inicio de una entrada del corpus: "- id: parentesco-001"
+_RE_ID = re.compile(r"^(\s*)-\s+id:\s*(\S+)\s*$")
+# Cualquier clave al nivel de la entrada: "  fuente: …", "  dominios:"
+_RE_CLAVE = re.compile(r"^(\s*)([a-z_]+):")
+
+
+def aplicar():
+    """Inserta `procedencia` **como texto**, sin round-trip de YAML.
+
+    Cargar y volver a volcar con `yaml.safe_dump` reformatea el archivo entero:
+    los bloques `>` de `contenido` se vuelven cadenas entrecomilladas y los
+    comentarios de cabecera desaparecen. Sobre datos de investigación curados
+    eso es inaceptable — el YAML se lee, no solo se parsea.
+
+    Así que se localiza la línea de `referencia:` de cada entrada migrable y se
+    inserta el bloque justo después de que termine, respetando la indentación y
+    dejando el resto del archivo byte a byte.
+    """
+    patrones = patrones_por_obra()
+    tocados = Counter()
+
+    for nombre in sorted(os.listdir(CORPUS)):
+        if not nombre.endswith(".yaml") or nombre == "genealogia.yaml":
+            continue
+        ruta = os.path.join(CORPUS, nombre)
+        with open(ruta, encoding="utf-8") as fh:
+            datos = yaml.safe_load(fh)
+        with open(ruta, encoding="utf-8") as fh:
+            lineas = fh.read().splitlines(keepends=True)
+
+        # id → obra, solo para los inequívocos y sin procedencia previa.
+        destino = {}
+        for _, _, h in recorrer(datos):
+            if "fuente" not in h or h.get("procedencia") is not None:
+                continue
+            citadas = obras_citadas(str(h.get("referencia", "")), patrones)
+            if len(citadas) == 1:
+                destino[h.get("id")] = citadas[0]
+        if not destino:
+            continue
+
+        salida = []
+        actual = None       # id de la entrada que se está recorriendo
+        sangria = "  "
+        i = 0
+        while i < len(lineas):
+            linea = lineas[i]
+            salida.append(linea)
+
+            m = _RE_ID.match(linea.rstrip("\n"))
+            if m:
+                actual = m.group(2)
+                sangria = m.group(1) + "  "
+                i += 1
+                continue
+
+            if actual in destino:
+                mc = _RE_CLAVE.match(linea)
+                if mc and mc.group(2) == "referencia":
+                    # Consumir el valor completo: puede ocupar varias líneas si
+                    # es un bloque o una cadena continuada.
+                    j = i + 1
+                    while j < len(lineas):
+                        siguiente = lineas[j]
+                        if not siguiente.strip():
+                            break
+                        mk = _RE_CLAVE.match(siguiente)
+                        if mk and len(mk.group(1)) <= len(mc.group(1)):
+                            break
+                        if _RE_ID.match(siguiente.rstrip("\n")):
+                            break
+                        salida.append(siguiente)
+                        j += 1
+                    salida.append(f"{sangria}procedencia: {{obra: {destino[actual]}}}\n")
+                    tocados[nombre] += 1
+                    del destino[actual]
+                    i = j
+                    continue
+            i += 1
+
+        with open(ruta, "w", encoding="utf-8", newline="") as fh:
+            fh.writelines(salida)
+    return tocados
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--aplicar", action="store_true")
+    ap.add_argument("--ambiguos", action="store_true")
+    args = ap.parse_args(argv)
+
+    resultado = analizar()
+    unica = ambigua = ninguna = ya = 0
+    ambiguos = []
+    sin = []
+    for archivo, filas in resultado.items():
+        for hid, citadas, proc in filas:
+            if proc:
+                ya += 1
+            elif len(citadas) == 1:
+                unica += 1
+            elif len(citadas) > 1:
+                ambigua += 1
+                ambiguos.append((archivo, hid, citadas))
+            else:
+                ninguna += 1
+                sin.append((archivo, hid))
+
+    total = unica + ambigua + ninguna + ya
+    print(f"\n── Corpus: {total} hechos ──")
+    print(f"  ya tienen procedencia      {ya:4d}")
+    print(f"  citan UNA obra → migrables {unica:4d}")
+    print(f"  citan VARIAS → decisión    {ambigua:4d}")
+    print(f"  no citan obra conocida     {ninguna:4d}")
+
+    if args.ambiguos:
+        print("\n── Los que citan varias obras ──")
+        print("  Casi siempre es «fuente última, vía intermediario»: son dos")
+        print("  papeles distintos y elegir uno por frecuencia sería inventar.\n")
+        for archivo, hid, citadas in ambiguos:
+            print(f"  {hid:26} {', '.join(citadas)}")
+        return 0
+
+    if not args.aplicar:
+        print("\n  ── SIMULACRO ── no se ha escrito nada.")
+        print("     Aplicar:  python migrar_corpus_procedencia.py --aplicar")
+        print("     Ver los ambiguos:  --ambiguos")
+        if sin:
+            print(f"\n  sin obra reconocible ({len(sin)}), muestra:")
+            for archivo, hid in sin[:8]:
+                print(f"     {hid}")
+        return 0
+
+    tocados = aplicar()
+    print("\n  aplicado:")
+    for archivo, n in sorted(tocados.items()):
+        print(f"     {archivo:28} +{n}")
+    print(f"\n  total migrados: {sum(tocados.values())}")
+    print("  `referencia` NO se ha tocado: la prosa dice cosas que un id no puede.")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/migrar_toponimos.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/migrar_toponimos.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — desarmar `lexicon_toponimos.py` en datos consultables
+===============================================================
+
+El módulo tenía **doce contenedores de nivel superior** para lo que en realidad
+son tres entidades distintas más un puñado de prosa:
+
+    NIVEL_A / NIVEL_B / NIVEL_C / DESCARTES      → topónimos analizados
+    MORFEMAS_DESPEJADOS / FORMATIVOS_SIN_GLOSA   → formantes extraídos
+    CORROBORACIONES_LEXICON                      → enlaces lexicón ↔ topónimo
+    REDUPLICACION / CONFLICTOS / ANTROPONIMOS    → prosa editorial
+    TOTALES / FUENTES                            → metadatos
+
+Tres problemas concretos que eso produjo:
+
+1. **El nivel de confianza era un campo disfrazado de tres contenedores.** Para
+   preguntar "todos los topónimos" había que unir tres dicts, y añadir un nivel
+   significaba crear un contenedor.
+2. **`TOTALES` declara `nivel_D: 47` y `NIVEL_D` no existe en el módulo.** Una
+   cifra a mano apuntando a nada — justo lo que la regla 1 prohíbe.
+3. **`ANTROPONIMOS` no contiene antropónimos**: contiene `total`,
+   `con_glosa_descriptiva`, `resueltos`, un `detalle` anidado con los datos, y
+   dos campos de prosa (`veredicto`, `consecuencia`). Dato, recuento y opinión
+   en la misma estructura.
+
+Y nadie importaba el módulo: 739 líneas de análisis curado que ningún consumidor
+leía.
+
+QUÉ EMITE
+---------
+    2-lengua/toponimos.yaml   los topónimos, con `nivel` como campo
+    2-lengua/morfemas.yaml    los formantes, con su estatus
+
+La prosa (`REDUPLICACION`, `CONFLICTOS`, el veredicto de los antropónimos) **no
+se migra**: se queda para `2-lengua/toponimia.md`, que es donde vive el
+argumento. Un YAML no es sitio para un veredicto.
+
+Uso:
+    python migrar_toponimos.py
+    python migrar_toponimos.py --stdout
+"""
+
+import argparse
+import io
+import os
+import sys
+
+import yaml
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+DIR_LENGUA = os.path.join(REPO, "2-lengua")
+
+# La obra que sostiene cada análisis, por el valor del campo `fuente` que traía
+# el módulo. Es la clave foránea a 4-fuentes/bibliografia.yaml.
+OBRA_POR_FUENTE = {
+    "zavala-reyes-2015": "zavala-reyes-2015",
+    "van-buurt-2014": "van-buurt-2014",
+    "gatschet-1885": "gatschet-1885",
+}
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def _limpio(d: dict, saltar=()) -> dict:
+    return {k: v for k, v in d.items() if k not in saltar and v not in (None, "", [], {})}
+
+
+def toponimos(T):
+    """NIVEL_A/B/C + DESCARTES → una lista con `nivel` como campo."""
+    registros = []
+    n = 0
+    for nivel, contenedor in (("A", T.NIVEL_A), ("B", T.NIVEL_B), ("C", T.NIVEL_C)):
+        for forma, e in contenedor.items():
+            n += 1
+            reg = {
+                "id": f"toponimo-{n:03d}",
+                "forma": forma,
+                "nivel": nivel,
+                "clase": e.get("clase", "topónimo"),
+            }
+            reg.update(_limpio(e, saltar=("clase", "fuente")))
+            obra = OBRA_POR_FUENTE.get(e.get("fuente"))
+            reg["procedencia"] = {"obra": obra} if obra else None
+            if not obra:
+                reg["deuda"] = "sin-procedencia"
+            registros.append(reg)
+
+    # DESCARTES viene indexado por RAZÓN, con una lista de formas dentro. Se
+    # expande a un registro por forma: la unidad es el topónimo, no el motivo.
+    for razon, e in T.DESCARTES.items():
+        for forma in e.get("formas", []):
+            n += 1
+            registros.append({
+                "id": f"toponimo-{n:03d}",
+                "forma": forma,
+                "nivel": "descartado",
+                "clase": "topónimo",
+                "razon": e.get("razon") or razon,
+                "procedencia": None,
+                "deuda": "sin-procedencia",
+            })
+    return registros
+
+
+def morfemas(T):
+    """MORFEMAS_DESPEJADOS + FORMATIVOS_SIN_GLOSA → una lista con `estatus`."""
+    registros = []
+    n = 0
+    for forma, e in T.MORFEMAS_DESPEJADOS.items():
+        n += 1
+        reg = {"id": f"morfema-{n:03d}", "forma": forma, "glosado": True}
+        reg.update(_limpio(e))
+        registros.append(reg)
+    for forma, e in T.FORMATIVOS_SIN_GLOSA.items():
+        n += 1
+        reg = {"id": f"morfema-{n:03d}", "forma": forma, "glosado": False}
+        reg.update(_limpio(e))
+        registros.append(reg)
+    return registros
+
+
+def corroboraciones(T):
+    """Palabras del lexicón que un topónimo respalda de forma independiente."""
+    salida = []
+    for palabra, e in T.CORROBORACIONES_LEXICON.items():
+        reg = {"palabra": palabra}
+        reg.update(_limpio(e))
+        salida.append(reg)
+    return salida
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stdout", action="store_true")
+    args = ap.parse_args(argv)
+
+    sys.path.insert(0, AQUI)
+    import lexicon_toponimos as T
+
+    tops = toponimos(T)
+    morfs = morfemas(T)
+    corrs = corroboraciones(T)
+
+    por_nivel = {}
+    for r in tops:
+        por_nivel[r["nivel"]] = por_nivel.get(r["nivel"], 0) + 1
+
+    doc_top = {
+        "meta": {
+            "generado_por": "curiana_sim/migrar_toponimos.py",
+            "toponimos": len(tops),
+            "por_nivel": por_nivel,
+            "con_procedencia": sum(1 for r in tops if r.get("procedencia")),
+            "corroboraciones_del_lexicon": len(corrs),
+            "nota": ("El nivel de confianza es un CAMPO, no un contenedor: "
+                     "antes eran NIVEL_A/B/C separados y para listar todos los "
+                     "topónimos había que unir tres dicts. La prosa (reduplicación, "
+                     "conflictos, veredicto sobre antropónimos) vive en "
+                     "2-lengua/toponimia.md, no aquí."),
+        },
+        "toponimos": tops,
+        "corroboraciones_lexicon": corrs,
+    }
+    doc_mor = {
+        "meta": {
+            "generado_por": "curiana_sim/migrar_toponimos.py",
+            "morfemas": len(morfs),
+            "glosados": sum(1 for m in morfs if m["glosado"]),
+            "sin_glosa": sum(1 for m in morfs if not m["glosado"]),
+        },
+        "morfemas": morfs,
+    }
+
+    if args.stdout:
+        print(yaml.safe_dump(doc_top, allow_unicode=True, sort_keys=False,
+                             default_flow_style=False, width=100))
+        return 0
+
+    os.makedirs(DIR_LENGUA, exist_ok=True)
+    for nombre, doc in (("toponimos.yaml", doc_top), ("morfemas.yaml", doc_mor)):
+        ruta = os.path.join(DIR_LENGUA, nombre)
+        with open(ruta, "w", encoding="utf-8") as fh:
+            fh.write(yaml.safe_dump(doc, allow_unicode=True, sort_keys=False,
+                                    default_flow_style=False, width=100))
+        print(f"  → {os.path.relpath(ruta, REPO)}")
+
+    print(f"\n  topónimos: {len(tops)}  {por_nivel}")
+    print(f"  con procedencia: {doc_top['meta']['con_procedencia']}/{len(tops)}")
+    print(f"  morfemas: {len(morfs)}  ({doc_mor['meta']['glosados']} glosados)")
+    print(f"  corroboraciones del lexicón: {len(corrs)}")
+    print("\n  ⚠ La prosa NO se migró (reduplicación, conflictos, veredicto de")
+    print("    antropónimos). Va a 2-lengua/toponimia.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_cronista.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_cronista.py
@@ -1,0 +1,85 @@
+"""Tests del cronista.
+
+Lo que protegen es que la perspectiva sea **comprobable** y no una declaración
+de intenciones. Una tabla de sustituciones que nadie verifica es una opinión;
+verificada contra el lexicón y la bibliografía, es una afirmación sobre el dato
+que se cae sola si alguien cambia el dato.
+
+Y protegen el límite epistémico: el cronista es una lectura, nunca una fuente.
+"""
+
+import pytest
+
+from curiana_cronista import (
+    DESCOLONIZAR,
+    LIMITE,
+    glosario_prompt,
+    prompt_cronista,
+    verificar,
+)
+
+
+def test_la_tabla_se_sostiene_contra_el_dato():
+    problemas = verificar()
+    assert not problemas, "la tabla de descolonización no cuadra:\n" + "\n".join(
+        f"  {p}" for p in problemas)
+
+
+@pytest.mark.parametrize("fila", DESCOLONIZAR, ids=lambda f: f["ajeno"][:18])
+def test_cada_sustitucion_dice_de_donde_viene_y_quien_lo_dice(fila):
+    """Sin `de_donde_viene` y `fuente`, la sustitución sería un gusto personal.
+    Con ellos es una corrección con cita."""
+    assert fila["de_donde_viene"].strip()
+    assert fila["fuente"].strip()
+    assert fila["nota"].strip()
+
+
+def test_las_palabras_ajenas_no_se_cuelan_en_el_prompt_como_nuestras():
+    """`piache` y `cacique` pueden aparecer en el prompt —hay que nombrarlas
+    para rechazarlas— pero solo del lado ajeno de la flecha."""
+    glosario = glosario_prompt()
+    for ajena in ("piache", "cacique"):
+        assert f"«{ajena}»" in glosario, f"{ajena} debería nombrarse para rechazarla"
+        assert f"→ **{ajena}**" not in glosario, (
+            f"{ajena} aparece como palabra propuesta, y no es caquetía")
+
+
+def test_el_prompt_usa_las_palabras_propias():
+    p = prompt_cronista()
+    for propia in ("boratio", "diao", "apopo", "capu", "barsure", "biro", "para"):
+        assert propia in p, f"el cronista debería nombrar `{propia}`"
+
+
+def test_el_prompt_prohibe_inventar_datos():
+    """La regla que impide que esta voz contamine el corpus."""
+    p = prompt_cronista().lower()
+    assert "no inventes" in p
+    assert "evidencia" in p and "corpus" in p, (
+        "el prompt tiene que decir que lo que cuenta no es evidencia ni entra "
+        "al corpus")
+
+
+def test_el_prompt_prohibe_romantizar():
+    """Contar desde dentro no es contar bonito: hay hambre y hay raids."""
+    assert "no romantices" in prompt_cronista().lower()
+
+
+def test_el_limite_epistemico_esta_escrito():
+    """La honestidad sobre qué es esta voz no puede quedar solo en el commit."""
+    assert "construida" in LIMITE
+    assert "extinta" in LIMITE
+    assert "Paraguaná" in LIMITE
+
+
+def test_el_limite_no_va_en_el_prompt_del_agente_por_defecto():
+    """Un cronista no se explica a sí mismo mientras narra; pero el límite tiene
+    que estar disponible para quien lea."""
+    assert LIMITE not in prompt_cronista()
+    assert LIMITE in prompt_cronista(incluir_limite=True)
+
+
+def test_no_promete_recuperar_la_voz_caquetia():
+    """El proyecto entero se cae si esto se vende como voz recuperada."""
+    texto = prompt_cronista(incluir_limite=True).lower()
+    assert "no se puede" in texto or "construida" in texto
+    assert "fabricando" in texto or "no lo sería" in texto

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_lengua.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_lengua.py
@@ -1,0 +1,190 @@
+"""Tests del validador de datos de lengua (compilar_lengua.py).
+
+Lo que estos tests protegen es **la integridad referencial de las citas**. Hasta
+que existió `bibliografia.yaml`, una cita era texto libre: nadie comprobaba que
+la obra citada existiera. Ahora `procedencia.obra` es una clave foránea, y si
+esa comprobación se rompe volvemos al régimen anterior sin enterarnos.
+
+Como en `test_compilar_corpus.py`, la mitad son negativos: un validador que
+nunca falla y uno que no valida nada se ven igual desde fuera.
+"""
+
+import pytest
+
+from compilar_lengua import (
+    LENGUAS_NUCLEO,
+    NIVELES_TOPONIMO,
+    compilar,
+    obras_conocidas,
+    validar_cognados,
+    validar_procedencia,
+    validar_toponimos,
+)
+
+
+def _codigos(problemas, nivel=None):
+    return {p.codigo for p in problemas if nivel is None or p.nivel == nivel}
+
+
+def _cognado(**kw):
+    base = {
+        "id": "cognado-001",
+        "glosa": "luna",
+        "formas": {"CQ": "cati", "LK": "katsi"},
+        "procedencia": {"obra": "oliver-1989-cap2", "pagina": 142},
+    }
+    base.update(kw)
+    return base
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Los datos reales
+# ══════════════════════════════════════════════════════════════════════
+
+def test_los_datos_de_lengua_validan():
+    _, problemas = compilar()
+    errores = [p for p in problemas if p.nivel == "error"]
+    assert not errores, "errores en los datos de lengua:\n" + "\n".join(
+        f"  {p}" for p in errores)
+
+
+def test_la_bibliografia_existe_y_tiene_obras():
+    """Sin ella no hay integridad referencial: toda cita vuelve a ser prosa."""
+    obras = obras_conocidas()
+    assert obras, "4-fuentes/bibliografia.yaml no existe o está vacía"
+    assert "oliver-1989-cap2" in obras
+    assert "zavala-reyes-2015" in obras
+
+
+def test_todo_cognado_declara_su_situacion_de_fuente():
+    """O cita una obra, o dice explícitamente que no la tiene. Lo que no vale
+    es callar: un hueco declarado es dato, un hueco callado es una cita que no
+    existe."""
+    datos, _ = compilar()
+    for r in datos["cognados"]["cognados"]:
+        tiene = r.get("procedencia") is not None
+        declara = r.get("deuda") == "sin-procedencia"
+        assert tiene or declara, f"{r['id']} no declara su situación de fuente"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# La integridad referencial
+# ══════════════════════════════════════════════════════════════════════
+
+def test_detecta_obra_que_no_existe():
+    """El punto entero de la bibliografía."""
+    r = _cognado(procedencia={"obra": "borges-1941-tlon", "pagina": 1})
+    problemas = validar_procedencia([r], {"oliver-1989-cap2"}, "cognados")
+    assert "obra-fantasma" in _codigos(problemas)
+
+
+def test_acepta_obra_que_si_existe():
+    r = _cognado()
+    assert not validar_procedencia([r], {"oliver-1989-cap2"}, "cognados")
+
+
+def test_detecta_procedencia_callada():
+    r = _cognado(procedencia=None)
+    assert "procedencia-callada" in _codigos(validar_procedencia([r], set(), "cognados"))
+
+
+def test_la_deuda_declarada_es_legal():
+    r = _cognado(procedencia=None, deuda="sin-procedencia")
+    assert not validar_procedencia([r], set(), "cognados")
+
+
+def test_detecta_procedencia_sin_obra():
+    r = _cognado(procedencia={"pagina": 42})
+    assert "procedencia-sin-obra" in _codigos(validar_procedencia([r], set(), "cognados"))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Lo que es un cognado y lo que no
+# ══════════════════════════════════════════════════════════════════════
+
+def test_un_cognado_de_una_sola_lengua_no_es_un_cognado():
+    doc = {"cognados": [_cognado(formas={"CQ": "quiripa"})]}
+    assert "no-es-un-cognado" in _codigos(validar_cognados(doc, {"oliver-1989-cap2"}))
+
+
+def test_codigo_del_nucleo_inventado_es_error():
+    """Los códigos en mayúscula los usa `transducir()`: uno inventado rompería
+    la transducción en silencio."""
+    doc = {"cognados": [_cognado(formas={"CQ": "cati", "XX": "algo"})]}
+    assert "codigo-de-lengua-desconocido" in _codigos(
+        validar_cognados(doc, {"oliver-1989-cap2"}))
+
+
+@pytest.mark.parametrize("lengua", ["maipure", "baré", "wapishana", "tariana"])
+def test_la_comparanda_en_minuscula_es_libre(lengua):
+    """Las ~24 lenguas arahuacas que cita Oliver son comparanda, no maquinaria.
+    Cerrar esa lista obligaría a tocar el esquema cada vez que una fuente cita
+    una lengua nueva."""
+    doc = {"cognados": [_cognado(formas={"CQ": "cati", lengua: "kethi"})]}
+    assert "codigo-de-lengua-desconocido" not in _codigos(
+        validar_cognados(doc, {"oliver-1989-cap2"}))
+
+
+def test_avisa_de_forma_repetida_entre_cognados():
+    """`para` estaba en los dos almacenes. No se fusiona sola —decidir que dos
+    entradas son la misma es criterio— pero no puede pasar desapercibido."""
+    doc = {"cognados": [
+        _cognado(id="cognado-001", formas={"CQ": "para", "LK": "bara"}),
+        _cognado(id="cognado-002", formas={"CQ": "para", "TN": "bagua"}),
+    ]}
+    assert "forma-repetida" in _codigos(validar_cognados(doc, {"oliver-1989-cap2"}), "aviso")
+
+
+def test_cognado_sin_glosa_es_error():
+    doc = {"cognados": [_cognado(glosa=None)]}
+    assert "sin-glosa" in _codigos(validar_cognados(doc, {"oliver-1989-cap2"}))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Topónimos
+# ══════════════════════════════════════════════════════════════════════
+
+def test_nivel_de_toponimo_ilegal():
+    doc = {"toponimos": [{"id": "toponimo-001", "forma": "x", "nivel": "Z",
+                          "procedencia": None, "deuda": "sin-procedencia"}]}
+    assert "nivel-ilegal" in _codigos(validar_toponimos(doc, set(), None, set()))
+
+
+@pytest.mark.parametrize("nivel", NIVELES_TOPONIMO)
+def test_los_cuatro_niveles_son_legales(nivel):
+    """El nivel es un CAMPO. Antes eran tres contenedores separados, y para
+    listar todos los topónimos había que unir tres dicts."""
+    doc = {"toponimos": [{"id": "toponimo-001", "forma": "x", "nivel": nivel,
+                          "procedencia": None, "deuda": "sin-procedencia"}]}
+    assert "nivel-ilegal" not in _codigos(validar_toponimos(doc, set(), None, set()))
+
+
+def test_toponimos_reales_conservan_los_totales_del_modulo_viejo():
+    """`lexicon_toponimos.TOTALES` declaraba 74 procesados y 6/8/13/47 por
+    nivel. Si la migración fuera infiel, esto lo cazaría."""
+    datos, _ = compilar()
+    por_nivel = datos["toponimos"]["meta"]["por_nivel"]
+    assert datos["toponimos"]["meta"]["toponimos"] == 74
+    assert por_nivel == {"A": 6, "B": 8, "C": 13, "descartado": 47}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Ids
+# ══════════════════════════════════════════════════════════════════════
+
+def test_ids_unicos_en_los_datos_reales():
+    datos, _ = compilar()
+    for clave, seccion in (("cognados", "cognados"), ("toponimos", "toponimos"),
+                           ("morfemas", "morfemas")):
+        regs = datos[clave][seccion]
+        ids = [r["id"] for r in regs]
+        assert len(ids) == len(set(ids)), f"ids repetidos en {clave}"
+
+
+def test_el_id_no_es_la_glosa_espanola():
+    """La clave era la glosa, y por eso existía `rojo_almagre`: un desempate
+    inventado para no chocar con `rojo`."""
+    datos, _ = compilar()
+    for r in datos["cognados"]["cognados"]:
+        assert r["id"].startswith("cognado-")
+        assert r["id"] != r.get("glosa")


### PR DESCRIPTION
**Apilado sobre #86** — mergear ese primero.

Reestructura de cómo guardamos cognados, topónimos y fuentes. Tres cambios que van juntos.

## Citar pasa a ser comprobable

Hasta ahora una cita era **texto libre**: nadie verificaba que la obra existiera. Ahora `4-fuentes/bibliografia.yaml` (30 obras, generado desde el frontmatter) es la autoridad, y `procedencia.obra` es una **clave foránea** que el validador comprueba.

Cuando no hay fuente, hay que declararlo con `deuda: sin-procedencia`. Un hueco declarado es dato; un hueco callado es una cita que no existe.

## Cognados: había dos almacenes, y el bueno no se usaba

| | `COGNADOS` | `COGNADOS_OLIVER` |
|---|---|---|
| entradas | 37 | 16 |
| procedencia | **0 de 37** | página, ancla, confianza |
| lo usaba el motor | **sí** | no |

El set que alimentaba `transducir()` no citaba nada; el que traía la página de Oliver solo lo leía su minador. Ahora es uno: 51 cognados, 16 con procedencia y 35 con la deuda declarada.

Las lenguas van en mapa abierto, con una distinción que importa: los códigos en mayúscula son el núcleo con reglas de transducción (uno inventado ahí rompería `transducir()` en silencio); los nombres en minúscula son las ~24 lenguas arahuacas de comparanda, libres a propósito.

**Dos cosas que la migración sacó a la luz sin decidir por su cuenta**: `para` estaba en los dos con versiones complementarias (Oliver da `TN bara-wa`, el set curado `TN bagua`) — es filología, no dedup. Y dos entradas tenían una sola lengua: `baruwa` ya está en el lexicón, pero `quiripa` no está en ninguna otra parte y este registro es su única constancia.

## Topónimos: el nivel era un campo disfrazado de tres contenedores

Doce contenedores para tres entidades más prosa, y **nadie importaba el módulo**. Ahora `toponimos.yaml` (74, `nivel` como campo) y `morfemas.yaml` (10). La prosa va a `toponimia.md`: un YAML no es sitio para un veredicto.

## Minar alimenta todas las esferas

`medir_sostiene.py` mide el rastro de cada obra en las cuatro esferas: **18 de 30 obras dejan rastro en una sola**, y el `sostiene` del frontmatter ha derivado en 17 de 30. La skill y CLAUDE.md pasan a decir que la nota de fuente es la bitácora, no el almacén.

## El corpus, a medio migrar a propósito

58 hechos migrados a `procedencia.obra`; 38 quedan porque citan varias obras — y eso **no es un fallo**: es la cadena de custodia (`creencia-001` cita Arcaya, Jahn y Oviedo porque el dato es de Oviedo vía los otros dos).

⚠️ La primera versión de esa migración reformateaba los YAML enteros con `yaml.safe_dump` (perdía los bloques `>` y los comentarios). Revertida y rehecha como inserción de texto: **58 inserciones, 0 borrados**.

---

24 tests nuevos (149), 7 guardianes en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
