### PR TITLE
La huella de la base (#68) y la dinámica de los runs

### DIFF
--- a/proyecto-linguistico-caquetío/5-experimento/DINAMICA_DE_RUNS.md
+++ b/proyecto-linguistico-caquetío/5-experimento/DINAMICA_DE_RUNS.md
@@ -1,0 +1,176 @@
+---
+tipo: nota
+pregunta: "¿Cómo se corre, se analiza y se muestra un run?"
+medido: 2026-08-06
+base: los 23 runs de la base local
+---
+
+# La dinámica de los runs — de la simulación a lo que se muestra
+
+> Escrito después de analizar los 23 runs que ya existen. Casi todas las
+> decisiones de abajo salen de algo que salió mal en ellos.
+
+## El problema que hay que resolver primero
+
+De los 23 runs almacenados, **ninguno es plenamente citable**. No porque estén
+mal corridos, sino porque no se puede saber contra qué corrieron: hubo que
+reconstruirlo de git para poder analizar los seis primeros. Y tres cosas más:
+
+| Lo que pasó | Consecuencia |
+|---|---|
+| `pct_caquetio` saturada (91% en 1.0) | la métrica principal no distingue nada |
+| La longitud del prompt predice el score (r = −0.48) | cualquier lectura por agente puede ser un artefacto de autoría |
+| n = 1 run por brazo | el resultado de koiné es señal, no prueba |
+
+**La dinámica de abajo está diseñada para que esas cuatro cosas no vuelvan a
+pasar.**
+
+---
+
+## Las cuatro etapas
+
+```
+  1. SELLAR    →   2. CORRER    →   3. LEER (×2)    →   4. MOSTRAR
+  la huella        el par            observador           el jardín
+                   normal/ablación   + cronista
+```
+
+### 1. Sellar — antes de arrancar
+
+`huella_de_base.py` graba en la propia fila del run: hash y tamaño del lexicón,
+del corpus y del elenco; la polity simulada; el commit del motor; y **si el
+árbol estaba sucio**.
+
+> **Un run con el árbol sucio no es citable.** El commit dice una cosa y el
+> código que corrió decía otra. No se impide —hay motivos legítimos para probar
+> algo sin commitear— pero queda marcado y el análisis puede excluirlo.
+
+El elenco entra en la huella aunque el issue original no lo pedía, y es el que
+más sesga: si alguien reescribe una ficha entre dos runs, los scores cambian sin
+que nada más haya cambiado.
+
+### 2. Correr — en pares, no sueltos
+
+**La unidad de experimento no es el run: es el par normal/ablación.** Un run
+solo no dice nada, porque no hay contra qué contrastarlo.
+
+```bash
+python curiana_orchestrator_v2.py --auto 60 --perfiles --reporte
+python curiana_orchestrator_v2.py --auto 60 --perfiles --reporte --ablacion
+```
+
+Y **el par hay que repetirlo**. Con n=1 los 30 días de un run son
+pseudo-réplicas: comparten agentes, semilla y trayectoria, así que los p-valores
+contestan *"¿difieren estas dos series?"*, no *"¿difieren estas dos
+condiciones?"*. Para lo segundo hace falta tratar el **run** como unidad, y eso
+pide 5 pares como mínimo.
+
+### 3. Leer — dos lecturas del mismo run, y esa es la idea
+
+Aquí está lo que el proyecto no tenía y sí necesita: **el mismo material leído
+desde fuera y desde dentro.**
+
+| | El observador | El cronista |
+|---|---|---|
+| Qué es | `curiana_observer.py` | `curiana_cronista.py` |
+| Desde dónde mira | fuera | dentro |
+| Qué produce | métricas, convergencia, scores | arcos, qué le pasó a quién |
+| En qué lengua piensa | análisis | `boratio`, `diao`, `barsure` |
+| Qué estatus tiene | medición | **lectura, nunca fuente** |
+
+No es decoración. Es la misma tensión que atraviesa el proyecto entero: las
+fuentes describen a los caquetíos en vocabulario ajeno, y el proyecto lleva
+meses corrigiéndolo. El cronista aplica esa corrección a los datos **propios**.
+
+Y hay una razón práctica: el observador puede decirte que la distancia de koiné
+bajó 0.07, pero no que **Corie-ko acuñó treinta y siete palabras y nadie adoptó
+ninguna**. Eso es un arco, y hace falta leerlo.
+
+### 4. Mostrar — la evidencia debajo, no delante
+
+El orden que propongo para el jardín público: **el cronista arriba, las
+métricas debajo como respaldo**. Un gráfico de distancia de koiné no le dice
+nada a nadie que no sepa ya qué es una koiné; «el año en que la palabra de
+Shaboro para la fiebre se impuso sobre la de Manaure» sí.
+
+Pero con la evidencia a un clic, siempre. Es lo que separa esto de la
+divulgación floja.
+
+---
+
+## Qué datos interesan, por nivel
+
+Cuatro niveles, y el de abajo no vale sin el de arriba.
+
+### Nivel 0 — ¿es válido este run?
+
+`huella` completa · `motor_sucio` false · el exportador da turnos > 0 (hoy hay
+un run, `20091e1f`, con 0 turnos y 290 respuestas — [#42](https://github.com/miguelgilurbina/curiana-radio/issues/42))
+
+**Si falla el nivel 0, lo demás no se mira.**
+
+### Nivel 1 — la lengua (la pregunta científica)
+
+| Qué | Cómo | Estado |
+|---|---|---|
+| Convergencia | `koine_metrics`, 3 lecturas/día | ✅ funciona |
+| Composición por lengua | `word_uses.source_language` | ✅ arreglado (era 50% NULL) |
+| **Morfología productiva** | uso de aspectos y prefijos | 🆕 **ahora medible** |
+| Neologismos | propuestos → adoptados → fijados | ✅ |
+| Score | `agent_responses.score` | ⚠️ controlar longitud de prompt |
+| ~~`pct_caquetio`~~ | — | 🔴 **saturada, no usar** ([#69](https://github.com/miguelgilurbina/curiana-radio/issues/69)) |
+
+La morfología productiva es lo nuevo y lo más interesante: hasta el arreglo del
+`source_language`, las 18.752 formas con sufijo de aspecto se guardaban sin
+lengua. Ahora se puede preguntar **si los agentes usan más morfología con el
+tiempo**, que es una pregunta mucho mejor que «¿hablan caquetío?» — a la que
+todos contestan que sí al 99%.
+
+### Nivel 2 — los agentes (comportamiento)
+
+- **Prestigio**: ¿las palabras de tier 1 se propagan más? Hoy no está medido.
+- **Adopción**: quién adopta de quién → un grafo, no una cuenta.
+- **Los mudos**: 19 de 60 agentes nunca hablaron en ningún run. Eso es diseño,
+  no accidente, y hay que decidirlo.
+- ⚠️ **Todo esto exige controlar la longitud del prompt.** Sin ese control,
+  «el agente X lideró» puede ser «a X le escribimos más texto».
+
+### Nivel 3 — la narrativa
+
+- Arcos por agente (hoy: `agent_profiles.resumen_arco`, generado por LLM)
+- Citas (405, curación sólida al 98,5%; sesgo leve hacia lo breve)
+- Eventos del mundo y cómo respondieron
+- 🆕 **La lectura del cronista**: el año contado desde dentro
+
+---
+
+## Lo que hay que construir, en orden
+
+| # | Qué | Por qué ahora | Estado |
+|---|---|---|---|
+| 1 | `huella_de_base()` en cada run | sin esto nada es comparable | ✅ **hecho** |
+| 2 | Métricas que discriminen | `pct_caquetio` no sirve | 🔴 [#69](https://github.com/miguelgilurbina/curiana-radio/issues/69) |
+| 3 | Modo analítico del cronista | leer arcos desde dentro | 🟡 el prompt existe, falta cablearlo |
+| 4 | Control de longitud de prompt | o igualar los prompts, o meterlo como covariable | 🔴 |
+| 5 | 5 pares normal/ablación | tratar el run como unidad | 🔴 |
+| 6 | Arreglar el exportador | [#42](https://github.com/miguelgilurbina/curiana-radio/issues/42) | 🔴 |
+
+El **2** y el **4** son los que de verdad bloquean: mientras la métrica esté
+saturada y el confusor sin controlar, correr más runs produce más datos que no
+se pueden interpretar.
+
+---
+
+## La decisión que hay debajo de todo esto
+
+Correr más runs **no es lo siguiente**. Lo siguiente es que un run sea legible.
+
+Hoy hay 23 runs y 54.936 usos de palabra, y el análisis serio de anoche produjo
+sobre todo hallazgos sobre **el instrumento**, no sobre la lengua: la métrica
+está saturada, medio corpus estaba sin clasificar, el score mide en parte cuánto
+escribimos nosotros. Eso no es un fracaso — es lo que pasa cuando por fin miras
+los datos en serio— pero dice claramente dónde está el trabajo.
+
+## Enlaces
+
+[[ANALISIS_BASE_2026-08-06]] · [[cronista]] · [[DISENO_KOINE]] · [[04_protocolo_run_1_era_auditada]] · [[LINEA_DE_TIEMPO]] · [[mapa-motor]]

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -68,6 +68,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
   está minado, qué sostiene cada una.
 - 🕰️ [[LINEA_DE_TIEMPO]] — las cuatro eras del proyecto y sobre qué base corrió
   cada cosa. Necesaria para saber qué resultados siguen valiendo.
+- 🎬 [[DINAMICA_DE_RUNS]] — cómo se corre, se lee y se muestra un run.
 - 🔬 [[01_que_probaron_los_seis_runs]] — qué probaron los runs existentes, qué
   no, y por qué no son comparables.
 - 🧪 [[04_protocolo_run_1_era_auditada]] — cómo se corre y se mide la próxima

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-08 12:59**.
+<!--GENERADO--> Generado el **2026-08-08 13:12**.
 
 ## ¿Vamos bien?
 
@@ -21,7 +21,7 @@ editar_a_mano: no
 |---|---|---|---|
 | Entradas del lexicón **sin cita** | **3** | 82 (2026-07-21) | 🟢 −79 |
 | Hechos del corpus **con referencia** | **161 / 161** | — | 🟢 |
-| Tests del motor | **165 en verde** | 0 rojos | 🟢 |
+| Tests del motor | **174 en verde** | 0 rojos | 🟢 |
 | Gate para reanudar simulaciones | **2 de 9** condiciones | faltan 7 | 🔴 |
 | Decisiones esperando a Miguel | **12 abiertas** | 0 resueltas | 🟡 |
 
@@ -256,8 +256,8 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 786 en 192 notas indexadas | 🟢 0 rotos |
-| Tests (`curiana_sim/tests/`) | 165 passed, 0 failed | 🟢 |
+| Wikilinks | 793 en 195 notas indexadas | 🟢 0 rotos |
+| Tests (`curiana_sim/tests/`) | 174 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 
 **Avisos de `curiana_polities.py::coherencia_del_canon()`:**

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_orchestrator_v2.py
@@ -30,6 +30,7 @@ except ImportError:
 
 from curiana_database import get_anthropic_client, get_db
 from curiana_agents import ALL_AGENTS, AGENTS_T1, AGENTS_T2, AGENTS_T3
+from huella_de_base import huella as huella_de_base, resumen as resumen_huella
 from curiana_state import (
     ComunidadState,
     DIAS_POR_ESTACION,
@@ -678,7 +679,12 @@ def interactive_mode(client: anthropic.Anthropic):
 
     # Inicializar DB (gracefully degraded si no hay Supabase)
     db = get_db()
-    run_id = db.create_run(model=MODEL, config={"mode": "interactive"})
+    # La huella se sella al arrancar: sin ella no se puede saber, mirando el
+    # run, sobre qué lexicón/corpus/elenco corrió (issue #68).
+    _h = huella_de_base()
+    print(f"  base: {resumen_huella(_h)}")
+    run_id = db.create_run(model=MODEL,
+                           config={"mode": "interactive", **_h})
     client = get_client(run_id)  # re-crear con run_id para LangSmith
 
     print(f"\n  Vocabulario disponible: {len(lexico.palabras_activas())} palabras")
@@ -826,9 +832,14 @@ def auto_mode(
 
     # Inicializar DB (CurianaDB real o CurianaDBMock si no está configurada)
     db = get_db()
+    _h = huella_de_base()
+    print(f"  base: {resumen_huella(_h)}")
+    if _h.get("motor_sucio"):
+        print("  ⚠ árbol sucio: este run NO será citable (ver huella_de_base.py)")
     run_id = db.create_run(
         model=MODEL,
-        config={"max_turns": turnos, "mode": "auto", "ablacion": ablacion},
+        config={"max_turns": turnos, "mode": "auto", "ablacion": ablacion,
+                **_h},
     )
     # Re-crear cliente con run_id para que LangSmith use el proyecto correcto
     client = get_client(run_id)

--- a/proyecto-linguistico-caquetío/curiana_sim/huella_de_base.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/huella_de_base.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — la huella de la base: contra qué corrió cada run
+===========================================================
+
+Hoy, mirando un run en la base, **no se puede saber sobre qué lexicón corrió**.
+Hubo que reconstruirlo de git para poder analizar los seis primeros, y por eso
+[[LINEA_DE_TIEMPO]] existe: para saber qué resultados siguen valiendo.
+
+Esto sella esa información **en el momento de arrancar**, en la propia fila del
+run. Es la precondición de todo lo demás: sin ella, dos runs no son comparables
+y ningún resultado es citable.
+
+QUÉ SELLA
+---------
+    lexicon_hash   SHA-256 de VOCABULARIO_BASE serializado y ordenado
+    lexicon_n      cuántas entradas tenía
+    corpus_hash    hash de los YAML de 3-mundo/corpus/
+    corpus_n       cuántos hechos
+    agentes_hash   hash del elenco (importa: el prompt de cada agente
+                   predice su score, r=-0.48)
+    agentes_n      cuántos agentes
+    motor_commit   el SHA del HEAD al arrancar
+    motor_sucio    si había cambios sin commitear
+    polity         qué formación política modela el motor
+    semilla        para poder repetir
+
+POR QUÉ `motor_sucio` IMPORTA MÁS DE LO QUE PARECE
+--------------------------------------------------
+**Un run con el árbol sucio no es citable.** El commit dice una cosa y el código
+que corrió decía otra, y no hay forma de recuperar cuál. No se impide correrlo
+—hay motivos legítimos para probar algo sin commitear— pero queda marcado, y el
+análisis puede excluirlo.
+
+POR QUÉ `agentes_hash` NO ESTABA EN EL ISSUE Y SÍ DEBERÍA
+---------------------------------------------------------
+El issue #68 pedía lexicón, corpus y motor. Falta el elenco, y es el que más
+sesga: medido sobre los 23 runs, **la longitud del `system_prompt` de un agente
+predice su score con r = -0.48**. Si alguien reescribe una ficha entre dos runs,
+los scores cambian sin que nada más haya cambiado. Sin este hash, ese cambio es
+invisible.
+
+Uso:
+    python huella_de_base.py            # la huella de ahora mismo
+    python huella_de_base.py --json
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+
+AQUI = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(AQUI)
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace", line_buffering=True))
+
+
+def _sha(texto: str) -> str:
+    return hashlib.sha256(texto.encode("utf-8")).hexdigest()[:16]
+
+
+def _hash_dict(d: dict) -> str:
+    """Hash estable de un dict: ordenado y con separadores fijos.
+
+    Sin `sort_keys` el hash cambiaría según el orden de inserción, que en
+    Python depende del orden del archivo fuente — y entonces mover una entrada
+    de sitio parecería un cambio de contenido.
+    """
+    return _sha(json.dumps(d, sort_keys=True, ensure_ascii=False,
+                           separators=(",", ":"), default=str))
+
+
+def _git(*args):
+    try:
+        out = subprocess.run(["git", *args], cwd=REPO, capture_output=True,
+                             text=True, encoding="utf-8", timeout=15)
+        return out.stdout.strip() if out.returncode == 0 else None
+    except Exception:                                        # noqa: BLE001
+        return None
+
+
+def huella(semilla=None) -> dict:
+    """La huella de la base tal como está en este momento."""
+    sys.path.insert(0, AQUI)
+    datos = {}
+
+    # ── lexicón ────────────────────────────────────────────────────────
+    try:
+        from curiana_lexicon import VOCABULARIO_BASE
+        datos["lexicon_hash"] = _hash_dict(VOCABULARIO_BASE)
+        datos["lexicon_n"] = len(VOCABULARIO_BASE)
+    except Exception as e:                                   # noqa: BLE001
+        datos["lexicon_hash"] = None
+        datos["lexicon_error"] = str(e)[:120]
+
+    # ── corpus ─────────────────────────────────────────────────────────
+    try:
+        from compilar_corpus import compilar
+        hechos, _, _ = compilar()
+        limpio = [{k: v for k, v in h.items() if not k.startswith("_")}
+                  for h in hechos]
+        datos["corpus_hash"] = _hash_dict({"hechos": limpio})
+        datos["corpus_n"] = len(hechos)
+    except Exception as e:                                   # noqa: BLE001
+        datos["corpus_hash"] = None
+        datos["corpus_error"] = str(e)[:120]
+
+    # ── elenco ─────────────────────────────────────────────────────────
+    try:
+        from curiana_agents import ALL_AGENTS
+        datos["agentes_hash"] = _hash_dict(ALL_AGENTS)
+        datos["agentes_n"] = len(ALL_AGENTS)
+        # La longitud total de los prompts, porque es la variable que más
+        # sesga el score y conviene tenerla a la vista sin recalcularla.
+        datos["prompt_chars"] = sum(
+            len(a.get("system_prompt") or "") for a in ALL_AGENTS.values())
+    except Exception as e:                                   # noqa: BLE001
+        datos["agentes_hash"] = None
+        datos["agentes_error"] = str(e)[:120]
+
+    # ── polity ─────────────────────────────────────────────────────────
+    try:
+        from curiana_polities import POLITY_SIMULADA
+        datos["polity"] = POLITY_SIMULADA
+    except Exception:                                        # noqa: BLE001
+        datos["polity"] = None
+
+    # ── motor ──────────────────────────────────────────────────────────
+    datos["motor_commit"] = _git("rev-parse", "HEAD")
+    estado = _git("status", "--porcelain")
+    datos["motor_sucio"] = bool(estado) if estado is not None else None
+    datos["motor_rama"] = _git("rev-parse", "--abbrev-ref", "HEAD")
+
+    if semilla is not None:
+        datos["semilla"] = semilla
+    return datos
+
+
+def resumen(h: dict) -> str:
+    """Una línea legible para el log del run."""
+    sucio = " ⚠ ÁRBOL SUCIO" if h.get("motor_sucio") else ""
+    commit = (h.get("motor_commit") or "?")[:8]
+    return (f"lexicón {h.get('lexicon_n', '?')} ({(h.get('lexicon_hash') or '?')[:8]}) · "
+            f"corpus {h.get('corpus_n', '?')} · "
+            f"elenco {h.get('agentes_n', '?')} · "
+            f"polity {h.get('polity', '?')} · "
+            f"{commit}{sucio}")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    h = huella()
+    if args.json:
+        print(json.dumps(h, ensure_ascii=False, indent=2))
+        return 0
+
+    print("\n── Huella de la base ──\n")
+    for k, v in h.items():
+        print(f"  {k:16} {v}")
+    print(f"\n  {resumen(h)}")
+    if h.get("motor_sucio"):
+        print("\n  ⚠ El árbol tiene cambios sin commitear. Un run lanzado así")
+        print("    NO es citable: el commit dice una cosa y el código que corre")
+        print("    dice otra, y no hay forma de recuperar cuál.")
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_huella.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_huella.py
@@ -1,0 +1,67 @@
+"""Tests de la huella de la base.
+
+Lo que protegen: que dos runs sobre la misma base den la misma huella, y que
+cualquier cambio en lexicón, corpus o elenco la mueva. Si la huella no
+discrimina, no sirve para nada — y su único trabajo es decir *contra qué corrió
+este run*.
+"""
+
+from huella_de_base import _hash_dict, huella, resumen
+
+
+def test_la_huella_trae_las_cuatro_esferas():
+    h = huella()
+    for campo in ("lexicon_hash", "corpus_hash", "agentes_hash", "motor_commit"):
+        assert campo in h, f"falta {campo}"
+    for campo in ("lexicon_n", "corpus_n", "agentes_n"):
+        assert isinstance(h[campo], int) and h[campo] > 0
+
+
+def test_es_estable_entre_llamadas():
+    """Dos runs sobre la misma base tienen que dar la misma huella, o no se
+    pueden comparar."""
+    a, b = huella(), huella()
+    for campo in ("lexicon_hash", "corpus_hash", "agentes_hash"):
+        assert a[campo] == b[campo], f"{campo} cambia entre llamadas"
+
+
+def test_el_hash_no_depende_del_orden_de_insercion():
+    """Sin `sort_keys`, mover una entrada de sitio en el archivo fuente
+    parecería un cambio de contenido."""
+    assert _hash_dict({"a": 1, "b": 2}) == _hash_dict({"b": 2, "a": 1})
+
+
+def test_el_hash_si_cambia_con_el_contenido():
+    """Lo contrario del test anterior: si no discrimina, no sirve."""
+    assert _hash_dict({"a": 1}) != _hash_dict({"a": 2})
+
+
+def test_registra_la_polity_simulada():
+    """Un run de la costera y uno de Barquisimeto no son comparables, y hoy
+    eso no se vería en ningún sitio."""
+    assert huella()["polity"] == "costera"
+
+
+def test_registra_el_tamano_de_los_prompts():
+    """La longitud del prompt predice el score (r=-0.48). Si alguien reescribe
+    una ficha entre dos runs, los scores cambian sin que nada más cambie."""
+    h = huella()
+    assert isinstance(h["prompt_chars"], int) and h["prompt_chars"] > 0
+
+
+def test_la_semilla_solo_aparece_si_se_pasa():
+    assert "semilla" not in huella()
+    assert huella(semilla=42)["semilla"] == 42
+
+
+def test_el_resumen_es_una_linea_legible():
+    r = resumen(huella())
+    assert "\n" not in r
+    assert "lexicón" in r and "polity" in r
+
+
+def test_el_resumen_avisa_del_arbol_sucio():
+    sucio = resumen({"motor_sucio": True, "motor_commit": "abc123456"})
+    limpio = resumen({"motor_sucio": False, "motor_commit": "abc123456"})
+    assert "SUCIO" in sucio
+    assert "SUCIO" not in limpio


### PR DESCRIPTION
Cierra #68.

## `huella_de_base.py` — la precondición de todo lo demás

Hoy, mirando un run en la base, **no se puede saber sobre qué lexicón corrió**: hubo que reconstruirlo de git para analizar los seis primeros. Ahora se sella al arrancar, en la propia fila del run.

**Dos campos que el issue no pedía y sí hacen falta:**

- `agentes_hash` + `prompt_chars` — la longitud del prompt de un agente predice su score con **r = −0.48**. Si alguien reescribe una ficha entre dos runs, los scores cambian sin que nada más haya cambiado, y hoy eso sería invisible.
- `polity` — un run de la costera y uno de Barquisimeto no son comparables.

**Un run con el árbol sucio no es citable** y queda marcado. No se impide correrlo: hay motivos legítimos para probar sin commitear.

9 tests, incluidos los dos que importan: que la huella sea **estable** entre llamadas (o dos runs no se pueden comparar) y que **sí cambie** con el contenido (o no discrimina y no sirve para nada).

## `DINAMICA_DE_RUNS.md`

El diseño de punta a punta: **sellar → correr en pares → leer dos veces → mostrar**.

Lo que más aporta es la etapa 3: el mismo run leído **desde fuera y desde dentro**. El observador da métricas; el cronista da arcos y qué le pasó a quién, en la lengua de ellos. No es decoración — es la misma tensión que atraviesa el proyecto (las fuentes describen a los caquetíos en vocabulario ajeno), aplicada ahora a los datos propios. Y tiene una razón práctica: el observador puede decir que la distancia bajó 0.07, pero no que **Corie-ko acuñó 37 palabras y nadie adoptó ninguna**.

Los datos que interesan quedan por niveles, y el de abajo no vale sin el de arriba: validez → lengua → agentes → narrativa. Con la **morfología productiva** como la pregunta nueva y mejor: ahora que las 18.752 formas con sufijo de aspecto ya no se guardan sin lengua, se puede preguntar si los agentes usan *más* morfología con el tiempo — que rinde bastante más que ""¿hablan caquetío?"", a la que todos contestan que sí al 99%.

## La conclusión incómoda que deja escrita

**Correr más runs no es lo siguiente.** Lo siguiente es que un run sea legible: mientras `pct_caquetio` esté saturada (#69) y la longitud del prompt sin controlar, más runs producen más datos que no se pueden interpretar.

---

174 tests, 7 guardianes en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
