### PR TITLE
Cerrar la fase 1 como experimento, y la sociedad como esfera multiétnica

### DIFF
--- a/proyecto-linguistico-caquetío/3-mundo/asentamientos.yaml
+++ b/proyecto-linguistico-caquetío/3-mundo/asentamientos.yaml
@@ -1,0 +1,346 @@
+# Curiana — registro de nodos de la esfera de interacción
+# =========================================================
+#
+# Responde a UNA pregunta: ¿qué asentamientos existían, cuándo, y con qué
+# evidencia? Es un artefacto DISTINTO de 2-lengua/toponimos.yaml, que responde
+# a "¿qué significa este nombre?".
+#
+# La distinción no es burocrática. En `toponimos.yaml`, Adícora, Curaçao y
+# Aruba están los tres como `descartado` — que ahí significa "sin etimología
+# despejable", NO "no existió". Un registro de nodos tiene que poder decir
+# "este lugar existió y no sabemos qué quiere decir su nombre".
+#
+# LOS TRES CAMPOS QUE NO SE PUEDEN CONFUNDIR
+# ------------------------------------------
+#   etiqueta      ¿tenemos evidencia de que este asentamiento existió?
+#                 atestiguado | reconstruido | hipotetico   (las del corpus)
+#
+#   atestacion    ¿de qué época es el DOCUMENTO que lo atestigua?
+#                 colonial | precolonial | arqueologica
+#
+#   precontacto   ¿existía en la ventana que simulamos (s. XIV-XV)?
+#                 si | probable | desconocido
+#
+# El tercero es el que importa y el que casi siempre dice `desconocido`.
+# Un poblado nombrado en una carta de 1538 está *atestiguado* sin que eso diga
+# nada de si existía cien años antes. Confundir `etiqueta: atestiguado` con
+# "sirve para la simulación" es exactamente la regla 3 de CLAUDE.md.
+#
+# EL HALLAZGO QUE DEJA VER ESTE REGISTRO
+# --------------------------------------
+# Ningún nodo continental tiene `precontacto: si`. Los únicos que lo tienen son
+# los insulares, y no por documento sino por ARQUEOLOGÍA (presencia dabajuroide
+# ~900 d.C.). Es decir: para la ventana que simulamos, las islas están mejor
+# sostenidas que la costa. Eso contradice la intuición y hay que tenerlo
+# delante al decidir qué nodo se pone en escena (#90).
+#
+# Valida: python curiana_sim/compilar_asentamientos.py --check
+
+meta:
+  pregunta: "¿Qué asentamientos existían en la esfera, cuándo, y con qué evidencia?"
+  creado: 2026-08-08
+  ambito: >
+    La esfera de interacción del Golfete de Coro — ver 3-mundo/esfera-de-interaccion.md.
+    NO es un gazeteer de Falcón: solo entran nodos con evidencia citable.
+  advertencia: >
+    Siete de los nodos continentales vienen de UNA sola fuente: la carta del
+    obispo Rodrigo de Bastidas a Carlos V (1538), vía Oliver 1989 cap.3.
+    Una lista de 1538 es documentación colonial once años posterior al pacto
+    Ampíes-Manaure. Sirve para saber qué topónimos existían; no para dar por
+    buena la organización política que describe.
+
+nodos:
+
+  # ── El eje continental: Coro y el Golfete ──────────────────────────────
+
+  - id: nodo-001
+    forma: todariquiba
+    tipo: asentamiento
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: >
+      Poblado real donde residió Manaure y donde se reasentó tras el pacto de
+      1527 con Juan de Ampíes; su hijo/sucesor Don Alexandre también residió
+      ahí. Es el mejor candidato a lo que la simulación llama "la Curiana".
+    ubicacion: >
+      Aprox. 1 legua (4,5-6 km) de la actual Coro. LA UBICACIÓN EXACTA SIGUE EN
+      DEBATE: no se ha hallado sitio arqueológico del tamaño correspondiente en
+      la periferia de Coro. Oliver sospecha que quedó bajo la expansión urbana
+      moderna, o más allá de la distancia que sugieren las crónicas.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "pp. 251 (pacto de 1527), 261-262 (registros Welser, Ponce y Vaccari 1977)"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+    nota: >
+      NO está en toponimos.yaml. Sí está `todarahuato` ('Indígena de la Vela'),
+      que NO se ha demostrado relacionado — no asumirlo.
+      ⚠ Trampa de extracción medida: `pypdf` parte "Todariquiba" en
+      "T odariquiba" en sus 7 apariciones de Oliver cap.3. Usar `pdftotext`.
+
+  - id: nodo-002
+    forma: cumarebo
+    tipo: asentamiento-puerto
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: >
+      Nombrado en la carta de Bastidas (1538). Su interés no es el poblado sino
+      la costa: una ensenada JUSTO AL ESTE de Puerto Cumarebo se llamaba
+      "Puerto de los Indios Curaçao", y es el punto de partida documentado
+      desde el que los caquetíos de Curazao cruzaban a la isla en canoa.
+      Es, con eso, el enlace continente-isla mejor sostenido del registro.
+    ubicacion: costa oriental del estado Falcón, al este de Coro.
+    procedencia:
+      obra: van-buurt-2014
+      detalle: "Puerto de los Indios Curaçao, citando a Hartog 1968; la lista de 1538 en Oliver 1989 cap.3 p.251"
+    corpus: [geografia_politica-001, geografia_politica-003]
+    etimologia: resuelto
+    etimologia_detalle: >
+      toponimo-004, nivel A: `Cumare` (antropónimo — la fuente lo identifica
+      como el nombre del cacique) + `ebo` ('camino, paso, senda', lexicón,
+      caquetío-atestiguado) = 'camino de Cumare'. Segunda atestación
+      independiente de `ebo` (la otra es `jurijurebo`).
+
+  - id: nodo-003
+    forma: guaibacoa
+    tipo: asentamiento
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: Nombrado en la carta de Bastidas a Carlos V (1538). Nada más se sabe.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 251, carta de Rodrigo de Bastidas 1538"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+    nota: >
+      El elemento `-bacoa` ('bosque, lugar, paraje') es productivo y está
+      atestiguado (yacarebacoa, quibacoas, guadabacoa, adabacoa, sazaribacoa).
+      Eso hace la segmentación plausible, pero `guai-` no recurre: NO se
+      despeja. Queda como tarea, no como hallazgo.
+
+  - id: nodo-004
+    forma: tomodore
+    tipo: asentamiento
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: Nombrado en la carta de Bastidas a Carlos V (1538). Nada más se sabe.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 251, carta de Rodrigo de Bastidas 1538"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+
+  - id: nodo-005
+    forma: caujarao
+    tipo: asentamiento
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: Nombrado en la carta de Bastidas a Carlos V (1538). Nada más se sabe.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 251, carta de Rodrigo de Bastidas 1538"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+
+  - id: nodo-006
+    forma: zazarida
+    variantes: [Zazárida]
+    tipo: asentamiento
+    region: falcon-occidental
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: Nombrado en la carta de Bastidas a Carlos V (1538). Nada más se sabe.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 251, carta de Rodrigo de Bastidas 1538"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+
+  - id: nodo-007
+    forma: capatarida
+    variantes: [Capatárida]
+    tipo: asentamiento
+    region: falcon-occidental
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: Nombrado en la carta de Bastidas a Carlos V (1538). Nada más se sabe.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 251, carta de Rodrigo de Bastidas 1538"
+    corpus: [geografia_politica-003]
+    etimologia: sin-resolver
+    nota: >
+      ⚠ NO confundir con `capadare` de toponimos.yaml (nivel C, 'Diente de
+      tigre'). Se parecen y no hay nada que demuestre que sean el mismo lugar.
+
+  - id: nodo-008
+    forma: san-bartolome
+    tipo: asentamiento-palafito
+    region: golfete-de-coro
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: >
+      El "Puerto de San Bartolomé" que describió Vespucio (1500-1509): un
+      poblado de viviendas sobre estacas que le recordó a Venecia y dio origen
+      al nombre "Venezuela" en el mapa de Juan de la Cosa. Ramos Pérez lo ubica
+      en el Golfete de Coro, no en el Lago de Maracaibo.
+    procedencia:
+      obra: oliver-1989-cap3
+      detalle: "p. 249, citando a Ramos Pérez (1976: 88) y Navarrete 1829 [3]: 218-219"
+    corpus: [geografia_politica-006]
+    etimologia: no-aplica
+    nota: >
+      🔴 DEUDA DE FUENTE: descansa en Ramos Pérez, obra que NO está en el repo
+      (ver 4-fuentes/ramos-perez-1978.md). Y Oliver sugiere que los palafitos
+      pudieran ser de una comunidad pesquera especializada cuya relación con
+      los asentamientos de tierra adentro NO está establecida — puede no ser
+      el mismo poblado ni la misma gente. Nombre castellano, no caquetío.
+
+  # ── Los nodos insulares: los únicos con precontacto sostenido ──────────
+
+  - id: nodo-009
+    forma: curazao
+    variantes: [Curaçao]
+    tipo: isla
+    region: islas-abc
+    etiqueta: atestiguado
+    atestacion: arqueologica
+    precontacto: si
+    rol: >
+      Nodo insular con presencia caquetía documentada, incluidos préstamos
+      léxicos caquetíos que sobreviven en el papiamento. Enlazado con el
+      continente por la travesía desde el este de Puerto Cumarebo (nodo-002).
+    procedencia:
+      obra: van-buurt-2014
+    corpus: [geografia_politica-001]
+    etimologia: sin-resolver
+    precontacto_razon: >
+      La ruta dabajuroide Yaracuy → costa → Aruba/Bonaire/Curazao está fechada
+      ~900 d.C. (Antczak et al. 2017 p.157). La presencia es arqueológica y muy
+      anterior a la ventana simulada — NO depende de las crónicas.
+
+  - id: nodo-010
+    forma: aruba
+    tipo: isla
+    region: islas-abc
+    etiqueta: atestiguado
+    atestacion: arqueologica
+    precontacto: si
+    rol: >
+      Nodo insular con presencia caquetía. Los indios de Alto Vista mantenían
+      contacto regular con el pueblo de Santa Ana, en Paraguaná, hasta el s.
+      XIX — el enlace isla-península con más continuidad documentada.
+    procedencia:
+      obra: van-buurt-2014
+    corpus: [geografia_politica-001]
+    etimologia: sin-resolver
+    precontacto_razon: ruta dabajuroide ~900 d.C. (Antczak et al. 2017 p.157).
+    nota: >
+      En Aruba y Bonaire la identidad indígena se mantuvo; en Curazao quedó
+      "swamped" por un acervo africano mucho mayor (van Buurt 2014). Los tres
+      nodos insulares NO son intercambiables.
+
+  - id: nodo-011
+    forma: bonaire
+    tipo: isla
+    region: islas-abc
+    etiqueta: atestiguado
+    atestacion: arqueologica
+    precontacto: si
+    rol: Nodo insular con presencia caquetía.
+    procedencia:
+      obra: van-buurt-2014
+    corpus: [geografia_politica-001]
+    etimologia: sin-resolver
+    precontacto_razon: ruta dabajuroide ~900 d.C. (Antczak et al. 2017 p.157).
+
+  # ── Paraguaná: nombrada, casi sin sostener ─────────────────────────────
+
+  - id: nodo-012
+    forma: adicora
+    variantes: [Adicoura]
+    tipo: asentamiento
+    region: paraguana
+    etiqueta: reconstruido
+    atestacion: colonial
+    precontacto: desconocido
+    rol: >
+      Topónimo de Paraguaná recogido por Zavala Reyes. NO hay en el repo
+      ninguna fuente que lo describa como asentamiento caquetío ni que lo feche.
+    procedencia:
+      obra: zavala-reyes-2015
+    etimologia: descartada
+    nota: >
+      En toponimos.yaml consta como `descartado`, que ahí significa "el
+      comentario del autor es histórico o anecdótico, no etimológico" — NO
+      significa que el lugar no exista. Degradado a `reconstruido` porque lo
+      único atestiguado es el NOMBRE, no el asentamiento.
+
+  - id: nodo-013
+    forma: santa-ana
+    tipo: asentamiento
+    region: paraguana
+    etiqueta: atestiguado
+    atestacion: colonial
+    precontacto: desconocido
+    rol: >
+      Pueblo de Paraguaná con el que los indios de Alto Vista (Aruba)
+      mantuvieron contacto regular hasta el s. XIX.
+    procedencia:
+      obra: van-buurt-2014
+    etimologia: no-aplica
+    nota: >
+      Nombre castellano y de misión: el topónimo es colonial con seguridad,
+      aunque el asentamiento pudiera ser anterior con otro nombre. Entra por la
+      RUTA que documenta, no por sí mismo.
+
+# ── Lo que falta, dicho en voz alta ───────────────────────────────────────
+#
+# Regla 8 de CLAUDE.md: el hueco se admite, callarlo no.
+
+huecos:
+
+  - que: >
+      Miraca, Moruy, Baraived, Jadacaquiva y los demás poblados de Paraguaná.
+    por_que_no_estan: >
+      No hay en el repo ninguna fuente que los nombre. Ponerlos como
+      `hipotetico` sería inventarlos: no se listan hasta que una fuente los
+      sostenga.
+    candidato_a_verificar: >
+      `jadicuar` está en toponimos.yaml y SE PARECE a Jadacaquiva. Parecerse no
+      es evidencia — hay que comprobarlo, no asumirlo.
+    donde: "issue #92"
+
+  - que: Los "más de 30 poblados" que infiere Oliver.
+    por_que_no_estan: >
+      La carta de Ballesteros (1550) dice que reparar el canal del `buco`
+      requería "cuatro o cinco mil indios", de lo que Oliver infiere
+      coordinación entre más de 30 poblados (geografia_politica-004). Tenemos
+      trece nodos, y siete de ellos son una sola lista. Faltan dos tercios.
+    donde: "issue #92"
+
+  - que: La ubicación de Todariquiba.
+    por_que_no_estan: >
+      Sigue en debate en la propia literatura. Descansa parcialmente en Ramos
+      Pérez 1978, que no está en el repo.
+    donde: "issue #92, y 4-fuentes/ramos-perez-1978.md"
+
+  - que: Qué lengua o lenguas hablaba cada nodo.
+    por_que_no_estan: >
+      Que la esfera fuera multiétnica no dice cuánto ni dónde. El lexicón tiene
+      7 formas jirajaroides y 4 de solapamiento caribe: no alcanza para modelar
+      un nodo bilingüe.
+    donde: "3-mundo/esfera-de-interaccion.md §6"

--- a/proyecto-linguistico-caquetío/3-mundo/esfera-de-interaccion.md
+++ b/proyecto-linguistico-caquetío/3-mundo/esfera-de-interaccion.md
@@ -1,0 +1,233 @@
+---
+tipo: nota
+pregunta: "¿Qué era la sociedad que llamamos caquetía, y qué unidad hay que simular?"
+medido: 2026-08-08
+abre: la fase 2 del experimento
+---
+
+# La esfera de interacción — por qué «caquetío» no nombra una etnia
+
+> **La tesis de esta nota.** La sociedad del Golfete de Coro **no era
+> monoétnica**, y el proyecto la ha modelado como si lo fuera. Corregir eso no
+> es añadir color: cambia qué se simula y cómo se mide la lengua, porque **una
+> lengua homogénea es un supuesto, no un dato**.
+
+---
+
+## 1. El nombre ya lo decía
+
+Oliver 1989, capítulo 3, nota al pie 3:
+
+> el término Caquetío /kaketío/ es **cognado del lokono `kakitho`, que significa
+> 'persona, gente'** — y por eso hay razón para creer que los españoles
+> designaron a los caquetíos etnohistóricos con **su propia autodenominación**.
+
+Es el dato que reordena todo lo demás. Un pueblo que se llama a sí mismo **«la
+gente»** no está trazando una frontera étnica: está diciendo *nosotros*. El
+mismo patrón que `lokono` ('gente'), `wayuu` ('persona'), `taíno` ('bueno,
+noble') — autodenominaciones que los cronistas convirtieron en etnónimos con
+bordes duros que en el original no tenían.
+
+**Consecuencia metodológica:** tratar «caquetío» como una etiqueta étnica
+excluyente es un artefacto de la fuente colonial, no un hallazgo. Y es
+exactamente el tipo de aplanamiento que Oliver denuncia cuando rechaza el
+«Cacicazgo Teocrático» por *borrar las diferencias que hacen diferencia*.
+
+---
+
+## 2. La evidencia de que la sociedad era multiétnica
+
+### 2.1 Las fronteras eran porosas — dicho por la arqueología
+
+Antczak et al. 2017, p. 157:
+
+- «las fronteras espaciales entre hablantes caribes, arahuacos y otros **no
+  deben considerarse impermeables**»
+- el sitio de **La Cajara mezcla cinco tradiciones cerámicas** distintas
+- y el propio Oliver, en comunicación personal de 2016, advierte que **no todos
+  los rasgos arqueológicos de estos sitios son dabajuroides**, lo que «plantea
+  un desafío a nuestra comprensión del caquetío protohistórico»
+
+Es decir: **la identidad caquetía es porosa en la propia evidencia material**,
+no solo en la interpretación.
+
+### 2.2 Había movimiento documentado, en las dos direcciones
+
+| Movimiento | Cuándo | Fuente |
+|---|---|---|
+| Ruta dabajuroide Yaracuy → costa → Aruba/Bonaire/Curazao | ~900 d.C. | Antczak 2017 p.157 |
+| Disputa arahuaco/caribe por Las Aves y Los Roques | 1200 d.C. – Contacto | Antczak 2017 p.157 |
+| Puestos de avanzada caquetíos en la Guajira, **fundados desde Falcón** | precolonial | Oliver 1989 cap.3 p.189 (`geografia_politica-002`) |
+| Préstamos léxicos caquetíos supervivientes en papiamento | colonial | Van Buurt 2014 (`geografia_politica-001`) |
+
+Una zona con rutas de ida y vuelta durante siglos **no produce una lengua
+homogénea**. Produce contacto, préstamo y variación — que es precisamente lo
+que el experimento dice querer estudiar.
+
+### 2.3 Lo multiétnico ya está en nuestros propios datos, en el margen
+
+Medido el 2026-08-08 sobre `curiana_agents.py` y `curiana_lexicon.py`:
+
+**El elenco** (60 agentes) ya no es monoétnico:
+
+| Etnia | n |
+|---|---|
+| caquetío / caquetía | 38 |
+| (sin campo) | 12 |
+| guaycarí | 4 |
+| jirajara | 2 |
+| caribe | 1 |
+| gayón | 1 |
+| caquetío_aruba | 1 |
+| **guaycarí_caquetío** (mixto) | 1 |
+
+**El lexicón** (1413 formas) ya tiene estratos de contacto declarados:
+
+| Estrato | n |
+|---|---|
+| kalinago | 19 |
+| jirajaroide-contacto | 7 |
+| kalinago-caribe-overlay | 4 |
+| caribe-cháima | 2 |
+| caribe-cumanagoto | 2 |
+| español-colonial | 2 |
+
+> **El punto no es que falte el dato: es que está en el margen.** Diez agentes
+> de sesenta y 36 formas de 1413 llevan la marca multiétnica, y ninguna de las
+> dos cosas es objeto de análisis. La sociedad multiétnica está en el reparto,
+> no en la pregunta.
+
+---
+
+## 3. «La Gran Curiana»: esfera, no polity
+
+Aquí hay una distinción que decide el diseño entero, y conviene no equivocarla.
+
+**La intuición es correcta**: hay una unidad supra-local que abarca Paraguaná,
+Aruba, Bonaire, Curazao, Coro y buena parte de Falcón, y que **no es
+geográfica** — no es «la península», es una red.
+
+**Pero llamarla *polity* afirma algo que la evidencia contradice.** El propio
+corpus ya lo razonó, en `parentesco-037`:
+
+> Manaure es el diao de Coro que además logró paramountcy sobre «algunas
+> circunvecinas» — **no sobre todo el mundo caquetío**: Barquisimeto y Yaracuy
+> son evidencia de una **esfera CULTURAL caquetía amplia, no de vasallaje
+> político directo**.
+
+Si «Gran Curiana» nombra una unidad política única, estamos construyendo un
+Cacicazgo Teocrático más grande — el error exacto que el proyecto lleva meses
+corrigiendo.
+
+### La forma correcta: esfera de interacción
+
+El modelo existe y es de la misma literatura: Antczak y Antczak describen la
+**«Valencioid Sphere of Interaction»** para el Valencioid, y hay evidencia
+dabajuroide equivalente (§2.2). Una **esfera de interacción** es una red de
+nodos que comparten cultura material, comercio, ritual y lengua **sin compartir
+una cabeza política**.
+
+| | Polity | Esfera de interacción |
+|---|---|---|
+| Autoridad | una | varias, y a veces ninguna común |
+| Fronteras | definidas | graduales, negociadas |
+| Lengua | tiende a homogénea | **contacto, variación, koiné** |
+| ¿Lo sostiene la evidencia? | solo hasta «algunas circunvecinas» | sí |
+
+Y hay una razón de fondo: **para la tesis de koineización, la esfera es mejor
+que la polity.** Una koiné no se forma dentro de una unidad homogénea con un
+jefe. Se forma justo donde hay nodos distintos que tienen que entenderse.
+
+> **Propuesta de nomenclatura:** «la Gran Curiana» nombra **la esfera**; la
+> polity de Coro/Todariquiba y las demás son **nodos** dentro de ella. La
+> escalera de `parentesco-037` —`apopo` → `diao` → *paramountcy*— es
+> exactamente el vocabulario atestiguado para describir esa estructura.
+
+### Esto además resuelve una decisión abierta
+
+`geografia_politica-007` dejó planteada la tensión de que «Curiana» está
+atestiguado como **territorio** («territorio donde estaban asentados los
+caquetíos», Zavala Reyes 2015 n.4) mientras el motor lo usa como nombre de
+asentamiento. Ofrecía tres salidas; el reencuadre de esta nota **es la salida
+(b)**: Curiana nombra el territorio/la esfera, y el asentamiento simulado recibe
+nombre propio. Ver [D2 (#33)](https://github.com/miguelgilurbina/curiana-radio/issues/33).
+
+---
+
+## 4. Qué cambia en el experimento: simulación geográficamente cerrada
+
+La simulación actual ocurre en «la Curiana», que no es un sitio: es un
+ambiente. **Un lugar vago no se puede falsear.** Un lugar enumerable sí.
+
+**El principio:** si se simula Paraguaná, se simula **Paraguaná** — con sus
+poblados nombrados, sus grupos familiares y las rutas que los unen. Y se expande
+añadiendo nodos, no ensanchando la niebla.
+
+### Por qué es metodológicamente superior
+
+| Hoy | Con nodos cerrados |
+|---|---|
+| «la Curiana», sin referente | poblados enumerados, cada uno con etiqueta epistémica |
+| no hay nada que contrastar contra el registro | cada nodo se puede auditar contra la fuente |
+| la variación dialectal es decorativa | la variación **tiene geografía**: nodo A ≠ nodo B |
+| expandir = subir el número de agentes | expandir = **añadir un nodo atestiguado** |
+
+Ese último renglón es el que más rinde para la lengua: **con nodos, la
+convergencia se puede medir entre ellos**, que es lo que una koiné significa. Con
+un solo asentamiento difuso, «convergencia» solo puede medirse entre individuos.
+
+### Lo que ya está atestiguado y sirve de punto de partida
+
+De la carta del obispo Rodrigo de Bastidas a Carlos V (1538), vía Oliver 1989
+cap.3 pp.251, 261-262 (`geografia_politica-003`):
+
+> **Todariquiba** (el poblado de Manaure, ~1 legua de Coro) · **Guaibacoa** ·
+> **Cumarebo** · **Tomodore** · **Caujarao** · **Zazárida** · **Capatárida**
+
+Y la escala, de la carta de Ballesteros (1550), vía Oliver cap.3 pp.262-263
+(`geografia_politica-004`): el canal del **buco** requería «cuatro o cinco mil
+indios» para repararlo, de lo que Oliver infiere coordinación entre **más de 30
+poblados**. La región tenía «catorce o quince mil indios».
+
+> ⚠️ **Advertencia epistémica, la de siempre.** Esta lista es de **1538 y 1550**:
+> es documentación **colonial**, y la simulación es de los siglos XIV-XV. Sirve
+> para saber qué topónimos existían y dónde, **no** para dar por buena la
+> organización política que las cartas describen — que ya está deformada por
+> once años de contacto. Regla 3 de [[CLAUDE]].
+
+---
+
+## 5. Lo que hay que construir
+
+| # | Qué | Por qué |
+|---|---|---|
+| 1 | **Registro de nodos** (`3-mundo/asentamientos.yaml`) con etiqueta epistémica por nodo | hoy no existe: los poblados viven en prosa dentro del corpus |
+| 2 | Minar Paraguaná específicamente (Arcaya trabajó los archivos de Coro) | falta la mitad de los topónimos y no sabemos cuáles son precontacto |
+| 3 | Que la simulación declare su nodo, como ya declara su polity | `huella_de_base.py` ya sella `polity`; falta `nodo` |
+| 4 | Variación dialectal **por nodo**, no por agente suelto | es la condición para que «koiné» signifique algo |
+| 5 | Grupos familiares por nodo (la escalera `apopo`/`diao`) | `parentesco-037` ya da el vocabulario |
+
+---
+
+## 6. Lo que esta nota **no** resuelve
+
+Honestidad primero, porque son huecos reales:
+
+- **Qué poblados de Paraguaná son precontacto.** La lista de Bastidas es de
+  1538 y es de la zona de Coro, no de la península. Adícora, Miraca, Moruy,
+  Baraived y compañía necesitan verificación fuente por fuente antes de entrar
+  en ningún registro.
+- **Qué lenguas hablaba cada nodo.** Que la esfera fuera multiétnica no dice
+  cuánto ni dónde. Jirajaroide y caribe aparecen en el lexicón con 7 y 4 formas:
+  eso no alcanza para modelar un nodo bilingüe.
+- **Si los guaycaríes eran un grupo distinto o una denominación de otra cosa.**
+  Son 4 agentes del elenco y no hay nota de fuente que los sostenga.
+
+Los tres son trabajo de minería, no de diseño. **Ninguno se resuelve
+decidiéndolo.**
+
+---
+
+## Enlaces
+
+[[polities-caquetias]] · [[horizonte-de-contacto]] · [[mapa-geografia-politica]] · [[HALLAZGOS_FASE_1]] · [[CULTURA_CAQUETIA]] · [[cronista]] · [[mapa-lengua]]

--- a/proyecto-linguistico-caquetío/3-mundo/esfera-de-interaccion.md
+++ b/proyecto-linguistico-caquetío/3-mundo/esfera-de-interaccion.md
@@ -184,6 +184,22 @@ cap.3 pp.251, 261-262 (`geografia_politica-003`):
 > **Todariquiba** (el poblado de Manaure, ~1 legua de Coro) · **Guaibacoa** ·
 > **Cumarebo** · **Tomodore** · **Caujarao** · **Zazárida** · **Capatárida**
 
+De esos, dos rinden mucho más que los otros cinco:
+
+- **Todariquiba** es el poblado de Manaure y el mejor candidato a lo que la
+  simulación llama «la Curiana». Su ubicación **sigue en debate**: no aparece
+  sitio arqueológico del tamaño correspondiente en la periferia de Coro.
+- **Cumarebo** tiene etimología resuelta —`Cumare` (antropónimo de cacique) +
+  `ebo` ('camino', atestiguado) = *'camino de Cumare'*, nivel A— y, sobre todo,
+  una ensenada **justo al este** llamada **«Puerto de los Indios Curaçao»**,
+  punto de partida documentado desde el que los caquetíos de Curazao cruzaban a
+  la isla en canoa (van Buurt 2014, citando a Hartog 1968).
+
+> **Ese par vale más que la lista entera**: Todariquiba es el centro político y
+> Cumarebo el puerto, y entre Cumarebo y Curazao hay una **ruta atestiguada**.
+> Es el enlace continente-isla mejor sostenido que tiene el proyecto, y es lo
+> que hace viable un diseño de dos nodos con tráfico real entre ellos.
+
 Y la escala, de la carta de Ballesteros (1550), vía Oliver cap.3 pp.262-263
 (`geografia_politica-004`): el canal del **buco** requería «cuatro o cinco mil
 indios» para repararlo, de lo que Oliver infiere coordinación entre **más de 30
@@ -197,11 +213,34 @@ poblados**. La región tenía «catorce o quince mil indios».
 
 ---
 
+### 🔴 Lo que el registro de nodos reveló al construirlo
+
+`3-mundo/asentamientos.yaml` separa tres cosas que la prosa mezclaba:
+**¿existió?** (`etiqueta`), **¿de qué época es el documento?** (`atestacion`) y
+**¿existía en el s. XIV-XV?** (`precontacto`). Al separarlas salió esto, medido
+el 2026-08-08 sobre 13 nodos:
+
+| Precontacto sostenido | n | Cuáles |
+|---|---|---|
+| **sí** | **3** | **Curazao, Aruba, Bonaire** — los tres insulares |
+| desconocido | 10 | todo el eje continental, incluida Todariquiba |
+
+**Ningún nodo continental tiene evidencia de existir en la ventana que
+simulamos.** Los tres que la tienen la deben a la **arqueología** —presencia
+dabajuroide ~900 d.C. (Antczak 2017 p.157)—, no a las crónicas.
+
+Es contraintuitivo y hay que tenerlo delante: **para el siglo XV, las islas
+están mejor sostenidas que la costa.** Toda la evidencia continental es de
+cartas de 1538 y 1550, y una carta de 1538 no dice nada de 1450.
+
+El validador lo protege con una regla ejecutable: `precontacto: si` **exige**
+`precontacto_razon`, y no puede convivir con `atestacion: colonial`.
+
 ## 5. Lo que hay que construir
 
 | # | Qué | Por qué |
 |---|---|---|
-| 1 | **Registro de nodos** (`3-mundo/asentamientos.yaml`) con etiqueta epistémica por nodo | hoy no existe: los poblados viven en prosa dentro del corpus |
+| 1 | ~~**Registro de nodos**~~ | ✅ **hecho**: `3-mundo/asentamientos.yaml`, 13 nodos, 4 huecos declarados, 8.º guardián |
 | 2 | Minar Paraguaná específicamente (Arcaya trabajó los archivos de Coro) | falta la mitad de los topónimos y no sabemos cuáles son precontacto |
 | 3 | Que la simulación declare su nodo, como ya declara su polity | `huella_de_base.py` ya sella `polity`; falta `nodo` |
 | 4 | Variación dialectal **por nodo**, no por agente suelto | es la condición para que «koiné» signifique algo |

--- a/proyecto-linguistico-caquetío/5-experimento/HALLAZGOS_FASE_1.md
+++ b/proyecto-linguistico-caquetío/5-experimento/HALLAZGOS_FASE_1.md
@@ -1,0 +1,197 @@
+---
+tipo: nota
+pregunta: "¿Qué preguntó este experimento, qué contestó y qué no puede contestar?"
+ambito: fase 1 — los 23 runs del 2026-06-21 al 2026-07-06
+medido: 2026-08-08
+cierra: la primera fase del experimento
+---
+
+# Hallazgos de la fase 1 — el marco científico
+
+> **Qué es esta nota.** El cierre de la primera fase. No un resumen de lo hecho
+> —eso está en [[LINEA_DE_TIEMPO]]— sino el enunciado de **qué se puede afirmar
+> con los datos que hay, y qué no**. Toda cifra viene de
+> [[ANALISIS_BASE_2026-08-06]], que es reproducible con `analizar_runs.py --todo`.
+
+---
+
+## 1. La pregunta, bien formulada
+
+La pregunta con la que arrancó el proyecto era **«¿podemos revivir el
+caquetío?»**, y la respuesta honesta es **no**. Revivir una lengua exige lo que
+el caquetío no tiene: hablantes, o un corpus lo bastante grande para deducir su
+gramática. Hay 226 palabras atestiguadas y ni una sola oración documentada.
+
+Pero esa formulación esconde una pregunta que **sí** es contestable, y es la que
+el experimento estuvo haciendo sin decirlo:
+
+> **¿Se puede producir un corpus de uso —cientos de miles de formas en
+> contexto— a partir de un léxico atestiguado y una morfología reconstruida, de
+> modo que la estructura que emerja sea consecuencia de las restricciones
+> impuestas y no del relleno del modelo?**
+
+Esa pregunta tiene tres virtudes: es empírica, admite un control, y su respuesta
+negativa es tan informativa como la positiva.
+
+**Lo que el experimento es, entonces:** no una resurrección, sino un
+**generador de hipótesis estructurales bajo restricción declarada**. El
+resultado no es «así hablaban los caquetíos». El resultado es «bajo estas
+restricciones explícitas, estas estructuras se estabilizan y estas no» — con
+las restricciones auditables una por una.
+
+---
+
+## 2. Lo que la fase 1 sí contestó
+
+Cuatro respuestas. **Dos son sobre el fenómeno y dos sobre el instrumento**, y
+las del instrumento son las que más valen, porque son las que nadie iba a mirar.
+
+### 2.1 ¿El mecanismo de contagio hace algo? — Sí
+
+Contraste pareado día a día entre el brazo normal y el de ablación (60 turnos
+cada uno):
+
+| Lectura | Δ | p | d de Cohen | Días que gana el normal |
+|---|---|---|---|---|
+| acumulada | +0.0214 | 3.5e-05 | 0.89 | 26/30 |
+| ventana | +0.0290 | 3.1e-04 | 0.75 | 22/30 |
+| **emergente** | **+0.0752** | **7.7e-11** | **1.81** | **29/30** |
+
+El brazo normal converge más en las tres lecturas, y la diferencia **crece en la
+lectura más exigente**. Sistemático, no un empate con medias distintas.
+
+> ⚠️ **Con n = 1 run por brazo esto es señal, no prueba.** Los 30 días
+> comparten agentes, semilla y trayectoria: son pseudo-réplicas. Los p-valores
+> contestan «¿difieren estas dos series?», no «¿difieren estas dos
+> condiciones?».
+
+### 2.2 ¿La convergencia se acumula? — **No**
+
+Este es el hallazgo negativo, y es el más interesante de los cuatro.
+
+En las tres lecturas la brecha entre brazos es **plana o levemente
+decreciente**. El mecanismo produce un desplazamiento **inmediato y sostenido**,
+no un efecto acumulativo.
+
+Si la hipótesis de trabajo era *«la koiné se va formando»*, el dato dice otra
+cosa: *«el contagio fija una diferencia desde el principio y la mantiene»*. Es
+un resultado más modesto y más preciso, y **cambia qué habría que medir en la
+fase 2**: no la pendiente, sino el punto de fijación y qué lo mueve.
+
+### 2.3 El instrumento medía en parte a sus autores
+
+**La longitud del `system_prompt` de un agente predice negativamente su score**
+(r = −0.481, p = 0.0046; Spearman −0.480, n = 33).
+
+Manaure —el diao, el centro narrativo, el prompt más largo con 834 caracteres—
+tiene **el peor score de todo el elenco**. Y el aparente efecto de género (las
+agentes femeninas puntúan más alto, p = 0.010) es, casi con seguridad, el mismo
+confusor: los prompts masculinos promedian 365 caracteres frente a 289 porque
+los protagonistas son hombres.
+
+> **Consecuencia dura:** toda lectura del tipo «el agente X lideró la
+> convergencia» puede ser «al agente X le escribimos más texto». No es una ley
+> sociolingüística: es una propiedad de cómo escribimos el elenco.
+
+### 2.4 La métrica principal no distinguía nada
+
+`pct_caquetio` tiene el **91% de las respuestas en 1.0** (σ = 0.028 y 0.013 en
+los dos brazos). Está saturada por diseño: si el objetivo era que el caquetío
+dominara, se cumplió con tanta holgura que ya no queda margen para medir mejora
+([#69](https://github.com/miguelgilurbina/curiana-radio/issues/69)).
+
+Y la mitad del corpus estaba mal guardada: **27.641 de 54.936 usos (50,3%)** sin
+lengua, y el **100%** de ellos eran formas morfológicamente complejas — justo
+las que prueban que los agentes manejan la morfología. Arreglado y rellenado.
+
+---
+
+## 3. Lo que la fase 1 **no** puede afirmar
+
+Aquí es donde hay que ser más estricto que un revisor hostil, porque estas
+objeciones se las va a hacer cualquiera y es mejor tenerlas escritas primero.
+
+### 3.1 🔴 La amenaza principal: los agentes ya saben hablar
+
+Los agentes son modelos de lenguaje que **ya conocen el español** y **ya
+conocen patrones arahuacos generales** (wayunaiki, lokono y taíno están en sus
+datos de entrenamiento; el propio lexicón del proyecto es 769 formas de
+wayunaiki y 198 de lokono).
+
+Cuando un agente produce una forma bien construida, **no sabemos por cuál de
+dos caminos llegó**:
+
+| Camino | Qué probaría |
+|---|---|
+| La morfología caquetía atestiguada lo restringió | el experimento funciona |
+| El modelo rellenó con lo que sabe de lenguas parecidas | el experimento se mide a sí mismo |
+
+**La ablación no distingue estos dos caminos.** Controla la afirmación sobre
+*convergencia* —apaga las inyecciones y compara—, pero ambos brazos usan el
+mismo modelo con el mismo conocimiento previo. Es un control del **mecanismo
+social**, no del **origen de las formas**.
+
+Esta es, hoy, la amenaza a la validez más seria del proyecto, y la fase 1 no la
+resolvió.
+
+### 3.2 Las otras cuatro
+
+1. **n = 1 por brazo.** Ya dicho: pseudo-réplica.
+2. **30 días simulados** prueban un mecanismo, no un fenómeno histórico. Una
+   koineización real ocurre en generaciones.
+3. **Ningún run es plenamente citable.** Hasta [[DINAMICA_DE_RUNS]] no se
+   registraba contra qué base corrió cada run; para analizar los seis primeros
+   hubo que reconstruirla de git. `huella_de_base.py` cierra esto **a partir de
+   ahora**, no hacia atrás.
+4. **El curador de citas premia lo breve sin comprobar que sea lengua.** El
+   momento de mayor impacto de toda la base es «**Ríe.**» — una acotación
+   escénica en español, impacto 9.8.
+
+---
+
+## 4. Qué convierte esto en una fase 2
+
+El instinto correcto es el que ya está sobre la mesa: **quitarle a los agentes
+la oportunidad de creer que entienden la lengua.**
+
+Si el problema es que el modelo puede rellenar con arahuaco genérico, la salida
+no es pedirle que no lo haga —no es verificable— sino **cerrarle la puerta por
+construcción**:
+
+| Restricción | Qué prueba si aun así producen |
+|---|---|
+| Fonotáctica declarada: solo secuencias atestiguadas | que la forma nueva es compatible con el caquetío, no con «una lengua indígena» |
+| Morfología cerrada: solo los afijos del inventario | que la productividad es del sistema, no del modelo |
+| Léxico cerrado con hueco explícito | que el agente **acuña** en vez de importar |
+| Sin glosa castellana en el prompt del turno | que la forma se usa, no se traduce |
+
+**El diseño clave**: si se cierra el inventario y aun así los agentes producen
+formas nuevas bien formadas *y las estabilizan entre ellos*, eso sí es un
+resultado. Y si no las producen, también — significa que lo que veíamos era
+relleno, y saberlo vale la fase entera.
+
+La segunda pieza es la **morfología productiva como métrica**, ahora medible por
+primera vez: hasta el arreglo del `source_language`, las 18.752 formas con
+sufijo de aspecto se guardaban sin lengua. «¿Usan más morfología con el tiempo?»
+rinde mucho más que «¿hablan caquetío?», a la que todos contestan que sí al 99%.
+
+---
+
+## 5. El error del que se saca provecho
+
+Conviene decirlo sin adornos: **la fase 1 corrió el experimento antes de tener
+el instrumento calibrado.** 23 runs y 54.936 usos de palabra produjeron sobre
+todo hallazgos sobre la métrica, el confusor y el guardado — no sobre la lengua.
+
+Eso no es un fracaso, es el orden en que suelen ocurrir las cosas cuando por fin
+miras los datos en serio. Pero deja una regla para la fase 2:
+
+> **Correr más runs no es lo siguiente. Lo siguiente es que un run sea
+> legible.** Mientras la métrica esté saturada y la longitud del prompt sin
+> controlar, más runs producen más datos que no se pueden interpretar.
+
+---
+
+## Enlaces
+
+[[ANALISIS_BASE_2026-08-06]] · [[DINAMICA_DE_RUNS]] · [[DISENO_KOINE]] · [[01_que_probaron_los_seis_runs]] · [[LINEA_DE_TIEMPO]] · [[esfera-de-interaccion]] · [[mapa-motor]]

--- a/proyecto-linguistico-caquetío/CLAUDE.md
+++ b/proyecto-linguistico-caquetío/CLAUDE.md
@@ -66,7 +66,7 @@ cura y se publica en Curiana Radio (`/simulador`).
 cd curiana_sim
 pip install -r requirements.txt
 
-python guardianes.py              # los 7 en verde antes de cerrar nada
+python guardianes.py              # los 8 en verde antes de cerrar nada
 python guardianes.py --rapido     # sin los tests (más rápido)
 
 # Los datos de lengua y la bibliografía
@@ -80,6 +80,7 @@ python generar_tablero.py --gh    # + decisiones del tablero (usa red)
 
 python analizar_runs.py --todo    # análisis de los runs en la base
 python compilar_corpus.py --check # valida 3-mundo/corpus/
+python compilar_asentamientos.py  # los nodos de la esfera: existencia y época
 python curiana_polities.py --canon
 
 supabase start                    # Docker local (ver puertos arriba)
@@ -107,6 +108,7 @@ TABLERO.md         el estado medido (generado — no se edita a mano)
 2-lengua/          ¿cómo es el caquetío?  lexicon · morfologia · toponimia · metodo-comparativo
                    datos: cognados.yaml · toponimos.yaml · morfemas.yaml (ver datos-de-lengua)
 3-mundo/           ¿cómo era ese pueblo?  5 mapas · polities-caquetias · corpus/ · ensayos/
+                   esfera-de-interaccion · asentamientos.yaml (los nodos)
 4-fuentes/         ¿de dónde lo sabemos?  una nota por obra + INDICE_FUENTES
 5-experimento/     ¿qué probamos?  mapa-motor · ARQUITECTURA · DISENO_KOINE · analisis/
 curiana_sim/       el motor + tests/

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -48,6 +48,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 | [[mapa-transmision]] | ¿Cómo sabía lo que sabía? | 34 |
 | [[mapa-geografia-politica]] | ¿Cuál era el mundo de Manaure? | 8 |
 | [[polities-caquetias]] | ¿Cuántos caquetíos había, y cuál simulamos? | 4 polities |
+| [[esfera-de-interaccion]] | ¿Era una sola etnia? ¿Qué unidad hay que simular? | 10/60 · 36/1413 |
 | [[horizonte-de-contacto]] | ¿Hasta dónde llegaba su mundo? ¿Tocó a los mayas? | prospección |
 | [[cronista]] | ¿Se puede contar desde dentro sin inventarlo? | 8 sustituciones |
 | [[mapa-motor]] | El código, los tests y los runs | — |
@@ -69,6 +70,8 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 - 🕰️ [[LINEA_DE_TIEMPO]] — las cuatro eras del proyecto y sobre qué base corrió
   cada cosa. Necesaria para saber qué resultados siguen valiendo.
 - 🎬 [[DINAMICA_DE_RUNS]] — cómo se corre, se lee y se muestra un run.
+- 🔭 [[HALLAZGOS_FASE_1]] — **el cierre de la primera fase como experimento**:
+  qué contestó, qué no puede contestar, y qué restricción abre la fase 2.
 - 🔬 [[01_que_probaron_los_seis_runs]] — qué probaron los runs existentes, qué
   no, y por qué no son comparables.
 - 🧪 [[04_protocolo_run_1_era_auditada]] — cómo se corre y se mide la próxima

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -48,7 +48,7 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 | [[mapa-transmision]] | ¿Cómo sabía lo que sabía? | 34 |
 | [[mapa-geografia-politica]] | ¿Cuál era el mundo de Manaure? | 8 |
 | [[polities-caquetias]] | ¿Cuántos caquetíos había, y cuál simulamos? | 4 polities |
-| [[esfera-de-interaccion]] | ¿Era una sola etnia? ¿Qué unidad hay que simular? | 10/60 · 36/1413 |
+| [[esfera-de-interaccion]] | ¿Era una sola etnia? ¿Qué unidad hay que simular? | 13 nodos |
 | [[horizonte-de-contacto]] | ¿Hasta dónde llegaba su mundo? ¿Tocó a los mayas? | prospección |
 | [[cronista]] | ¿Se puede contar desde dentro sin inventarlo? | 8 sustituciones |
 | [[mapa-motor]] | El código, los tests y los runs | — |

--- a/proyecto-linguistico-caquetío/curiana_sim/compilar_asentamientos.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/compilar_asentamientos.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — validador del registro de nodos
+=========================================
+
+Valida `3-mundo/asentamientos.yaml`: qué asentamientos existían, cuándo, y con
+qué evidencia. Es la pieza que hace posible la **simulación geográficamente
+cerrada** de la fase 2 (`3-mundo/esfera-de-interaccion.md` §4).
+
+POR QUÉ NO VIVE EN `compilar_corpus.py`
+---------------------------------------
+Un nodo no es un hecho del corpus: no tiene `contenido` ni etiqueta epistémica
+sobre una afirmación, sino sobre la EXISTENCIA de un lugar y sobre su ÉPOCA.
+Meterlo en el corpus obligaría a que `cargar()` supiera de dos esquemas.
+
+Y no vive en `compilar_lengua.py` porque `toponimos.yaml` contesta otra cosa:
+"¿qué significa este nombre?". Ahí Adícora, Curaçao y Aruba constan como
+`descartado`, que significa "sin etimología despejable" y NO "no existió".
+
+LA VALIDACIÓN QUE JUSTIFICA EL MÓDULO
+-------------------------------------
+`precontacto: si` **exige** `precontacto_razon`.
+
+Es la única regla que de verdad protege algo. Todo el registro se apoya en
+documentos coloniales —la carta de Bastidas es de 1538, once años después del
+pacto Ampíes-Manaure— y la simulación es del s. XIV-XV. Sin esta regla,
+"atestiguado" se desliza a "precontacto" sin que nadie lo note, que es la
+regla 3 de CLAUDE.md incumplida en silencio.
+
+Y su corolario: un nodo con `atestacion: colonial` **no puede** declarar
+`precontacto: si`. Un documento de 1538 no prueba nada sobre 1450. Si existe
+esa evidencia, será arqueológica, y entonces `atestacion` lo tiene que decir.
+
+Uso:
+    python compilar_asentamientos.py            # informe
+    python compilar_asentamientos.py --check    # exit 1 si hay errores (CI)
+    python compilar_asentamientos.py --json     # el informe en JSON
+
+No modifica el YAML: valida e informa. Misma disciplina que los minadores.
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+import yaml
+
+_AQUI = os.path.dirname(os.path.abspath(__file__))
+REGISTRO = os.path.join(_AQUI, "..", "3-mundo", "asentamientos.yaml")
+BIBLIOGRAFIA = os.path.join(_AQUI, "..", "4-fuentes", "bibliografia.yaml")
+CORPUS_DIR = os.path.join(_AQUI, "..", "3-mundo", "corpus")
+
+RE_ID = re.compile(r"^nodo-\d{3}$")
+RE_HECHO = re.compile(r"^[a-z][a-z_]*-\d{3}[a-z]?$")
+
+# Vocabularios cerrados. Un campo con valores libres deja de poder agruparse:
+# es el bug de `taíno`/`taino` en el lexicón (issue #93), y no se repite aquí.
+ETIQUETAS = ("atestiguado", "reconstruido", "hipotetico")
+ATESTACIONES = ("colonial", "precolonial", "arqueologica")
+PRECONTACTO = ("si", "probable", "desconocido")
+TIPOS = ("asentamiento", "asentamiento-puerto", "asentamiento-palafito", "isla")
+ETIMOLOGIAS = ("resuelto", "sin-resolver", "descartada", "no-aplica")
+
+OBLIGATORIOS = ("id", "forma", "tipo", "region", "etiqueta", "atestacion",
+                "precontacto", "rol", "procedencia", "etimologia")
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace",
+                line_buffering=True))
+
+
+def _error(codigo, donde, mensaje):
+    return {"nivel": "error", "codigo": codigo, "donde": donde, "mensaje": mensaje}
+
+
+def _aviso(codigo, donde, mensaje):
+    return {"nivel": "aviso", "codigo": codigo, "donde": donde, "mensaje": mensaje}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# CARGA
+# ══════════════════════════════════════════════════════════════════════
+
+def cargar(ruta: str = REGISTRO):
+    """Devuelve `(nodos, huecos, problemas)`."""
+    if not os.path.exists(ruta):
+        return [], [], [_error("registro-ausente", ruta,
+                               "3-mundo/asentamientos.yaml no existe")]
+    try:
+        with open(ruta, encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh) or {}
+    except yaml.YAMLError as e:
+        return [], [], [_error("yaml-invalido", ruta, f"no parsea: {e}")]
+
+    if not isinstance(doc, dict):
+        return [], [], [_error("raiz-inesperada", ruta,
+                               f"la raíz es {type(doc).__name__}, se esperaba dict")]
+
+    nodos = doc.get("nodos") or []
+    huecos = doc.get("huecos") or []
+    problemas = []
+    if not isinstance(nodos, list):
+        problemas.append(_error("nodos-inesperado", ruta,
+                                f"`nodos` es {type(nodos).__name__}, se esperaba lista"))
+        nodos = []
+    return [n for n in nodos if isinstance(n, dict)], huecos, problemas
+
+
+def _obras_de_la_bibliografia():
+    """Los ids de `4-fuentes/bibliografia.yaml`, o None si no existe."""
+    if not os.path.exists(BIBLIOGRAFIA):
+        return None
+    with open(BIBLIOGRAFIA, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+    return {o["id"] for o in doc.get("obras", []) if o.get("id")}
+
+
+def _ids_del_corpus():
+    """Los ids de hecho de `3-mundo/corpus/`, o None si no se puede leer."""
+    if not os.path.isdir(CORPUS_DIR):
+        return None
+    ids = set()
+    for nombre in sorted(os.listdir(CORPUS_DIR)):
+        if not nombre.endswith(".yaml"):
+            continue
+        try:
+            with open(os.path.join(CORPUS_DIR, nombre), encoding="utf-8") as fh:
+                datos = yaml.safe_load(fh)
+        except yaml.YAMLError:
+            continue
+        secciones = datos.values() if isinstance(datos, dict) else [datos]
+        for entradas in secciones:
+            if not isinstance(entradas, list):
+                continue
+            for e in entradas:
+                if isinstance(e, dict) and e.get("id"):
+                    ids.add(e["id"])
+    return ids
+
+
+# ══════════════════════════════════════════════════════════════════════
+# VALIDACIONES
+# ══════════════════════════════════════════════════════════════════════
+
+def validar_estructura(nodos: list) -> list:
+    problemas, vistos = [], set()
+    for i, nodo in enumerate(nodos):
+        nid = nodo.get("id")
+        donde = nid or f"nodos[{i}]"
+
+        for campo in OBLIGATORIOS:
+            valor = nodo.get(campo)
+            if valor is None or (isinstance(valor, str) and not valor.strip()):
+                problemas.append(_error("campo-ausente", donde,
+                                        f"falta el campo obligatorio `{campo}`"))
+
+        if nid and not RE_ID.match(str(nid)):
+            problemas.append(_error("id-mal-formado", donde,
+                                    f"`{nid}` no tiene la forma `nodo-NNN`"))
+        if nid in vistos:
+            problemas.append(_error("id-duplicado", donde, f"`{nid}` está repetido"))
+        vistos.add(nid)
+    return problemas
+
+
+def validar_vocabularios(nodos: list) -> list:
+    """Cada campo cerrado, con su lista cerrada. Sin esto no se puede agrupar."""
+    cerrados = (("etiqueta", ETIQUETAS), ("atestacion", ATESTACIONES),
+                ("precontacto", PRECONTACTO), ("tipo", TIPOS),
+                ("etimologia", ETIMOLOGIAS))
+    problemas = []
+    for nodo in nodos:
+        donde = nodo.get("id", "(sin id)")
+        for campo, legales in cerrados:
+            valor = nodo.get(campo)
+            if valor is not None and valor not in legales:
+                problemas.append(_error(
+                    f"{campo}-ilegal", donde,
+                    f"`{campo}: {valor}` no es legal — solo {', '.join(legales)}"))
+    return problemas
+
+
+def validar_precontacto(nodos: list) -> list:
+    """**La regla que justifica este módulo.**
+
+    Afirmar que un asentamiento existía en el s. XIV-XV es la afirmación más
+    fuerte del registro y la única que la simulación consume de verdad. No se
+    puede hacer de gratis:
+
+    1. `precontacto: si` exige `precontacto_razon`.
+    2. `precontacto: si` con `atestacion: colonial` es contradicción: un
+       documento de 1538 no dice nada de 1450. Si hay evidencia precontacto,
+       será arqueológica, y `atestacion` lo tiene que declarar.
+    """
+    problemas = []
+    for nodo in nodos:
+        donde = nodo.get("id", "(sin id)")
+        pre = nodo.get("precontacto")
+        razon = nodo.get("precontacto_razon")
+
+        if pre == "si" and not (razon and str(razon).strip()):
+            problemas.append(_error(
+                "precontacto-sin-razon", donde,
+                "declara `precontacto: si` sin `precontacto_razon`. La "
+                "afirmación más fuerte del registro no se hace de gratis"))
+
+        if pre == "si" and nodo.get("atestacion") == "colonial":
+            problemas.append(_error(
+                "precontacto-por-documento-colonial", donde,
+                "declara `precontacto: si` con `atestacion: colonial`: un "
+                "documento colonial no prueba existencia precontacto "
+                "(regla 3 de CLAUDE.md)"))
+
+        if pre != "si" and razon:
+            problemas.append(_aviso(
+                "razon-huerfana", donde,
+                f"tiene `precontacto_razon` pero `precontacto: {pre}`"))
+    return problemas
+
+
+def validar_procedencia(nodos: list, obras) -> list:
+    """`procedencia.obra` es clave foránea contra la bibliografía."""
+    if obras is None:
+        return [_aviso("sin-bibliografia", "4-fuentes/bibliografia.yaml",
+                       "no existe: las citas no se pueden comprobar. Genérala "
+                       "con `python curiana_sim/generar_bibliografia.py`")]
+    problemas = []
+    for nodo in nodos:
+        donde = nodo.get("id", "(sin id)")
+        proc = nodo.get("procedencia")
+        if proc is None:
+            continue
+        if not isinstance(proc, dict):
+            problemas.append(_error("procedencia-mal-formada", donde,
+                                    f"es {type(proc).__name__}, se esperaba dict"))
+            continue
+        obra = proc.get("obra")
+        if not obra:
+            problemas.append(_error("procedencia-sin-obra", donde,
+                                    "`procedencia` sin campo `obra`"))
+        elif obra not in obras:
+            problemas.append(_error("obra-fantasma", donde,
+                                    f"cita `{obra}`, que no está en la bibliografía"))
+    return problemas
+
+
+def validar_corpus(nodos: list, ids) -> list:
+    """Los hechos citados en `corpus:` tienen que existir."""
+    if ids is None:
+        return [_aviso("sin-corpus", "3-mundo/corpus", "no se pudo leer")]
+    problemas = []
+    for nodo in nodos:
+        donde = nodo.get("id", "(sin id)")
+        for hecho in nodo.get("corpus") or []:
+            if not RE_HECHO.match(str(hecho)):
+                problemas.append(_error("hecho-mal-formado", donde,
+                                        f"`{hecho}` no tiene forma `<dominio>-NNN`"))
+            elif hecho not in ids:
+                problemas.append(_error("hecho-fantasma", donde,
+                                        f"cita `{hecho}`, que no está en el corpus"))
+    return problemas
+
+
+def compilar(ruta: str = REGISTRO):
+    """Carga, valida y devuelve `(nodos, huecos, problemas)`."""
+    nodos, huecos, problemas = cargar(ruta)
+    problemas += validar_estructura(nodos)
+    problemas += validar_vocabularios(nodos)
+    problemas += validar_precontacto(nodos)
+    problemas += validar_procedencia(nodos, _obras_de_la_bibliografia())
+    problemas += validar_corpus(nodos, _ids_del_corpus())
+    return nodos, huecos, problemas
+
+
+# ══════════════════════════════════════════════════════════════════════
+# INFORME
+# ══════════════════════════════════════════════════════════════════════
+
+def informe(nodos, huecos, problemas) -> None:
+    errores = [p for p in problemas if p["nivel"] == "error"]
+    avisos = [p for p in problemas if p["nivel"] == "aviso"]
+
+    print(f"\n── registro de nodos ── {len(nodos)} nodos, {len(huecos)} hueco(s)\n")
+
+    por_region = Counter(n.get("region") for n in nodos)
+    for region, n in por_region.most_common():
+        print(f"  {region:22} {n}")
+
+    print("\n  por evidencia de precontacto (la que consume la simulación):")
+    por_pre = Counter(n.get("precontacto") for n in nodos)
+    for valor in PRECONTACTO:
+        if por_pre.get(valor):
+            print(f"    {valor:14} {por_pre[valor]}")
+
+    utiles = [n.get("forma") for n in nodos if n.get("precontacto") == "si"]
+    if utiles:
+        print(f"\n  Con precontacto sostenido: {', '.join(utiles)}")
+    else:
+        print("\n  ⚠ NINGÚN nodo tiene precontacto sostenido.")
+
+    if errores:
+        print(f"\n  ✗ {len(errores)} error(es):")
+        for p in errores:
+            print(f"      [{p['codigo']}] {p['donde']}: {p['mensaje']}")
+    if avisos:
+        print(f"\n  ⚠ {len(avisos)} aviso(s):")
+        for p in avisos:
+            print(f"      [{p['codigo']}] {p['donde']}: {p['mensaje']}")
+    if not errores:
+        print(f"\n  ✓ registro válido — {len(nodos)} nodos, {len(avisos)} aviso(s)\n")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="exit 1 si hay errores")
+    ap.add_argument("--json", action="store_true", help="el informe en JSON")
+    args = ap.parse_args(argv)
+
+    nodos, huecos, problemas = compilar()
+    errores = [p for p in problemas if p["nivel"] == "error"]
+
+    if args.json:
+        print(json.dumps({"nodos": len(nodos), "huecos": len(huecos),
+                          "problemas": problemas}, ensure_ascii=False, indent=2))
+    elif args.check:
+        if errores:
+            print(f"✗ {len(errores)} error(es) en el registro de nodos")
+            for p in errores:
+                print(f"    [{p['codigo']}] {p['donde']}: {p['mensaje']}")
+        else:
+            avisos = len(problemas) - len(errores)
+            print(f"✓ registro de nodos válido — {len(nodos)} nodos, {avisos} aviso(s)")
+    else:
+        informe(nodos, huecos, problemas)
+
+    return 1 if (args.check and errores) else 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/guardianes.py
@@ -4,7 +4,7 @@
 CURIANA — los guardianes, en un solo comando
 ============================================
 
-El proyecto tiene siete comprobaciones que miden **contra el dato** y no contra
+El proyecto tiene ocho comprobaciones que miden **contra el dato** y no contra
 la documentación. Estaban sueltas, y correrlas dependía de que alguien se
 acordara de todas:
 
@@ -15,8 +15,9 @@ acordara de todas:
     5. las polities               python curiana_sim/curiana_polities.py --check
     6. la bibliografía al día     python curiana_sim/generar_bibliografia.py --check
     7. los datos de lengua        python curiana_sim/compilar_lengua.py --check
+    8. el registro de nodos       python curiana_sim/compilar_asentamientos.py --check
 
-Acordarse de siete cosas no es un método: es suerte. Esto las corre todas,
+Acordarse de ocho cosas no es un método: es suerte. Esto las corre todas,
 informa en una tabla y sale con código ≠ 0 si alguna falla, para que se pueda
 colgar de un hook o de CI.
 
@@ -25,7 +26,7 @@ viejo cada vez que cambia una cifra medida, que es constantemente, y bloquear
 por eso sería ruido. Se regenera, no se vigila.
 
 Uso:
-    python guardianes.py            # los cinco, informe en tabla
+    python guardianes.py            # los ocho, informe en tabla
     python guardianes.py --rapido   # salta los tests (los más lentos)
     python guardianes.py --silencio # solo el veredicto, para hooks
 """
@@ -63,6 +64,9 @@ GUARDIANES = [
      REPO, False),
     ("datos de lengua",
      [PY, os.path.join(AQUI, "compilar_lengua.py"), "--check"],
+     REPO, False),
+    ("registro de nodos",
+     [PY, os.path.join(AQUI, "compilar_asentamientos.py"), "--check"],
      REPO, False),
 ]
 

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_asentamientos.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_asentamientos.py
@@ -1,0 +1,99 @@
+"""Tests del registro de nodos.
+
+Lo que protegen: que no se pueda afirmar que un asentamiento existía en el
+siglo XV sin decir por qué, y que un documento colonial no cuele como evidencia
+precontacto. Todo el registro se apoya en cartas de 1538-1550 y la simulación
+es del XIV-XV; sin estas dos reglas, "atestiguado" se desliza a "precontacto"
+sin que nadie lo note.
+"""
+
+import compilar_asentamientos as CA
+
+
+def _nodo(**kw):
+    base = dict(id="nodo-001", forma="x", tipo="asentamiento", region="r",
+                etiqueta="atestiguado", atestacion="colonial",
+                precontacto="desconocido", rol="algo",
+                procedencia={"obra": "oliver-1989-cap3"},
+                etimologia="sin-resolver")
+    base.update(kw)
+    return base
+
+
+# ── la regla que justifica el módulo ──────────────────────────────────
+
+def test_precontacto_si_exige_razon():
+    p = CA.validar_precontacto([_nodo(precontacto="si", atestacion="arqueologica")])
+    assert any(x["codigo"] == "precontacto-sin-razon" for x in p)
+
+
+def test_precontacto_si_con_razon_pasa():
+    p = CA.validar_precontacto([_nodo(precontacto="si", atestacion="arqueologica",
+                                      precontacto_razon="dabajuroide ~900 d.C.")])
+    assert not [x for x in p if x["nivel"] == "error"]
+
+
+def test_un_documento_colonial_no_prueba_precontacto():
+    """Una carta de 1538 no dice nada de 1450. Regla 3 de CLAUDE.md."""
+    p = CA.validar_precontacto([_nodo(precontacto="si", atestacion="colonial",
+                                      precontacto_razon="lo dice Bastidas")])
+    assert any(x["codigo"] == "precontacto-por-documento-colonial" for x in p)
+
+
+def test_razon_sin_afirmacion_es_solo_aviso():
+    p = CA.validar_precontacto([_nodo(precontacto="desconocido",
+                                      precontacto_razon="sobra")])
+    assert [x["nivel"] for x in p] == ["aviso"]
+
+
+# ── vocabularios cerrados ─────────────────────────────────────────────
+
+def test_los_campos_cerrados_rechazan_valores_nuevos():
+    """Un campo con valores libres deja de poder agruparse — es el bug
+    `taíno`/`taino` del lexicón (#93), y aquí no se repite."""
+    p = CA.validar_vocabularios([_nodo(etiqueta="mas o menos")])
+    assert any(x["codigo"] == "etiqueta-ilegal" for x in p)
+
+
+def test_atestacion_arqueologica_es_legal():
+    assert not CA.validar_vocabularios([_nodo(atestacion="arqueologica")])
+
+
+# ── integridad referencial ────────────────────────────────────────────
+
+def test_la_obra_citada_tiene_que_existir():
+    p = CA.validar_procedencia([_nodo(procedencia={"obra": "inventada-1999"})],
+                               {"oliver-1989-cap3"})
+    assert any(x["codigo"] == "obra-fantasma" for x in p)
+
+
+def test_el_hecho_del_corpus_citado_tiene_que_existir():
+    p = CA.validar_corpus([_nodo(corpus=["geografia_politica-999"])],
+                          {"geografia_politica-003"})
+    assert any(x["codigo"] == "hecho-fantasma" for x in p)
+
+
+def test_id_duplicado_es_error():
+    p = CA.validar_estructura([_nodo(), _nodo()])
+    assert any(x["codigo"] == "id-duplicado" for x in p)
+
+
+# ── el registro real ──────────────────────────────────────────────────
+
+def test_el_registro_real_valida():
+    nodos, _, problemas = CA.compilar()
+    errores = [p for p in problemas if p["nivel"] == "error"]
+    assert not errores, errores
+    assert len(nodos) >= 13
+
+
+def test_los_nodos_con_precontacto_son_los_insulares():
+    """El hallazgo que el registro deja ver: para la ventana simulada, las
+    islas están mejor sostenidas que la costa — y por arqueología, no por
+    crónica. Si esto cambia, es que entró evidencia nueva y hay que mirarla."""
+    nodos, _, _ = CA.compilar()
+    con_pre = {n["forma"] for n in nodos if n.get("precontacto") == "si"}
+    assert con_pre == {"curazao", "aruba", "bonaire"}
+    for n in nodos:
+        if n.get("precontacto") == "si":
+            assert n["atestacion"] == "arqueologica"


### PR DESCRIPTION
docs(experimento): cerrar la fase 1 y reencuadrar la sociedad como esfera multiétnica

Dos notas: una cierra, la otra abre.

## HALLAZGOS_FASE_1.md — el experimento, dicho como experimento

Reformula la pregunta. "¿Podemos revivir el caquetío?" se contesta que no —hacen
falta hablantes o un corpus, y hay 226 palabras y cero oraciones—, pero esconde
otra que sí es contestable: si un léxico atestiguado y una morfología
reconstruida bastan para que emerja estructura que sea consecuencia de las
restricciones y no del relleno del modelo. Eso es empírico y admite control.

Cuatro respuestas de la fase 1, y las dos que más valen son negativas:

- el mecanismo de contagio hace algo (d = 1.81 en la lectura emergente, 29/30
  días) — señal, no prueba, con n=1 por brazo
- **la convergencia NO se acumula**: desplaza de entrada y sostiene. Si la
  hipótesis era "la koiné se va formando", el dato dice otra cosa
- el instrumento medía en parte a sus autores (longitud de prompt vs. score,
  r = -0.48; el "efecto de género" es el mismo confusor visto de lado)
- `pct_caquetio` saturada al 91%, y medio corpus se guardaba sin lengua

Y la amenaza a la validez que hay que decir antes de que la diga otro: los
agentes ya saben español y ya conocen patrones arahuacos —el propio lexicón es
769 formas de wayunaiki—, así que cuando producen una forma bien construida no
sabemos si la restringió el caquetío o la rellenó el modelo. La ablación
controla el mecanismo social, NO el origen de las formas. Cerrar fonotáctica y
morfología es lo que convertiría eso en prueba: si con el inventario cerrado
aun así acuñan y se copian entre ellos, es resultado; y si no, también.

## esfera-de-interaccion.md — la sociedad no era monoétnica

Oliver cap.3 n.3: `caquetío` es cognado del lokono `kakitho` = 'persona, gente',
y era autodenominación. Un pueblo que se llama "la gente" no está trazando una
frontera étnica, y tratarla como etiqueta excluyente es artefacto de la fuente
colonial.

Lo multiétnico ya está en nuestros datos, pero en el margen: medido hoy, 10 de
60 agentes no son caquetíos (guaycarí, jirajara, caribe, gayón, uno de Aruba y
un mixto) y 36 de 1413 formas del lexicón llevan estrato de contacto
(jirajaroide, caribe-cháima, cumanagoto, kalinago-overlay). Está en el reparto,
no en la pregunta.

**Donde discrepo del planteamiento inicial**: "la Gran Curiana" como *polity*
afirma algo que la evidencia contradice, y el propio corpus ya lo razonó —
`parentesco-037` dice literalmente "esfera CULTURAL caquetía amplia, no de
vasallaje político directo", y la paramountcy de Manaure llegaba a "algunas
circunvecinas". Nombrarla polity construye un Cacicazgo Teocrático más grande,
que es el error que el proyecto lleva meses corrigiendo. La forma que sí aguanta
es **esfera de interacción** (el modelo existe: la Valencioid Sphere de
Antczak), con nodos que comparten cultura y comercio sin cabeza común. Y para la
tesis de koiné es mejor: una koiné no se forma dentro de una unidad homogénea,
se forma donde hay nodos distintos que tienen que entenderse.

Esto además resuelve D2 (#33): `geografia_politica-007` dejó tres salidas a la
tensión "Curiana = territorio vs. asentamiento"; el reencuadre es la salida (b).

## Simulación geográficamente cerrada

Un lugar vago no se puede falsear. Con nodos enumerados la variación dialectal
deja de ser decorativa y pasa a tener geografía — que es la condición para que
"convergencia" signifique algo más que "entre individuos". Hay lista atestiguada
de dónde partir (Bastidas 1538: Todariquiba, Guaibacoa, Cumarebo, Tomodore,
Caujarao, Zazárida, Capatárida) con la advertencia de que es documentación
colonial y la simulación es del XIV-XV.

La nota deja escrito lo que NO resuelve: qué poblados de Paraguaná son
precontacto, qué lenguas hablaba cada nodo, y si los guaycaríes son un grupo
distinto o una denominación de otra cosa. Los tres son minería, no diseño.

Los 7 guardianes en verde, 174 tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
