### PR TITLE
La fonotáctica del caquetío: el resultado negativo de #91

### DIFF
--- a/proyecto-linguistico-caquetío/2-lengua/fonotactica.md
+++ b/proyecto-linguistico-caquetío/2-lengua/fonotactica.md
@@ -1,0 +1,139 @@
+---
+tipo: nota
+pregunta: "¿Se puede cerrar la forma de la palabra para que el modelo no rellene?"
+medido: 2026-08-09
+herramienta: curiana_sim/curiana_fonotactica.py
+base: las 234 formas caquetío-atestiguado del lexicón
+---
+
+# La fonotáctica — un resultado negativo, y por qué vale
+
+> **La respuesta corta:** no. Cerrar la fonotáctica **no** impide que el modelo
+> rellene con arahuaco genérico, porque el arahuaco genérico ya satisface la
+> fonotáctica caquetía. Lo que sí hace es detectar castellano.
+
+---
+
+## 1. Lo que se quería y lo que salió
+
+[[HALLAZGOS_FASE_1]] §3.1 nombró la amenaza principal de la fase 1: los agentes
+son modelos que ya saben español y ya conocen patrones arahuacos, así que
+cuando producen una forma bien construida no sabemos si los restringió el
+caquetío o los rellenó su conocimiento previo.
+
+La idea era **cerrarles la puerta por construcción**: derivar un filtro de forma
+solo del caquetío atestiguado y rechazar lo que no lo cumpla.
+
+Se construyó el filtro y se midió qué deja pasar de cada fuente:
+
+| Fuente | Pasa | |
+|---|---|---|
+| caquetío atestiguado (control) | 100.0 % | ██████████████████████████████ |
+| caquetío reconstruido | 98.5 % | █████████████████████████████ |
+| taíno | 94.4 % | ████████████████████████████ |
+| **wayunaiki** | **86.3 %** | █████████████████████████ |
+| lokono | 79.8 % | ███████████████████████ |
+| **castellano** (control externo) | **44.7 %** | █████████████ |
+
+> **Bloquea el 55 % del castellano y solo el 14 % del wayunaiki.**
+
+El wayunaiki es la fuente de contaminación que preocupaba —769 de las 1413
+entradas del lexicón, y una lengua viva bien representada en los datos de
+entrenamiento del modelo— y el filtro apenas lo toca.
+
+**La razón es estructural, no un fallo de implementación**: caquetío y
+wayunaiki son las dos abrumadoramente CV (86.8 % y 81.4 % de formas
+estrictamente CV) y, tras normalizar la ortografía, sus inventarios difieren en
+dos letras. No hay nada que discriminar.
+
+## 2. Qué sí sirve, entonces
+
+**El filtro se queda, con su función rebajada y dicha**: es un detector de
+castellano. El castellano ES una vía de contaminación real —los agentes piensan
+en castellano— y detectarlo cuesta nada.
+
+**El control de validez de la fase 2 tiene que ser otro.** Las dos vías que
+quedan, y ambas son más prometedoras que ésta:
+
+| Vía | Por qué puede funcionar |
+|---|---|
+| **Morfología cerrada** | el inventario de afijos caquetíos es específico (`-ka`/`-ni`/`-da`, `ta-`/`pi-`/`nü-`, los seis de `REGLAS_ZAVALA`). El wayunaiki NO comparte ese paradigma, así que aquí sí hay contraste |
+| **Léxico cerrado con hueco declarado** | si falta la palabra, el agente tiene que **acuñar** en vez de importar. Es la prueba directa de productividad |
+
+## 3. 🔴 Dos problemas del dato que salieron al medir
+
+### 3.1 La ortografía estaba midiendo al transcriptor
+
+En la primera pasada, sin normalizar, el inventario "atestiguado" tenía **29
+letras** —incluidas `c`, `q`, `z`, `f`, `v`, `á`, `é`, `í`— y el del wayunaiki
+21, ninguna de ésas. Las iniciales más frecuentes eran `c:48, q:11` en el
+atestiguado y `k:11` en el reconstruido.
+
+Eso no es fonología: **el caquetío atestiguado está transcrito en ortografía
+castellana colonial y el reconstruido en ortografía lingüística moderna.** Sin
+normalizar, lo que se mide es quién escribió, no qué lengua es.
+
+`fonemizar()` lo normaliza con diez reglas, cada una con su porqué en el código.
+
+### 3.2 El conjunto atestiguado tiene residuo castellano
+
+Al inspeccionar qué formas aportan los clusters raros al inventario:
+
+| Forma | Glosa | Problema |
+|---|---|---|
+| `caquetillo` | 'árbol, madera de construcción' | **diminutivo castellano `-illo`** |
+| `casquito` | 'agrio, fermentado' | **diminutivo castellano `-ito`** |
+| `bagre` | 'pez' | palabra castellana |
+| `barbasco` | 'hierba de borrachera' | palabra castellana |
+| `despopo` | 'fuerza' | prefijo `des-` castellano |
+
+Cada una mete su cluster (`ll`, `sk`, `gr`, `sp`) en el inventario
+"atestiguado" y **hace el filtro más permisivo**. Es residuo que se hereda: una
+palabra con morfología castellana no puede ser caquetío atestiguado.
+
+## 4. 🔴 D5 no es cosmética: decide si el filtro discrimina
+
+El hallazgo con más consecuencias de toda la medición.
+
+`gua`/`güe` en transcripción colonial puede valer **/gwa/** o simplemente
+**/wa/**. `guaitiao` es el taíno *waitiao*, donde `<gu>` es claramente /w/. Y de
+las 50 formas atestiguadas con `<g>`, la mayoría son `gua-`/`güe-`.
+
+Aplicando la regla `<gu>` → /w/ y volviendo a medir:
+
+| | sin la regla | con la regla |
+|---|---|---|
+| wayunaiki pasa | 86.3 % | **65.4 %** |
+| castellano pasa | 44.7 % | 44.7 % |
+| caquetío reconstruido pasa | 98.5 % | 91.2 % ⚠️ |
+
+**Una sola decisión ortográfica multiplica por 2,5 el poder discriminante del
+filtro contra el wayunaiki.** Eso convierte
+[D5 (#36)](https://github.com/miguelgilurbina/curiana-radio/issues/36) —hoy
+catalogada como política ortográfica c/k y bloqueante del gate— en una decisión
+con consecuencias directas sobre el experimento.
+
+> ⚠️ Y con un aviso: la regla también hace caer el caquetío **reconstruido** de
+> 98.5 % a 91.2 %, porque al convertir `gü` en `w` desaparece la `ü` del
+> inventario atestiguado y las formas reconstruidas que la llevan empiezan a
+> fallar. No es gratis.
+
+**Deliberadamente no se aplica por defecto.** Activarla sería decidir D5 por la
+puerta de atrás. Queda medible con `--gu-es-w`.
+
+## 5. Reproducirlo
+
+```bash
+python curiana_sim/curiana_fonotactica.py            # el informe
+python curiana_sim/curiana_fonotactica.py --gu-es-w  # con la regla abierta
+python curiana_sim/curiana_fonotactica.py --json
+```
+
+12 tests en `tests/test_fonotactica.py`. Dos de ellos protegen el **resultado
+negativo**: si el wayunaiki empieza a no pasar, no es una mejora automática —
+hay que mirar si el filtro se volvió más estricto por buenas razones o si el
+lexicón cambió debajo.
+
+## Enlaces
+
+[[HALLAZGOS_FASE_1]] · [[morfologia]] · [[lexicon]] · [[metodo-comparativo]] · [[mapa-lengua]] · [[esfera-de-interaccion]]

--- a/proyecto-linguistico-caquetío/INDICE.md
+++ b/proyecto-linguistico-caquetío/INDICE.md
@@ -72,6 +72,8 @@ ensayo. Los ensayos —el argumento, con su evidencia— viven en
 - 🎬 [[DINAMICA_DE_RUNS]] — cómo se corre, se lee y se muestra un run.
 - 🔭 [[HALLAZGOS_FASE_1]] — **el cierre de la primera fase como experimento**:
   qué contestó, qué no puede contestar, y qué restricción abre la fase 2.
+- 🔤 [[fonotactica]] — **un resultado negativo**: cerrar la forma de la palabra
+  detecta castellano, no arahuaco genérico. Y por qué D5 no es cosmética.
 - 🔬 [[01_que_probaron_los_seis_runs]] — qué probaron los runs existentes, qué
   no, y por qué no son comparables.
 - 🧪 [[04_protocolo_run_1_era_auditada]] — cómo se corre y se mide la próxima

--- a/proyecto-linguistico-caquetío/curiana_sim/curiana_fonotactica.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/curiana_fonotactica.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CURIANA — fonotáctica del caquetío atestiguado
+==============================================
+
+Deriva un filtro de forma **solo** del subconjunto atestiguado del lexicón y
+mide cuánto deja pasar de cada otra fuente. Es la primera mitad del issue #91
+("cerrar el inventario"), y su resultado principal es **negativo**.
+
+EL RESULTADO, ANTES QUE NADA
+----------------------------
+#91 quería cerrar la fonotáctica para impedir que el modelo "rellenara" con
+arahuaco genérico. **No sirve para eso.** Medido:
+
+    CQ-ATT (control)   100.0 % pasa
+    caquetío-reconstr.  98.5 %
+    taíno               94.4 %
+    wayunaiki           86.3 %   <-- la fuente de contaminación principal
+    lokono              79.8 %
+    castellano          44.7 %
+
+El filtro bloquea **el 55 % del castellano y solo el 14 % del wayunaiki**. Es
+un **detector de castellano**, no de arahuaco genérico: el wayunaiki ya
+satisface la fonotáctica caquetía porque ambas lenguas son abrumadoramente CV.
+
+Sigue valiendo la pena tenerlo —el castellano ES una vía de contaminación
+real y barata de detectar— pero **el control de validez de la fase 2 tiene que
+ser morfológico y léxico**, no fonotáctico. Ver `2-lengua/fonotactica.md`.
+
+DOS ADVERTENCIAS SOBRE EL DATO
+------------------------------
+1. **La ortografía no es la fonología.** El caquetío atestiguado está
+   transcrito en ortografía castellana colonial (`c`, `qu`, `z`, `gua`) y el
+   reconstruido en ortografía lingüística (`k`, `w`, `ü`). Sin normalizar, lo
+   que se mide es el transcriptor. `fonemizar()` normaliza; sus reglas están
+   abajo, cada una con su porqué, y **no** pretenden resolver D5 (#36).
+
+2. **El conjunto atestiguado tiene residuo castellano**, y ensancha el filtro:
+   `caquetillo` y `casquito` llevan diminutivo castellano (`-illo`, `-ito`);
+   `bagre` y `barbasco` son palabras castellanas. Cada una mete su cluster
+   (`sk`, `gr`, `ll`) en el inventario "atestiguado" y hace el filtro más
+   permisivo. Limpiarlas lo haría más estricto — ver el issue de fidelidad.
+
+Uso:
+    python curiana_fonotactica.py            # el informe medido
+    python curiana_fonotactica.py --json
+"""
+
+import argparse
+import io
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter
+
+VOCALES = frozenset("aeiouü")
+
+# ── Normalización ortográfica ────────────────────────────────────────────
+# El mínimo para poder comparar dos corpus escritos con convenciones
+# distintas. NO es una decisión sobre la ortografía del proyecto (D5, #36):
+# es una capa de medición, y se aplica a todo por igual.
+REGLAS_ORTOGRAFICAS = [
+    (r"qu(?=[ei])", "k",  "castellano: <qu> ante e/i vale /k/"),
+    (r"gu(?=[ei])", "g",  "castellano: <gu> ante e/i vale /g/"),
+    (r"c(?=[ei])",  "s",  "castellano: <ce>/<ci> vale /s/ (seseo americano)"),
+    (r"c",          "k",  "el resto de <c> vale /k/"),
+    (r"q",          "k",  "<q> sin <u> también es /k/"),
+    (r"z",          "s",  "seseo: <z> no contrasta con <s> en América"),
+    (r"v",          "b",  "betacismo: <v> y <b> no contrastan"),
+    (r"h",          "",   "<h> castellana es muda"),
+    (r"y(?![aeiou])", "i", "<y> sin vocal detrás es vocálica"),
+    (r"x",          "sh", "<x> colonial suele valer /ʃ/"),
+]
+
+_TILDES = str.maketrans("áéíóú", "aeiou")
+
+# ⚠️ CUESTIÓN ABIERTA, deliberadamente NO resuelta aquí.
+# `gua`/`güe` en transcripción colonial puede valer /gwa/ o simplemente /wa/:
+# `guaitiao` es el taíno *waitiao*, y ahí <gu> es claramente /w/. De las 50
+# formas atestiguadas con <g>, la mayoría son `gua-`/`güe-`. Si la regla
+# fuera <gu> → /w/, el fonema /g/ casi desaparecería del inventario.
+# Se deja medible con `gu_es_w=True` en vez de decidirlo por la puerta de atrás.
+GU_ES_W = (r"g[uü](?=[aeio])", "w")
+
+
+def fonemizar(forma: str, gu_es_w: bool = False) -> str:
+    """Lleva una forma escrita a un esqueleto fonémico comparable.
+
+    `gu_es_w` activa la regla abierta de arriba. Por defecto **no** se aplica:
+    cambiar el inventario por una regla no decidida sería exactamente el tipo
+    de decisión silenciosa que el proyecto evita.
+    """
+    f = unicodedata.normalize("NFC", (forma or "").lower())
+    f = re.sub(r"[^a-záéíóúüïöñ]", "", f).translate(_TILDES)
+    f = f.replace("ï", "i").replace("ö", "o")
+    if gu_es_w:
+        f = re.sub(GU_ES_W[0], GU_ES_W[1], f)
+    for patron, reemplazo, _porque in REGLAS_ORTOGRAFICAS:
+        f = re.sub(patron, reemplazo, f)
+    return f
+
+
+def clusters(forma: str):
+    """Los grupos de dos o más consonantes seguidas."""
+    return [m.group() for m in re.finditer(r"[^aeiouü]{2,}", forma)]
+
+
+# ── El filtro ────────────────────────────────────────────────────────────
+
+class Fonotactica:
+    """Inventario, clusters y codas derivados de un conjunto de formas.
+
+    Se construye **solo** con el caquetío atestiguado: si se entrenara con
+    todo el lexicón, el 55 % sería wayunaiki y el filtro no diría nada sobre
+    el caquetío.
+    """
+
+    def __init__(self, formas, gu_es_w: bool = False):
+        self.gu_es_w = gu_es_w
+        self.base = [f for f in (fonemizar(x, gu_es_w) for x in formas) if f]
+        self.inventario = frozenset(c for f in self.base for c in f)
+        self.clusters = frozenset(c for f in self.base for c in clusters(f))
+        self.codas = frozenset(f[-1] for f in self.base if f[-1] not in VOCALES)
+
+    def valida(self, forma: str):
+        """Devuelve `(ok, motivos)`. `motivos` es una lista, no un bool."""
+        f = fonemizar(forma, self.gu_es_w)
+        motivos = []
+        if not f:
+            return False, ["vacía tras normalizar"]
+
+        fuera = sorted(set(f) - self.inventario)
+        if fuera:
+            motivos.append(f"letras fuera del inventario: {', '.join(fuera)}")
+
+        malos = sorted({c for c in clusters(f) if c not in self.clusters})
+        if malos:
+            motivos.append(f"clusters no atestiguados: {', '.join(malos)}")
+
+        if f[-1] not in VOCALES and f[-1] not in self.codas:
+            motivos.append(f"coda final no atestiguada: -{f[-1]}")
+
+        return not motivos, motivos
+
+    def tasa_de_violacion(self, formas):
+        """La métrica que la fase 2 quiere: qué fracción viola el inventario.
+
+        Aplicada a la salida de un agente, dice cuánto está inventando fuera
+        de la forma caquetía. Aplicada a otra lengua, dice cuánto discrimina
+        el filtro — que es como se midió el resultado negativo de arriba.
+        """
+        formas = [f for f in formas if f]
+        if not formas:
+            return 0.0
+        malas = sum(1 for f in formas if not self.valida(f)[0])
+        return malas / len(formas)
+
+
+# ── Medición contra el lexicón ───────────────────────────────────────────
+
+FAMILIAS = {
+    "caquetío-atestiguado": "caquetío atestiguado",
+    "caquetío": "caquetío atestiguado",
+    "caquetío-reconstruido": "caquetío reconstruido",
+    "wayunaiki": "wayunaiki",
+    "lokono": "lokono",
+    "taíno": "taíno",
+    "taino": "taíno",
+}
+
+# Control externo: castellano corriente. No es una muestra representativa del
+# idioma, es un termómetro — si el filtro no distingue esto, no distingue nada.
+CASTELLANO = (
+    "casa perro tierra hombre mujer agua fuego viento noche dia sol luna mar "
+    "rio monte piedra arbol flor pescado carne sangre corazon cabeza mano pie "
+    "padre madre hijo hermano pueblo camino trabajo palabra verdad muerte vida "
+    "grande pequeno blanco negro rojo verde comer beber dormir andar hablar"
+).split()
+
+
+def _grupos_del_lexicon():
+    from curiana_lexicon import VOCABULARIO_BASE
+    grupos = {}
+    for forma, entrada in VOCABULARIO_BASE.items():
+        familia = FAMILIAS.get(entrada.get("fuente"))
+        if familia:
+            grupos.setdefault(familia, []).append(forma)
+    return grupos
+
+
+def medir(gu_es_w: bool = False):
+    """Construye el filtro con lo atestiguado y mide qué deja pasar."""
+    grupos = _grupos_del_lexicon()
+    atestiguado = grupos.get("caquetío atestiguado", [])
+    fono = Fonotactica(atestiguado, gu_es_w=gu_es_w)
+
+    paso = {}
+    for familia, formas in grupos.items():
+        paso[familia] = 1.0 - fono.tasa_de_violacion(formas)
+    paso["castellano (control)"] = 1.0 - fono.tasa_de_violacion(CASTELLANO)
+    return fono, paso
+
+
+def _forzar_utf8() -> None:
+    for nombre in ("stdout", "stderr"):
+        flujo = getattr(sys, nombre)
+        if hasattr(flujo, "buffer") and (flujo.encoding or "").lower() != "utf-8":
+            setattr(sys, nombre, io.TextIOWrapper(
+                flujo.buffer, encoding="utf-8", errors="replace",
+                line_buffering=True))
+
+
+def informe(gu_es_w: bool = False) -> None:
+    fono, paso = medir(gu_es_w)
+    print(f"\n── fonotáctica del caquetío atestiguado ── "
+          f"{len(fono.base)} formas base"
+          f"{'  [gu→w activado]' if gu_es_w else ''}\n")
+    print(f"  inventario ({len(fono.inventario)}): "
+          f"{''.join(sorted(fono.inventario))}")
+    print(f"  clusters ({len(fono.clusters)}): {', '.join(sorted(fono.clusters))}")
+    print(f"  codas finales: {', '.join(sorted(fono.codas)) or '(ninguna)'}")
+
+    print("\n  cuánto deja pasar:\n")
+    for familia, pct in sorted(paso.items(), key=lambda kv: -kv[1]):
+        barra = "█" * int(pct * 30)
+        print(f"    {familia:24} {100*pct:5.1f}%  {barra}")
+
+    wy = paso.get("wayunaiki", 0)
+    es = paso.get("castellano (control)", 0)
+    print(f"\n  Bloquea el {100*(1-es):.0f}% del castellano y solo el "
+          f"{100*(1-wy):.0f}% del wayunaiki.")
+    print("  → es un detector de castellano, no de arahuaco genérico.")
+    print("  → el control de validez de la fase 2 tiene que ser "
+          "morfológico y léxico.\n")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="el informe en JSON")
+    ap.add_argument("--gu-es-w", action="store_true",
+                    help="aplica la regla abierta <gu> → /w/ y remide")
+    args = ap.parse_args(argv)
+
+    if args.json:
+        fono, paso = medir(args.gu_es_w)
+        print(json.dumps({
+            "formas_base": len(fono.base),
+            "inventario": sorted(fono.inventario),
+            "clusters": sorted(fono.clusters),
+            "codas": sorted(fono.codas),
+            "pasa": {k: round(v, 4) for k, v in paso.items()},
+        }, ensure_ascii=False, indent=2))
+    else:
+        informe(args.gu_es_w)
+    return 0
+
+
+if __name__ == "__main__":
+    _forzar_utf8()
+    sys.path.insert(0, __file__.rsplit("curiana_fonotactica.py", 1)[0] or ".")
+    sys.exit(main())

--- a/proyecto-linguistico-caquetío/curiana_sim/tests/test_fonotactica.py
+++ b/proyecto-linguistico-caquetío/curiana_sim/tests/test_fonotactica.py
@@ -1,0 +1,98 @@
+"""Tests de la fonotáctica.
+
+Lo que protegen: que el filtro se entrene solo con lo atestiguado, que la
+normalización ortográfica no dependa de cómo escribió el transcriptor, y —
+sobre todo— **que el resultado negativo siga a la vista**. Si alguien mejora
+el filtro y el wayunaiki empieza a pasar al 99%, el filtro dejó de medir algo.
+"""
+
+import curiana_fonotactica as F
+
+
+# ── normalización ─────────────────────────────────────────────────────
+
+def test_dos_grafias_de_la_misma_palabra_convergen():
+    """El caquetío atestiguado se escribió a la castellana y el reconstruido
+    a la moderna. Si no convergen, se mide al transcriptor."""
+    assert F.fonemizar("caquetio") == F.fonemizar("kaketio")
+    assert F.fonemizar("quiba") == F.fonemizar("kiba")
+
+
+def test_el_seseo_y_el_betacismo_no_contrastan():
+    assert F.fonemizar("zazarida") == F.fonemizar("sasarida")
+    assert F.fonemizar("vaca") == F.fonemizar("baka")
+
+
+def test_la_h_castellana_es_muda():
+    assert F.fonemizar("harifuche") == F.fonemizar("arifuche")
+
+
+def test_las_tildes_no_crean_fonemas():
+    assert F.fonemizar("Zazárida") == F.fonemizar("zazarida")
+
+
+def test_la_regla_gu_es_w_no_se_aplica_sola():
+    """Es una cuestión abierta: activarla por defecto sería decidir D5 por la
+    puerta de atrás."""
+    assert F.fonemizar("gua") != F.fonemizar("wa")
+    assert F.fonemizar("gua", gu_es_w=True) == F.fonemizar("wa")
+
+
+# ── el filtro ─────────────────────────────────────────────────────────
+
+def test_el_filtro_acepta_todo_lo_que_lo_entrena():
+    """Trivial pero necesario: si el propio conjunto base fallara, el filtro
+    estaría mal construido."""
+    fono, paso = F.medir()
+    assert paso["caquetío atestiguado"] == 1.0
+
+
+def test_valida_devuelve_motivos_no_un_bool():
+    fono, _ = F.medir()
+    ok, motivos = fono.valida("transporte")
+    assert not ok
+    assert motivos and all(isinstance(m, str) for m in motivos)
+
+
+def test_una_forma_caquetia_pasa():
+    fono, _ = F.medir()
+    assert fono.valida("barsure")[0]
+
+
+def test_la_tasa_de_violacion_es_una_fraccion():
+    fono, _ = F.medir()
+    t = fono.tasa_de_violacion(["barsure", "transporte", "kashi"])
+    assert 0.0 <= t <= 1.0
+    assert F.Fonotactica(["kasa"]).tasa_de_violacion([]) == 0.0
+
+
+# ── el resultado negativo, protegido ──────────────────────────────────
+
+def test_el_filtro_discrimina_el_castellano():
+    """Lo único que el filtro sí hace: el castellano tiene que caer bastante
+    por debajo de las lenguas arahuacas."""
+    _, paso = F.medir()
+    assert paso["castellano (control)"] < 0.60
+    assert paso["castellano (control)"] < paso["wayunaiki"] - 0.20
+
+
+def test_el_filtro_NO_discrimina_el_wayunaiki():
+    """**El resultado negativo de #91.** El wayunaiki pasa casi entero porque
+    ya satisface la fonotáctica caquetía: ambas son abrumadoramente CV.
+
+    Si este test empieza a fallar porque el wayunaiki bajó, no es una mejora
+    automática — hay que mirar si el filtro se volvió más estricto por buenas
+    razones o si el lexicón cambió debajo."""
+    _, paso = F.medir()
+    assert paso["wayunaiki"] > 0.80, (
+        "el wayunaiki dejó de pasar mayoritariamente: revisar si el filtro "
+        "cambió o si cambió el lexicón")
+
+
+def test_la_regla_gu_cambia_la_discriminacion_a_lo_grande():
+    """Una sola decisión ortográfica (D5, #36) mueve el poder discriminante
+    del filtro contra el wayunaiki por un factor grande. Es la razón de que
+    D5 no sea cosmética."""
+    _, sin_regla = F.medir(gu_es_w=False)
+    _, con_regla = F.medir(gu_es_w=True)
+    assert sin_regla["wayunaiki"] - con_regla["wayunaiki"] > 0.15


### PR DESCRIPTION
feat(lengua): la fonotáctica del caquetío, y el resultado negativo de #91

#91 quería cerrar la fonotáctica para impedir que el modelo rellenara con
arahuaco genérico. Se construyó el filtro entrenándolo SOLO con las 234 formas
atestiguadas, y se midió qué deja pasar. **No sirve para eso.**

    caquetío atestiguado (control)  100.0 %
    caquetío reconstruido            98.5 %
    taíno                            94.4 %
    wayunaiki                        86.3 %   <- la contaminación que importa
    lokono                           79.8 %
    castellano (control externo)     44.7 %

Bloquea el 55 % del castellano y solo el 14 % del wayunaiki. Es un detector de
castellano, no de arahuaco genérico, y la razón es estructural: caquetío y
wayunaiki son las dos abrumadoramente CV (86.8 % y 81.4 % de formas
estrictamente CV) y tras normalizar la ortografía sus inventarios difieren en
dos letras. No hay nada que discriminar.

El filtro se queda con su función rebajada y dicha —los agentes piensan en
castellano y detectarlo cuesta nada— pero el control de validez de la fase 2
tiene que ser MORFOLÓGICO y LÉXICO. Ahí sí hay contraste: el paradigma de
afijos caquetío no lo comparte el wayunaiki.

## Dos problemas del dato que salieron al medir

**La ortografía estaba midiendo al transcriptor.** Sin normalizar, el
inventario "atestiguado" tenía 29 letras (c, q, z, f, v, tildes) y el del
wayunaiki 21, ninguna de ésas. Las iniciales eran c:48/q:11 en lo atestiguado y
k:11 en lo reconstruido. Es que lo atestiguado está transcrito a la castellana
colonial y lo reconstruido a la lingüística moderna. `fonemizar()` lo normaliza
con diez reglas, cada una con su porqué en el código.

**El conjunto atestiguado tiene residuo castellano**, y ensancha el filtro:
`caquetillo` y `casquito` llevan diminutivo castellano (-illo, -ito), `bagre` y
`barbasco` son palabras castellanas, `despopo` lleva des-. Cada una mete su
cluster (ll, sk, gr, sp) en el inventario y hace el filtro más permisivo.

## D5 no es cosmética: decide si el filtro discrimina

`gua`/`güe` colonial puede valer /gwa/ o /wa/ — `guaitiao` es el taíno
*waitiao*, donde <gu> es claramente /w/, y de las 50 formas atestiguadas con
<g> la mayoría son gua-/güe-.

Aplicando <gu> → /w/ y remidiendo, el wayunaiki cae de 86.3 % a 65.4 %: **una
sola decisión ortográfica multiplica por 2.5 el poder discriminante del
filtro.** Eso convierte D5 (#36) —hoy catalogada como política ortográfica c/k—
en una decisión con consecuencias directas sobre el experimento.

No es gratis: la misma regla hace caer el caquetío reconstruido de 98.5 % a
91.2 %, porque al convertir `gü` en `w` desaparece la `ü` del inventario. Queda
medible con `--gu-es-w` y deliberadamente SIN aplicar por defecto: activarla
sería decidir D5 por la puerta de atrás.

12 tests, dos de ellos protegiendo el resultado negativo — si el wayunaiki
empieza a no pasar, no es una mejora automática y hay que mirar por qué.

197 tests en total, los 8 guardianes en verde.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
