### PR TITLE
feat(galeria): la galería visual, su motor de mosaico y la ingesta de 821 imágenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-error.log*
 next-env.d.ts
 
 .vercel
+
+# galería: derivados regenerables (escalera WebP antes de subir a Blob)
+.galeria-trabajo/

--- a/GALERIA.md
+++ b/GALERIA.md
@@ -1,0 +1,173 @@
+# Galería visual
+
+Sección de Curiana Radio junto a Archivo y Simulador. Publica los experimentos
+de imagen generados con IA con su prompt y su procedencia a la vista.
+
+- **Índice:** `/galeria` — mosaico justificado, orden aleatorio, lightbox.
+- **Ficha:** `/galeria/<slug>` — imagen grande, concepto, prompt, licencia.
+- **Fuente de verdad:** [`content/galeria/obras.json`](content/galeria/obras.json)
+- **Tipos:** [`types/galeria.ts`](types/galeria.ts) · **Lectura:** [`lib/galeria.ts`](lib/galeria.ts)
+
+## Infraestructura
+
+Cuatro capas, ninguna con coste fijo:
+
+| Capa | Qué | Dónde |
+|---|---|---|
+| Imágenes | Escalera WebP pre-generada (400/800/nativo) | Vercel Blob público |
+| Entrega | El navegador pide al CDN directamente | Edge de Vercel |
+| Metadatos | Manifest JSON versionado | git |
+| Render | HTML estático generado en el build | — |
+
+### Por qué NO usamos la optimización de imágenes de Vercel
+
+`next/image` con optimización factura una **transformación por cada fallo de
+caché**, más lecturas y escrituras de caché, y hace esperar al primer visitante
+de cada variante mientras se genera.
+
+Como las imágenes son estáticas y conocidas, la escalera se genera **una vez al
+ingerir** y se sirve como archivos planos. Resultado: cero transformaciones
+facturables y ninguna espera de generación. Por eso
+[`ImagenObra.tsx`](components/galeria/ImagenObra.tsx) es un `<img>` con `srcSet`
+y no un `<Image>`.
+
+Medido sobre el volcado real (821 imágenes de Midjourney, 1,72 GB de PNG):
+
+| | Por imagen | Total |
+|---|---|---|
+| PNG original | ~2.048 KB | 1,72 GB |
+| Escalera WebP servida | ~167 KB | ~0,14 GB |
+
+Con eso, el almacenamiento cabe de sobra en lo incluido en cualquier plan y la
+transferencia ronda los 750 KB por visita del mosaico.
+
+> **Ojo con el plan.** Hobby está restringido por política a uso personal no
+> comercial. En cuanto se vendan licencias o impresiones hace falta Pro. Es un
+> tema de contrato, no técnico.
+
+### Peso del payload
+
+Con ~800 obras, el manifest completo serializado al cliente pesaría más que las
+imágenes de la primera pantalla. Por eso:
+
+- `ObraGrid` (lo que cruza al cliente) es un tipo aparte del registro completo:
+  sin `concepto`, sin `procedencia`, sin `originalKey`.
+- El manifest guarda `blobBase` **una vez** y por obra solo los anchos
+  disponibles. La URL se compone en el cliente. Guardar URLs completas serían
+  ~200 KB de JSON repetido.
+- El hueco se reserva con el **color dominante** (7 bytes) en vez de una
+  miniatura borrosa en base64 (~400 bytes). A esta escala son 330 KB de
+  diferencia antes de ver la primera imagen.
+- El mosaico pinta una ventana de 60 piezas y crece al bajar
+  ([`Mosaico.tsx`](components/galeria/Mosaico.tsx)).
+
+## Publicar imágenes
+
+### 1. Extraer
+
+Deja los archivos **fuera del repo**:
+
+```bash
+Expand-Archive "$env:USERPROFILE\Downloads\midjourney_session_1.zip" -DestinationPath "$env:TEMP\galeria-fuente"
+```
+
+### 2. Preparar (local, sin credenciales)
+
+```bash
+npm run galeria:preparar -- "$env:TEMP\galeria-fuente" --serie archivo
+```
+
+Por cada imagen: extrae el prompt del nombre del archivo, genera la escalera
+WebP en `.galeria-trabajo/` (ignorada por git), calcula el color dominante y
+añade la obra al manifest. Es reanudable: salta lo que ya generó.
+
+`--limite N` procesa solo las primeras N, para probar.
+
+### 3. Subir
+
+Vercel conecta los stores de Blob con **OIDC** por defecto: el proyecto recibe
+`BLOB_STORE_ID` y un `VERCEL_OIDC_TOKEN` corto que rota solo, en vez de un
+`BLOB_READ_WRITE_TOKEN` estático. El script acepta las dos vías.
+
+**Con OIDC** (lo normal). En el store → pestaña **Projects** → ⋯ → *Update
+Project Connection*, incluye el entorno **Development**. Después:
+
+```bash
+vercel env pull "$env:TEMP\curiana-blob.env"
+```
+
+```bash
+npm run galeria:subir -- --env "$env:TEMP\curiana-blob.env"
+```
+
+**Con token estático**, si tu store sí creó `BLOB_READ_WRITE_TOKEN`:
+
+```bash
+$env:BLOB_READ_WRITE_TOKEN = Read-Host "Token"; npm run galeria:subir
+```
+
+En ambos casos el archivo de credenciales va **fuera del repo**. No uses
+`vercel env pull` sin ruta: escribiría `.env.local` en la carpeta del proyecto,
+que OneDrive sincroniza aunque esté en `.gitignore`.
+
+La subida apunta `blobBase` al store y marca las obras como publicadas. Lleva
+registro en `.galeria-trabajo/subidas.json`, así que reintentar solo sube lo
+que faltaba.
+
+### 4. Curar
+
+Lo que el script no puede saber, y queda con valores conservadores:
+
+| Campo | Valor por defecto | Qué hacer |
+|---|---|---|
+| `licencia` | `reservado` | Decidir obra por obra o por lote |
+| `concepto` | vacío | Escribir statement en las que lo merezcan |
+| `tags` | `[]` | Sin tags, la faceta «Motivos» no aparece |
+| `titulo` | primeras 8 palabras del prompt | Reescribir las destacadas |
+| `alt` | el prompt sin parámetros | Suficiente y honesto; mejorable a mano |
+
+## El mosaico
+
+[`lib/mosaico.ts`](lib/mosaico.ts) reparte las obras en **filas justificadas**:
+cada fila ocupa el ancho exacto del contenedor y su altura la deciden las
+proporciones reales de las imágenes que le tocaron. Solo la última fila queda
+corta: no se estira, para no inflar dos imágenes sueltas hasta ocupar toda la
+pantalla. Es un módulo puro, sin DOM.
+
+Perillas:
+
+| Dónde | Qué |
+|---|---|
+| `GAP` en `Mosaico.tsx` | Separación entre piezas (4px: casi seamless) |
+| `TANDA` en `Mosaico.tsx` | Piezas por tanda de scroll |
+| `alturaObjetivoPara()` en `mosaico.ts` | Altura a la que tienden las filas |
+| `ESCALERA` / `CALIDAD` en el script de ingesta | Anchos y compresión |
+
+### Orden aleatorio
+
+La galería se baraja en cada visita, pero la página es **estática**. Barajar en
+servidor congelaría el orden en el build; barajar durante el render del cliente
+rompería la hidratación. La semilla se modela como dato externo a React
+([`lib/semilla-orden.ts`](lib/semilla-orden.ts)) leído con
+`useSyncExternalStore`: el HTML prerenderizado sale en orden curatorial
+—estable para los rastreadores— y el cliente conmuta al barajado al hidratar.
+
+Después del barajado, `separarHermanas()` aparta las variantes de una misma
+generación: Midjourney entrega cuatro imágenes casi idénticas por prompt
+(mismo `generacion`, distinto `variante`) y el azar las junta cada tanto.
+
+## Licencias
+
+Cada obra declara `licencia` y `licenciaDetalle.print`. Hoy es informativo: se
+muestra en la pieza, en el lightbox y en la ficha, y no hay checkout.
+
+El esquema existe desde ya porque el modelo de datos es lo caro de cambiar
+después. Piezas previstas para ese momento, deliberadamente sin implementar:
+
+- `Obra.originalKey` — ruta del máster en un **store privado** de Blob
+  (`vercel blob create-store <nombre> --access private`). Se guarda la ruta, no
+  una URL firmada, porque el manifest está versionado. Hoy los másteres se
+  quedan en disco local, fuera de la plataforma.
+- `lib/galeria.ts → getOriginalKey()` — único punto de acceso, solo servidor.
+  Que `ObraGrid` sea un tipo aparte hace que ese campo no cruce al cliente por
+  descuido.

--- a/app/galeria/[slug]/page.tsx
+++ b/app/galeria/[slug]/page.tsx
@@ -1,0 +1,224 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import ImagenObra from "@/components/galeria/ImagenObra";
+import LicenciaBadge from "@/components/galeria/LicenciaBadge";
+import {
+  getBlobBase,
+  getObra,
+  getSeries,
+  getSlugs,
+  getVecinas,
+} from "@/lib/galeria";
+import { DESCRIPCION_LICENCIA, urlVariante } from "@/types/galeria";
+
+interface ObraPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return getSlugs().map((slug) => ({ slug }));
+}
+
+export const dynamicParams = false;
+
+export async function generateMetadata({
+  params,
+}: ObraPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const obra = getObra(slug);
+  if (!obra) return { title: "Obra no encontrada | Curiana Radio" };
+  const blobBase = getBlobBase();
+  const mayor = obra.anchos[obra.anchos.length - 1];
+  const og = mayor ? urlVariante(blobBase, obra.slug, mayor) : null;
+  const descripcion = (obra.concepto || obra.alt).slice(0, 160);
+  return {
+    title: `${obra.titulo} — Galería | Curiana Radio`,
+    description: descripcion,
+    openGraph: {
+      title: `${obra.titulo} — Galería | Curiana Radio`,
+      description: descripcion,
+      images: og ? [{ url: og, alt: obra.alt }] : undefined,
+    },
+  };
+}
+
+export default async function ObraPage({ params }: ObraPageProps) {
+  const { slug } = await params;
+  const obra = getObra(slug);
+  if (!obra) notFound();
+
+  const blobBase = getBlobBase();
+  const serie = getSeries().find((s) => s.id === obra.serie);
+  const { anterior, siguiente } = getVecinas(slug);
+  const proporcion = obra.w && obra.h ? obra.w / obra.h : 4 / 5;
+
+  return (
+    <article className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+      <Link
+        href="/galeria"
+        className="font-sans text-sm text-earth-600 transition-colors hover:text-frequency"
+      >
+        ← Galería
+      </Link>
+
+      <div
+        className="relative mt-6 w-full overflow-hidden rounded-sm"
+        style={{ aspectRatio: `${proporcion}`, backgroundColor: obra.color }}
+      >
+        <ImagenObra
+          obra={obra}
+          blobBase={blobBase}
+          prioridad
+          sizes="(max-width: 1024px) 100vw, 1024px"
+          className="h-full w-full object-contain"
+        />
+      </div>
+
+      <div className="mt-10 grid gap-10 lg:grid-cols-[1fr_18rem]">
+        {/* Lectura principal */}
+        <div>
+          {serie && (
+            <div className="mb-3 font-sans text-xs tracking-[0.2em] uppercase text-earth-600">
+              {serie.titulo}
+            </div>
+          )}
+          <h1 className="mb-5 font-serif text-4xl leading-tight text-deep-900 md:text-5xl">
+            {obra.titulo}
+          </h1>
+          {obra.concepto && (
+            <p className="max-w-reading font-sans text-lg leading-relaxed text-earth-800">
+              {obra.concepto}
+            </p>
+          )}
+
+          {obra.procedencia.prompt && (
+            <section className="mt-8">
+              <h2 className="mb-3 font-sans text-xs tracking-[0.2em] uppercase text-earth-600">
+                El prompt
+              </h2>
+              <blockquote className="border-l-2 border-frequency bg-earth-50 py-4 pl-5 pr-4">
+                <p className="max-w-reading font-mono text-sm leading-relaxed text-deep-800">
+                  {obra.procedencia.prompt}
+                </p>
+              </blockquote>
+            </section>
+          )}
+
+          {obra.procedencia.posproceso && (
+            <section className="mt-8">
+              <h2 className="mb-2 font-sans text-xs tracking-[0.2em] uppercase text-earth-600">
+                Proceso
+              </h2>
+              <p className="max-w-reading font-sans text-sm leading-relaxed text-earth-700">
+                {obra.procedencia.posproceso}
+              </p>
+            </section>
+          )}
+        </div>
+
+        {/* Ficha técnica */}
+        <aside className="space-y-6 border-t border-earth-200 pt-6 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+          <Dato etiqueta="Herramienta">{obra.procedencia.herramienta}</Dato>
+          <Dato etiqueta="Año">{obra.anio}</Dato>
+          {obra.w && obra.h && (
+            <Dato etiqueta="Dimensiones">
+              {obra.w} × {obra.h}
+            </Dato>
+          )}
+          {obra.estado === "pendiente" && (
+            <Dato etiqueta="Estado">Concepto sin render</Dato>
+          )}
+          {obra.edicion && (
+            <Dato etiqueta="Edición">
+              <Link
+                href={`/${obra.edicion}`}
+                className="border-b border-earth-300 transition-colors hover:border-frequency hover:text-frequency"
+              >
+                #{obra.edicion}
+              </Link>
+            </Dato>
+          )}
+
+          <div>
+            <div className="mb-2 font-sans text-xs tracking-[0.2em] uppercase text-earth-500">
+              Licencia
+            </div>
+            <LicenciaBadge tipo={obra.licencia} />
+            <p className="mt-2 font-sans text-sm leading-relaxed text-earth-700">
+              {DESCRIPCION_LICENCIA[obra.licencia]}
+            </p>
+            {obra.licenciaDetalle.notas && (
+              <p className="mt-2 font-sans text-xs italic leading-relaxed text-earth-600">
+                {obra.licenciaDetalle.notas}
+              </p>
+            )}
+            <p className="mt-2 font-sans text-xs text-earth-600">
+              {obra.licenciaDetalle.print
+                ? "Apta para impresión."
+                : "No disponible para impresión."}
+            </p>
+          </div>
+
+          {obra.tags.length > 0 && (
+            <div>
+              <div className="mb-2 font-sans text-xs tracking-[0.2em] uppercase text-earth-500">
+                Motivos
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {obra.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="border border-earth-200 px-2 py-0.5 font-sans text-xs text-earth-700"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </aside>
+      </div>
+
+      <nav className="mt-14 flex items-center justify-between gap-4 border-t border-earth-200 pt-6 font-sans text-sm">
+        {anterior ? (
+          <Link
+            href={`/galeria/${anterior.slug}`}
+            className="text-earth-700 transition-colors hover:text-frequency"
+          >
+            ← {anterior.titulo}
+          </Link>
+        ) : (
+          <span />
+        )}
+        {siguiente ? (
+          <Link
+            href={`/galeria/${siguiente.slug}`}
+            className="text-right text-earth-700 transition-colors hover:text-frequency"
+          >
+            {siguiente.titulo} →
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </article>
+  );
+}
+
+function Dato({
+  etiqueta,
+  children,
+}: {
+  etiqueta: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 font-sans text-xs tracking-[0.2em] uppercase text-earth-500">
+        {etiqueta}
+      </div>
+      <div className="font-sans text-sm text-earth-800">{children}</div>
+    </div>
+  );
+}

--- a/app/galeria/page.tsx
+++ b/app/galeria/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import GaleriaGrid from "@/components/galeria/GaleriaGrid";
+import { Heading, BodyText } from "@/components/ui/Typography";
+import { getBlobBase, getObrasGrid, getSeries, getTags } from "@/lib/galeria";
+
+export const metadata: Metadata = {
+  title: "Galería - Curiana Radio",
+  description:
+    "Experimentos visuales de Curiana Radio: imágenes generadas con IA sobre el desierto de Coro, la señal y la memoria caquetía.",
+  openGraph: {
+    title: "Galería - Curiana Radio",
+    description:
+      "Experimentos visuales de Curiana Radio: imágenes generadas con IA sobre el desierto de Coro, la señal y la memoria caquetía.",
+  },
+};
+
+export default function GaleriaPage() {
+  const obras = getObrasGrid();
+  const series = getSeries();
+  const tags = getTags();
+  const blobBase = getBlobBase();
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <header className="mb-14 text-center">
+          <div className="mb-4 font-sans text-sm tracking-[0.2em] uppercase text-earth-600">
+            Curiana Radio — 88.8 FM
+          </div>
+          <Heading level={1} className="mb-6">
+            Galería
+          </Heading>
+          <BodyText className="mx-auto max-w-2xl text-deep-600">
+            Experimentos visuales generados con IA. Cada imagen se publica con
+            su prompt y su procedencia a la vista: la máquina es parte del
+            material, no un truco que esconder.
+          </BodyText>
+        </header>
+
+        {obras.length > 0 ? (
+          <GaleriaGrid
+            obras={obras}
+            blobBase={blobBase}
+            series={series}
+            tags={tags}
+          />
+        ) : (
+          <p className="py-16 text-center font-sans text-earth-600">
+            Todavía no hay obras publicadas.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getAllEditions } from '@/lib/content';
 import { getAllPersonajes } from '@/lib/personajes';
+import { getSlugs } from '@/lib/galeria';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const editions = await getAllEditions();
@@ -16,6 +17,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${baseUrl}/archivo`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/galeria`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
@@ -63,11 +70,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
+  // Fichas de obra de la galería.
+  const galeriaPages: MetadataRoute.Sitemap = getSlugs().map((slug) => ({
+    url: `${baseUrl}/galeria/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.5,
+  }));
+
   return [
     ...staticPages,
     ...editionPages,
     ...simuladorPages,
     ...personajePages,
     ...jaiSoundsPages,
+    ...galeriaPages,
   ];
 }

--- a/components/galeria/GaleriaGrid.tsx
+++ b/components/galeria/GaleriaGrid.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useMemo, useState, useSyncExternalStore } from "react";
+import Mosaico from "./Mosaico";
+import Lightbox from "./Lightbox";
+import { mezclar, separarHermanas } from "@/lib/mosaico";
+import {
+  leerSemilla,
+  leerSemillaServidor,
+  rebarajar,
+  suscribirse,
+} from "@/lib/semilla-orden";
+import type { ObraGrid, Serie } from "@/types/galeria";
+
+interface GaleriaGridProps {
+  obras: ObraGrid[];
+  blobBase: string | null;
+  series: Serie[];
+  tags: { tag: string; total: number }[];
+}
+
+export default function GaleriaGrid({
+  obras,
+  blobBase,
+  series,
+  tags,
+}: GaleriaGridProps) {
+  const [serieActiva, setSerieActiva] = useState<string | null>(null);
+  const [tagsActivos, setTagsActivos] = useState<string[]>([]);
+  const [abierta, setAbierta] = useState<number | null>(null);
+
+  // `null` en servidor (orden curatorial, el que se prerenderiza) y un número
+  // en el navegador. Ver lib/semilla-orden.ts.
+  const semilla = useSyncExternalStore(
+    suscribirse,
+    leerSemilla,
+    leerSemillaServidor
+  );
+
+  const barajadas = useMemo(() => {
+    if (semilla === null) return obras;
+    // Barajar y luego apartar las variantes hermanas: Midjourney entrega
+    // cuatro imágenes casi iguales por prompt y el azar las junta cada tanto.
+    return separarHermanas(mezclar(obras, semilla), (o) => o.generacion);
+  }, [obras, semilla]);
+
+  const visibles = useMemo(
+    () =>
+      barajadas.filter((obra) => {
+        if (serieActiva && obra.serie !== serieActiva) return false;
+        // Dentro de la faceta de tags la lógica es OR: sumar un tag amplía la
+        // selección en vez de estrangularla hasta el estado vacío.
+        if (tagsActivos.length > 0) {
+          return tagsActivos.some((t) => obra.tags.includes(t));
+        }
+        return true;
+      }),
+    [barajadas, serieActiva, tagsActivos]
+  );
+
+  const hayFiltros = serieActiva !== null || tagsActivos.length > 0;
+
+  // Cambiar el filtro reordena `visibles`, y el índice del lightbox apunta a
+  // esa lista: cerrarlo evita quedar mirando otra obra de la que se abrió.
+  const alternarTag = (tag: string) => {
+    setAbierta(null);
+    setTagsActivos((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const elegirSerie = (id: string | null) => {
+    setAbierta(null);
+    setSerieActiva(id);
+  };
+
+  const limpiar = () => {
+    setAbierta(null);
+    setSerieActiva(null);
+    setTagsActivos([]);
+  };
+
+  const barajar = () => {
+    setAbierta(null);
+    rebarajar();
+  };
+
+  // Remonta el mosaico cuando cambia lo que muestra, para que la ventana de
+  // piezas pintadas vuelva a empezar por la primera tanda.
+  const firma = `${serieActiva ?? ""}|${tagsActivos.join(",")}|${semilla ?? ""}`;
+
+  return (
+    <div>
+      {/* ── Filtros ─────────────────────────────────────────────── */}
+      <div className="mb-8 space-y-4 border-y border-earth-200 py-6">
+        {series.length > 1 && (
+          <Faceta etiqueta="Serie">
+            <Pill activo={serieActiva === null} onClick={() => elegirSerie(null)}>
+              Todas
+            </Pill>
+            {series.map((serie) => (
+              <Pill
+                key={serie.id}
+                activo={serieActiva === serie.id}
+                onClick={() => elegirSerie(serie.id)}
+              >
+                {serie.titulo}
+              </Pill>
+            ))}
+          </Faceta>
+        )}
+
+        {tags.length > 0 && (
+          <Faceta etiqueta="Motivos">
+            {tags.map(({ tag, total }) => (
+              <Pill
+                key={tag}
+                activo={tagsActivos.includes(tag)}
+                onClick={() => alternarTag(tag)}
+              >
+                {tag}
+                <span className="ml-1.5 opacity-50">{total}</span>
+              </Pill>
+            ))}
+          </Faceta>
+        )}
+
+        <div
+          className="flex flex-wrap items-center gap-4 font-sans text-sm text-earth-600"
+          aria-live="polite"
+        >
+          <span>
+            {visibles.length} {visibles.length === 1 ? "obra" : "obras"}
+          </span>
+          <button
+            type="button"
+            onClick={barajar}
+            className="border-b border-earth-400 transition-colors hover:border-frequency hover:text-frequency"
+          >
+            Barajar
+          </button>
+          {hayFiltros && (
+            <button
+              type="button"
+              onClick={limpiar}
+              className="border-b border-earth-400 transition-colors hover:border-frequency hover:text-frequency"
+            >
+              Limpiar filtros
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Mosaico ─────────────────────────────────────────────── */}
+      {visibles.length > 0 ? (
+        <Mosaico
+          key={firma}
+          obras={visibles}
+          blobBase={blobBase}
+          onAmpliar={setAbierta}
+        />
+      ) : (
+        <p className="py-16 text-center font-sans text-earth-600">
+          Ninguna obra coincide con esos filtros.
+        </p>
+      )}
+
+      {abierta !== null && (
+        <Lightbox
+          obras={visibles}
+          blobBase={blobBase}
+          indice={abierta}
+          onCerrar={() => setAbierta(null)}
+          onIr={setAbierta}
+        />
+      )}
+    </div>
+  );
+}
+
+function Faceta({
+  etiqueta,
+  children,
+}: {
+  etiqueta: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="mr-1 font-sans text-xs tracking-[0.2em] uppercase text-earth-500">
+        {etiqueta}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function Pill({
+  activo,
+  onClick,
+  children,
+}: {
+  activo: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={activo}
+      className={`border px-3 py-1 font-sans text-sm transition-colors ${
+        activo
+          ? "border-frequency bg-frequency text-white"
+          : "border-earth-300 text-earth-700 hover:border-frequency hover:text-frequency"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/galeria/ImagenObra.tsx
+++ b/components/galeria/ImagenObra.tsx
@@ -1,0 +1,64 @@
+import { srcSetDe, urlVariante, type ObraGrid } from "@/types/galeria";
+import PlaceholderTile from "./PlaceholderTile";
+
+/**
+ * La imagen de una obra, servida como archivo plano desde Vercel Blob.
+ *
+ * Es un `<img>` a pelo y no `next/image` a propósito. La escalera de anchos ya
+ * está generada en la ingesta, así que no hace falta que nada la produzca al
+ * vuelo: `/_next/image` factura una transformación por cada fallo de caché y
+ * hace esperar al primer visitante de cada variante. Aquí el navegador elige
+ * del `srcset` y el archivo sale del CDN tal cual.
+ *
+ * El hueco se reserva con `aspect-ratio` y se pinta del color dominante, así
+ * que el mosaico no se mueve mientras cargan las piezas.
+ */
+
+interface ImagenObraProps {
+  obra: ObraGrid;
+  blobBase: string | null;
+  /** Qué ancho ocupará la pieza. Sin esto el navegador asume 100vw. */
+  sizes: string;
+  /** La primera pantalla carga con prisa; el resto, en diferido. */
+  prioridad?: boolean;
+  className?: string;
+}
+
+export default function ImagenObra({
+  obra,
+  blobBase,
+  sizes,
+  prioridad = false,
+  className = "",
+}: ImagenObraProps) {
+  const mayor = obra.anchos[obra.anchos.length - 1];
+  const src = mayor ? urlVariante(blobBase, obra.slug, mayor) : null;
+
+  if (!src) {
+    return <PlaceholderTile slug={obra.slug} conRotulo={false} className={className} />;
+  }
+
+  return (
+    /* El <img> es deliberado, no un descuido. La regla de Next asume que hay
+       que optimizar al vuelo, pero la escalera ya está generada en la ingesta
+       y se sirve desde el CDN. Cambiarlo por <Image /> reintroduciría justo el
+       coste por transformación y la espera del primer visitante que evitamos.
+       Ver GALERIA.md → «Por qué NO usamos la optimización de imágenes». */
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      srcSet={srcSetDe(blobBase, obra)}
+      sizes={sizes}
+      alt={obra.alt}
+      width={obra.w ?? undefined}
+      height={obra.h ?? undefined}
+      loading={prioridad ? "eager" : "lazy"}
+      // `high` en la primera pantalla adelanta estas peticiones a las de la
+      // cola normal; `auto` deja que el navegador decida en el resto.
+      fetchPriority={prioridad ? "high" : "auto"}
+      decoding="async"
+      style={{ backgroundColor: obra.color }}
+      className={className}
+    />
+  );
+}

--- a/components/galeria/LicenciaBadge.tsx
+++ b/components/galeria/LicenciaBadge.tsx
@@ -1,0 +1,26 @@
+import { ETIQUETA_LICENCIA, type TipoLicencia } from "@/types/galeria";
+
+const ESTILO: Record<TipoLicencia, string> = {
+  "cc-by-nc": "bg-earth-100 text-earth-800 border-earth-300",
+  editorial: "bg-deep-100 text-deep-800 border-deep-300",
+  comercial: "bg-frequency/10 text-frequency border-frequency/40",
+  reservado: "bg-deep-900 text-earth-100 border-deep-900",
+};
+
+interface LicenciaBadgeProps {
+  tipo: TipoLicencia;
+  className?: string;
+}
+
+export default function LicenciaBadge({
+  tipo,
+  className = "",
+}: LicenciaBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center border px-2 py-0.5 font-sans text-[0.65rem] tracking-[0.15em] uppercase ${ESTILO[tipo]} ${className}`}
+    >
+      {ETIQUETA_LICENCIA[tipo]}
+    </span>
+  );
+}

--- a/components/galeria/Lightbox.tsx
+++ b/components/galeria/Lightbox.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import Link from "next/link";
+import ImagenObra from "./ImagenObra";
+import LicenciaBadge from "./LicenciaBadge";
+import { DESCRIPCION_LICENCIA, type ObraGrid } from "@/types/galeria";
+
+const FOCUSABLES =
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface LightboxProps {
+  obras: ObraGrid[];
+  blobBase: string | null;
+  indice: number;
+  onCerrar: () => void;
+  onIr: (indice: number) => void;
+}
+
+export default function Lightbox({
+  obras,
+  blobBase,
+  indice,
+  onCerrar,
+  onIr,
+}: LightboxProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const obra = obras[indice];
+
+  const hayAnterior = indice > 0;
+  const haySiguiente = indice < obras.length - 1;
+
+  const anterior = useCallback(() => {
+    if (hayAnterior) onIr(indice - 1);
+  }, [hayAnterior, indice, onIr]);
+
+  const siguiente = useCallback(() => {
+    if (haySiguiente) onIr(indice + 1);
+  }, [haySiguiente, indice, onIr]);
+
+  // Al abrir: recordar quién tenía el foco para devolvérselo al cerrar. Sin
+  // esto, cerrar el lightbox tira el foco al <body> y quien navega por teclado
+  // pierde el sitio en la grilla.
+  useEffect(() => {
+    const previo = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => previo?.focus?.();
+  }, []);
+
+  // Bloquear el scroll del fondo mientras el diálogo está abierto.
+  useEffect(() => {
+    const previo = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previo;
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCerrar();
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        anterior();
+        return;
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        siguiente();
+        return;
+      }
+      // Trampa de foco: el Tab no debe escaparse a la página de atrás.
+      if (e.key === "Tab") {
+        const nodos =
+          dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLES);
+        if (!nodos || nodos.length === 0) return;
+        const primero = nodos[0];
+        const ultimo = nodos[nodos.length - 1];
+        const activo = document.activeElement;
+        if (e.shiftKey && (activo === primero || activo === dialogRef.current)) {
+          e.preventDefault();
+          ultimo.focus();
+        } else if (!e.shiftKey && activo === ultimo) {
+          e.preventDefault();
+          primero.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [anterior, siguiente, onCerrar]);
+
+  if (!obra) return null;
+
+  const proporcion = obra.w && obra.h ? obra.w / obra.h : 4 / 5;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-deep-900/95 p-4 backdrop-blur-sm sm:p-8"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCerrar();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="lightbox-titulo"
+        tabIndex={-1}
+        className="relative flex max-h-full w-full max-w-6xl flex-col gap-6 overflow-y-auto outline-none lg:flex-row lg:items-center"
+      >
+        {/* Imagen */}
+        <div className="flex min-w-0 flex-1 items-center justify-center">
+          <div
+            className="relative max-h-[70vh] w-full overflow-hidden"
+            style={{ aspectRatio: `${proporcion}` }}
+          >
+            <ImagenObra
+              obra={obra}
+              blobBase={blobBase}
+              prioridad
+              sizes="(max-width: 1024px) 100vw, 66vw"
+              className="h-full w-full object-contain"
+            />
+          </div>
+        </div>
+
+        {/* Ficha lateral */}
+        <div className="w-full shrink-0 text-earth-100 lg:w-80">
+          <div className="mb-3 font-sans text-xs tracking-[0.2em] uppercase text-earth-400">
+            {indice + 1} / {obras.length}
+          </div>
+          <h2
+            id="lightbox-titulo"
+            className="mb-4 font-serif text-2xl leading-tight text-white"
+          >
+            {obra.titulo}
+          </h2>
+
+          <div className="mb-4">
+            <LicenciaBadge tipo={obra.licencia} />
+            <p className="mt-2 font-sans text-xs leading-relaxed text-earth-400">
+              {DESCRIPCION_LICENCIA[obra.licencia]}
+            </p>
+          </div>
+
+          <Link
+            href={`/galeria/${obra.slug}`}
+            className="inline-block border-b border-frequency font-sans text-sm text-frequency transition-colors hover:border-white hover:text-white"
+          >
+            Ver ficha completa
+          </Link>
+
+          {/* Navegación */}
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={anterior}
+              disabled={!hayAnterior}
+              className="border border-earth-600 px-4 py-2 font-sans text-sm text-earth-200 transition-colors hover:border-frequency hover:text-frequency disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:border-earth-600 disabled:hover:text-earth-200"
+            >
+              ← Anterior
+            </button>
+            <button
+              type="button"
+              onClick={siguiente}
+              disabled={!haySiguiente}
+              className="border border-earth-600 px-4 py-2 font-sans text-sm text-earth-200 transition-colors hover:border-frequency hover:text-frequency disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:border-earth-600 disabled:hover:text-earth-200"
+            >
+              Siguiente →
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onCerrar}
+          aria-label="Cerrar"
+          className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center border border-earth-600 text-xl leading-none text-earth-200 transition-colors hover:border-frequency hover:text-frequency"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/galeria/Mosaico.tsx
+++ b/components/galeria/Mosaico.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import ObraCard from "./ObraCard";
+import {
+  alturaObjetivoPara,
+  aspectoDeObra,
+  componerFilas,
+} from "@/lib/mosaico";
+import type { ObraGrid } from "@/types/galeria";
+
+/** Casi cero: las piezas se tocan y el conjunto se lee como un tejido. */
+const GAP = 4;
+
+/**
+ * Ancho asumido al renderizar en servidor, donde no hay contenedor que medir:
+ * max-w-7xl (1280) menos el padding lateral de la página. El HTML estático
+ * sale ya maquetado —importa para SEO y para que no haya un hueco en blanco—
+ * y al hidratar se remide contra el viewport real.
+ */
+const ANCHO_SSR = 1216;
+
+/** Piezas que cargan con priority: aproximadamente la primera fila. */
+const PIEZAS_PRIORITARIAS = 4;
+
+/**
+ * Cuántas piezas se pintan de entrada y cuántas se añaden por tanda.
+ *
+ * El catálogo entero viaja al cliente en el payload —son metadatos, unos
+ * pocos KB comprimidos— pero pintarlo de golpe metería ~800 nodos con imagen
+ * en el DOM y varios cientos de KB de HTML en la respuesta. Se pinta una
+ * ventana y crece al bajar.
+ */
+const TANDA = 60;
+
+interface MosaicoProps {
+  obras: ObraGrid[];
+  blobBase: string | null;
+  onAmpliar: (indice: number) => void;
+}
+
+export default function Mosaico({ obras, blobBase, onAmpliar }: MosaicoProps) {
+  const [ancho, setAncho] = useState(ANCHO_SSR);
+  const [limite, setLimite] = useState(TANDA);
+
+  /**
+   * Medición por callback de ref, no por efecto: React la ejecuta durante el
+   * commit, antes de pintar, así que la primera medida no depende de que el
+   * navegador llegue a componer un frame. Importa — los callbacks de
+   * ResizeObserver se entregan dentro del ciclo de render, y una pestaña que
+   * aún no se ha mostrado no lo ejecuta: sin la medida síncrona el mosaico se
+   * quedaría maquetado a ANCHO_SSR y desbordaría su contenedor.
+   *
+   * El observer sigue, pero solo para lo que viene después: cambios de ancho
+   * sin cambio de viewport (barra de scroll que aparece, zoom, panel lateral).
+   */
+  const medirContenedor = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return;
+    const medir = () => {
+      const medido = el.getBoundingClientRect().width;
+      if (medido > 0) setAncho(medido);
+    };
+    medir();
+    const observador = new ResizeObserver(medir);
+    observador.observe(el);
+    return () => observador.disconnect();
+  }, []);
+
+  /** Centinela al pie: al asomarse, pide la siguiente tanda. */
+  const observarPie = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return;
+    const observador = new IntersectionObserver(
+      (entradas) => {
+        if (entradas.some((e) => e.isIntersecting)) {
+          setLimite((l) => l + TANDA);
+        }
+      },
+      // Margen generoso: la tanda siguiente se prepara antes de que el borde
+      // llegue a la vista, así el scroll no se topa con un vacío.
+      { rootMargin: "1200px 0px" }
+    );
+    observador.observe(el);
+    return () => observador.disconnect();
+  }, []);
+
+  const pintadas = useMemo(() => obras.slice(0, limite), [obras, limite]);
+  const quedan = obras.length - pintadas.length;
+
+  const filas = useMemo(
+    () =>
+      componerFilas(pintadas, ancho, aspectoDeObra, {
+        alturaObjetivo: alturaObjetivoPara(ancho),
+        gap: GAP,
+      }),
+    [pintadas, ancho]
+  );
+
+  // El motor conserva el orden, así que un contador corrido basta para saber
+  // a qué posición de `obras` corresponde cada pieza (lo que espera el lightbox).
+  let indice = -1;
+
+  return (
+    <div>
+      {/* overflow-hidden como red: entre el HTML servido a ANCHO_SSR y la
+          primera medida, las filas pueden ser más anchas que el hueco real.
+          Que eso se recorte un instante es aceptable; que empuje la página de
+          lado, no. */}
+      <div ref={medirContenedor} className="overflow-hidden">
+        {filas.map((fila, i) => (
+          <div
+            key={i}
+            className="flex"
+            style={{
+              gap: GAP,
+              marginBottom: i === filas.length - 1 ? 0 : GAP,
+            }}
+          >
+            {fila.celdas.map((celda) => {
+              indice++;
+              const posicion = indice;
+              return (
+                <ObraCard
+                  key={celda.item.slug}
+                  obra={celda.item}
+                  blobBase={blobBase}
+                  ancho={celda.ancho}
+                  alto={celda.alto}
+                  prioridad={posicion < PIEZAS_PRIORITARIAS}
+                  onAmpliar={() => onAmpliar(posicion)}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      {quedan > 0 && (
+        <div ref={observarPie} className="mt-8 text-center">
+          {/* Botón además del centinela: el scroll infinito a secas deja sin
+              salida a quien navega con teclado, y funciona igual si el
+              IntersectionObserver no llega a dispararse. */}
+          <button
+            type="button"
+            onClick={() => setLimite((l) => l + TANDA)}
+            className="border border-earth-300 px-5 py-2 font-sans text-sm text-earth-700 transition-colors hover:border-frequency hover:text-frequency"
+          >
+            Ver más ({quedan} {quedan === 1 ? "obra" : "obras"})
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/galeria/ObraCard.tsx
+++ b/components/galeria/ObraCard.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import ImagenObra from "./ImagenObra";
+import { ETIQUETA_LICENCIA, type ObraGrid } from "@/types/galeria";
+
+interface ObraCardProps {
+  obra: ObraGrid;
+  blobBase: string | null;
+  /** Medidas calculadas por el motor del mosaico, en píxeles. */
+  ancho: number;
+  alto: number;
+  /** Abre el lightbox. La pieza sigue siendo un <a> real a la ficha: el
+   *  lightbox es mejora progresiva, no el único camino a la obra. */
+  onAmpliar: () => void;
+  /** Las primeras piezas cargan con prioridad; el resto, perezosas. */
+  prioridad?: boolean;
+}
+
+export default function ObraCard({
+  obra,
+  blobBase,
+  ancho,
+  alto,
+  onAmpliar,
+  prioridad = false,
+}: ObraCardProps) {
+  return (
+    <Link
+      href={`/galeria/${obra.slug}`}
+      onClick={(e) => {
+        // Respetar ctrl/cmd/click medio: eso es "ábrelo en otra pestaña",
+        // no "ampliá aquí".
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+        e.preventDefault();
+        onAmpliar();
+      }}
+      style={{ width: ancho, height: alto, backgroundColor: obra.color }}
+      className="group relative block shrink-0 overflow-hidden focus-visible:z-10"
+    >
+      <ImagenObra
+        obra={obra}
+        blobBase={blobBase}
+        prioridad={prioridad}
+        // El motor ya sabe cuántos píxeles ocupa la pieza: decírselo evita que
+        // el navegador baje una variante mayor de la necesaria.
+        sizes={`${Math.ceil(ancho)}px`}
+        className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"
+      />
+
+      {/* Rótulo. Aparece al pasar por encima o al enfocar con teclado; en
+          pantallas táctiles no hay hover, así que ahí vive siempre visible. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-deep-900/85 via-deep-900/45 to-transparent p-4 pt-10 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100 [@media(hover:none)]:opacity-100">
+        <h3 className="line-clamp-2 font-serif text-base leading-tight text-white drop-shadow-sm">
+          {obra.titulo}
+        </h3>
+        <p className="mt-1 font-sans text-[0.65rem] tracking-[0.15em] uppercase text-earth-200">
+          {obra.estado === "pendiente"
+            ? "Sin render"
+            : ETIQUETA_LICENCIA[obra.licencia]}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/components/galeria/PlaceholderTile.tsx
+++ b/components/galeria/PlaceholderTile.tsx
@@ -1,0 +1,61 @@
+import { hashTexto } from "@/lib/mosaico";
+
+/**
+ * Tile para obras en estado "pendiente": el concepto ya existe, el render no.
+ *
+ * No inventa una imagen ni finge una: dibuja un degradado determinista a
+ * partir del slug (misma obra = mismo degradado siempre, sin hydration
+ * mismatch) y se declara pendiente en texto. Es un hueco reservado, no un
+ * sustituto.
+ */
+
+const DEGRADADOS = [
+  ["#4f3e35", "#b09880"], // earth-900 → earth-400
+  ["#0f1621", "#4d6d94"], // deep-900 → deep-500
+  ["#5f4a3f", "#ff6b35"], // earth-800 → frequency
+  ["#1f2c3e", "#9d7f66"], // deep-800 → earth-500
+  ["#2f425b", "#c5b59f"], // deep-700 → earth-300
+] as const;
+
+interface PlaceholderTileProps {
+  slug: string;
+  className?: string;
+  /** En el mosaico el rótulo estorba; en la ficha grande, informa. */
+  conRotulo?: boolean;
+}
+
+export default function PlaceholderTile({
+  slug,
+  className = "",
+  conRotulo = true,
+}: PlaceholderTileProps) {
+  const h = hashTexto(slug);
+  const [desde, hasta] = DEGRADADOS[h % DEGRADADOS.length];
+  const angulo = 25 + (h % 7) * 20;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`relative overflow-hidden ${className}`}
+      style={{
+        background: `linear-gradient(${angulo}deg, ${desde}, ${hasta})`,
+      }}
+    >
+      {/* Grano sutil: evita que el degradado se lea como una banda plana. */}
+      <div
+        className="absolute inset-0 opacity-20 mix-blend-overlay"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(90deg, rgba(255,255,255,.35) 0 1px, transparent 1px 3px)",
+        }}
+      />
+      {conRotulo && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="font-sans text-[0.65rem] tracking-[0.25em] uppercase text-white/80">
+            Sin render
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -55,7 +55,9 @@ export default function Navigation({ editionNumber }: NavigationProps) {
             </Link>
 
             {/* Navigation Items */}
-            <div className="flex items-center space-x-6">
+            {/* Con Galería son tres enlaces visibles en móvil: a 375px el gap
+                de 24px desborda la barra. Se aprieta hasta sm. */}
+            <div className="flex items-center space-x-4 sm:space-x-6">
               {/* Edition Number (if on edition page) */}
               {editionNumber && (
                 <div className="font-serif text-lg text-deep-800">
@@ -77,6 +79,14 @@ export default function Navigation({ editionNumber }: NavigationProps) {
                 className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
               >
                 JAI Sounds
+              </Link>
+
+              {/* Galería Link */}
+              <Link
+                href="/galeria"
+                className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+              >
+                Galería
               </Link>
 
               {/* Simulador Link */}

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -55,9 +55,12 @@ export default function Navigation({ editionNumber }: NavigationProps) {
             </Link>
 
             {/* Navigation Items */}
-            {/* Con Galería son tres enlaces visibles en móvil: a 375px el gap
-                de 24px desborda la barra. Se aprieta hasta sm. */}
-            <div className="flex items-center space-x-4 sm:space-x-6">
+            {/* Con Galería son cuatro enlaces visibles en móvil, y a 375px no
+                caben. Hasta sm se aprietan cuerpo y espaciado, y la fila puede
+                desplazarse en horizontal: así ninguna sección desaparece del
+                menú en pantallas estrechas ni empuja la página de lado. De sm
+                en adelante sobra sitio y todo vuelve a su tamaño. */}
+            <div className="flex items-center space-x-3 sm:space-x-6 min-w-0 overflow-x-auto sm:overflow-x-visible [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {/* Edition Number (if on edition page) */}
               {editionNumber && (
                 <div className="font-serif text-lg text-deep-800">
@@ -68,7 +71,7 @@ export default function Navigation({ editionNumber }: NavigationProps) {
               {/* Archive Link */}
               <Link
                 href="/archivo"
-                className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+                className="shrink-0 whitespace-nowrap text-xs sm:text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-normal sm:tracking-wide uppercase"
               >
                 Archivo
               </Link>
@@ -76,7 +79,7 @@ export default function Navigation({ editionNumber }: NavigationProps) {
               {/* JAI Sounds Link */}
               <Link
                 href="/jai-sounds"
-                className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+                className="shrink-0 whitespace-nowrap text-xs sm:text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-normal sm:tracking-wide uppercase"
               >
                 JAI Sounds
               </Link>
@@ -84,7 +87,7 @@ export default function Navigation({ editionNumber }: NavigationProps) {
               {/* Galería Link */}
               <Link
                 href="/galeria"
-                className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+                className="shrink-0 whitespace-nowrap text-xs sm:text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-normal sm:tracking-wide uppercase"
               >
                 Galería
               </Link>
@@ -92,7 +95,7 @@ export default function Navigation({ editionNumber }: NavigationProps) {
               {/* Simulador Link */}
               <Link
                 href="/simulador"
-                className="text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+                className="shrink-0 whitespace-nowrap text-xs sm:text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-normal sm:tracking-wide uppercase"
               >
                 Simulador
               </Link>
@@ -100,7 +103,7 @@ export default function Navigation({ editionNumber }: NavigationProps) {
               {/* About Link (optional) */}
               <Link
                 href="/sobre"
-                className="hidden md:block text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-wide uppercase"
+                className="hidden md:block shrink-0 whitespace-nowrap text-xs sm:text-sm font-sans text-deep-700 hover:text-frequency transition-colors tracking-normal sm:tracking-wide uppercase"
               >
                 Sobre
               </Link>

--- a/content/galeria/obras.json
+++ b/content/galeria/obras.json
@@ -1,0 +1,25524 @@
+{
+  "blobBase": null,
+  "series": [
+    {
+      "id": "umbral",
+      "titulo": "El Umbral",
+      "descripcion": "Los cinco planos que abren la Edición #01. Médanos de Coro leídos como circuito: el desierto no es vacío, es una superficie que guarda señal."
+    },
+    {
+      "id": "archivo",
+      "titulo": "archivo",
+      "descripcion": "TODO: describir la serie."
+    }
+  ],
+  "obras": [
+    {
+      "slug": "120mm-cinematic-still-of-cyberpunk-eye-shape-sta-b9553ee2-2",
+      "serie": "archivo",
+      "orden": 1,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "120mm cinematic still of cyberpunk eye shape starship with a",
+        "generacion": "b9553ee2-647f-4f27-a063-1cb5f32c1ebc",
+        "variante": 2
+      },
+      "titulo": "120mm cinematic still of cyberpunk eye shape starship",
+      "alt": "120mm cinematic still of cyberpunk eye shape starship with a",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#53646c",
+      "generacion": "b9553ee2-647f-4f27-a063-1cb5f32c1ebc"
+    },
+    {
+      "slug": "120mm-film-cinematic-still-of-cyberpunk-eye-shap-b8ae891e-0",
+      "serie": "archivo",
+      "orden": 2,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+        "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e",
+        "variante": 0
+      },
+      "titulo": "120mm film cinematic still of cyberpunk eye shape",
+      "alt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#67764c",
+      "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e"
+    },
+    {
+      "slug": "120mm-film-cinematic-still-of-cyberpunk-eye-shap-b8ae891e-3",
+      "serie": "archivo",
+      "orden": 3,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+        "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e",
+        "variante": 3
+      },
+      "titulo": "120mm film cinematic still of cyberpunk eye shape",
+      "alt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#7a5a43",
+      "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e"
+    },
+    {
+      "slug": "35mm-cinematic-close-up-shot-movie-s-aff3dc50-0",
+      "serie": "archivo",
+      "orden": 4,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm Cinematic close up shot movie s",
+        "generacion": "aff3dc50-44d6-42b1-ad59-7fad783806a2",
+        "variante": 0
+      },
+      "titulo": "35mm Cinematic close up shot movie s",
+      "alt": "35mm Cinematic close up shot movie s",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#728c86",
+      "generacion": "aff3dc50-44d6-42b1-ad59-7fad783806a2"
+    },
+    {
+      "slug": "35mm-cinematic-close-up-shot-movie-still-of-2241cc4c-2",
+      "serie": "archivo",
+      "orden": 5,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm Cinematic close up shot movie still of esoteric scene An",
+        "generacion": "2241cc4c-10f6-4d6a-b49b-aed7cd941576",
+        "variante": 2
+      },
+      "titulo": "35mm Cinematic close up shot movie still of",
+      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5ca2b9",
+      "generacion": "2241cc4c-10f6-4d6a-b49b-aed7cd941576"
+    },
+    {
+      "slug": "35mm-cinematic-close-up-shot-movie-still-of-24683f3d-0",
+      "serie": "archivo",
+      "orden": 6,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm Cinematic close up shot movie still of esoteric scene An",
+        "generacion": "24683f3d-96b5-4924-beb0-d5d18251fd5f",
+        "variante": 0
+      },
+      "titulo": "35mm Cinematic close up shot movie still of",
+      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#56a4ca",
+      "generacion": "24683f3d-96b5-4924-beb0-d5d18251fd5f"
+    },
+    {
+      "slug": "35mm-cinematic-close-up-shot-movie-still-of-527313a8-0",
+      "serie": "archivo",
+      "orden": 7,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm Cinematic close up shot movie still of esoteric scene An",
+        "generacion": "527313a8-6389-4bdb-a5b9-e74614b3f0b1",
+        "variante": 0
+      },
+      "titulo": "35mm Cinematic close up shot movie still of",
+      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#648fab",
+      "generacion": "527313a8-6389-4bdb-a5b9-e74614b3f0b1"
+    },
+    {
+      "slug": "35mm-cinematic-wide-shot-movie-still-1c45bcae-3",
+      "serie": "archivo",
+      "orden": 8,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm Cinematic wide shot movie still",
+        "generacion": "1c45bcae-6172-4333-84a2-d03fffd46727",
+        "variante": 3
+      },
+      "titulo": "35mm Cinematic wide shot movie still",
+      "alt": "35mm Cinematic wide shot movie still",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#72897b",
+      "generacion": "1c45bcae-6172-4333-84a2-d03fffd46727"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-movie-still-of-an-9eace293-2",
+      "serie": "archivo",
+      "orden": 9,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic movie still of An indeginous main m",
+        "generacion": "9eace293-9207-47f5-b080-aad58550bac3",
+        "variante": 2
+      },
+      "titulo": "35mm full shot Cinematic movie still of An",
+      "alt": "35mm full shot Cinematic movie still of An indeginous main m",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#23353b",
+      "generacion": "9eace293-9207-47f5-b080-aad58550bac3"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-movie-still-of-an-c1cd86d7-1",
+      "serie": "archivo",
+      "orden": 10,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic movie still of An indigenous stands",
+        "generacion": "c1cd86d7-6d8f-4f5e-95be-b60cdcf14b34",
+        "variante": 1
+      },
+      "titulo": "35mm full shot Cinematic movie still of An",
+      "alt": "35mm full shot Cinematic movie still of An indigenous stands",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4c5965",
+      "generacion": "c1cd86d7-6d8f-4f5e-95be-b60cdcf14b34"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-w-bedf12e9-0",
+      "serie": "archivo",
+      "orden": 11,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic w",
+        "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6",
+        "variante": 0
+      },
+      "titulo": "35mm full shot Cinematic panoramic w",
+      "alt": "35mm full shot Cinematic panoramic w",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#0f1e42",
+      "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-w-bedf12e9-3",
+      "serie": "archivo",
+      "orden": 12,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic w",
+        "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6",
+        "variante": 3
+      },
+      "titulo": "35mm full shot Cinematic panoramic w",
+      "alt": "35mm full shot Cinematic panoramic w",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#091b42",
+      "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-w-dd3989df-2",
+      "serie": "archivo",
+      "orden": 13,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic w",
+        "generacion": "dd3989df-fff9-4b02-85c9-d8b6a782bf85",
+        "variante": 2
+      },
+      "titulo": "35mm full shot Cinematic panoramic w",
+      "alt": "35mm full shot Cinematic panoramic w",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1f2940",
+      "generacion": "dd3989df-fff9-4b02-85c9-d8b6a782bf85"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-wide-shot-mov-52a5b695-0",
+      "serie": "archivo",
+      "orden": 14,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic wide shot movie still of",
+        "generacion": "52a5b695-7ea7-4b67-bfed-c65c7eb37680",
+        "variante": 0
+      },
+      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
+      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8d868a",
+      "generacion": "52a5b695-7ea7-4b67-bfed-c65c7eb37680"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-wide-shot-mov-5937eba9-0",
+      "serie": "archivo",
+      "orden": 15,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic wide shot movie still of",
+        "generacion": "5937eba9-874d-4f84-8464-78a537d8deb3",
+        "variante": 0
+      },
+      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
+      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#aec8d9",
+      "generacion": "5937eba9-874d-4f84-8464-78a537d8deb3"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-wide-shot-mov-de7ebc7d-3",
+      "serie": "archivo",
+      "orden": 16,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic wide shot movie still of a",
+        "generacion": "de7ebc7d-12b6-449d-9b28-fea2cb744645",
+        "variante": 3
+      },
+      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
+      "alt": "35mm full shot Cinematic panoramic wide shot movie still of a",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#181e43",
+      "generacion": "de7ebc7d-12b6-449d-9b28-fea2cb744645"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-wide-shot-mov-e0615cd4-2",
+      "serie": "archivo",
+      "orden": 17,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic wide shot movie still of",
+        "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd",
+        "variante": 2
+      },
+      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
+      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#787d8b",
+      "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd"
+    },
+    {
+      "slug": "35mm-full-shot-cinematic-panoramic-wide-shot-mov-e0615cd4-3",
+      "serie": "archivo",
+      "orden": 18,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "35mm full shot Cinematic panoramic wide shot movie still of",
+        "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd",
+        "variante": 3
+      },
+      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
+      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7ea0a8",
+      "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd"
+    },
+    {
+      "slug": "3d-graphics-8d-rendering-of-a-caribean-conch-236636af-2",
+      "serie": "archivo",
+      "orden": 19,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "3D graphics 8D Rendering of a caribean conch shell with metal",
+        "generacion": "236636af-c376-40fb-a000-68b7f427b538",
+        "variante": 2
+      },
+      "titulo": "3D graphics 8D Rendering of a caribean conch",
+      "alt": "3D graphics 8D Rendering of a caribean conch shell with metal",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#c4aa9f",
+      "generacion": "236636af-c376-40fb-a000-68b7f427b538"
+    },
+    {
+      "slug": "a-black-and-white-photo-of-an-african-1aedc09f-2",
+      "serie": "archivo",
+      "orden": 20,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a black and white photo of an African American man with short",
+        "generacion": "1aedc09f-e82c-46f6-a74b-b446263d3197",
+        "variante": 2
+      },
+      "titulo": "A black and white photo of an African",
+      "alt": "a black and white photo of an African American man with short",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3e3e3d",
+      "generacion": "1aedc09f-e82c-46f6-a74b-b446263d3197"
+    },
+    {
+      "slug": "a-blurry-out-of-focus-photograph-taken-from-7ae7e0fc-2",
+      "serie": "archivo",
+      "orden": 21,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A blurry out of focus photograph taken from quite far away by",
+        "generacion": "7ae7e0fc-edba-442f-9e94-a7a2751ed761",
+        "variante": 2
+      },
+      "titulo": "A blurry out of focus photograph taken from",
+      "alt": "A blurry out of focus photograph taken from quite far away by",
+      "w": 1344,
+      "h": 880,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6c7350",
+      "generacion": "7ae7e0fc-edba-442f-9e94-a7a2751ed761"
+    },
+    {
+      "slug": "a-book-cover-for-scifi-in-the-style-d49e7c63-0",
+      "serie": "archivo",
+      "orden": 22,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a book cover for scifi in the style of colorful moebius daydr",
+        "generacion": "d49e7c63-25cc-4f5d-a500-0aae2cc0ec8b",
+        "variante": 0
+      },
+      "titulo": "A book cover for scifi in the style",
+      "alt": "a book cover for scifi in the style of colorful moebius daydr",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#8a5b4c",
+      "generacion": "d49e7c63-25cc-4f5d-a500-0aae2cc0ec8b"
+    },
+    {
+      "slug": "a-burning-pyre-with-a-character-from-the-25f91447-0",
+      "serie": "archivo",
+      "orden": 23,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a burning pyre with a character from The Curiana watching fro",
+        "generacion": "25f91447-8196-4d9b-be80-bdd5f845e0a5",
+        "variante": 0
+      },
+      "titulo": "A burning pyre with a character from The",
+      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#23302c",
+      "generacion": "25f91447-8196-4d9b-be80-bdd5f845e0a5"
+    },
+    {
+      "slug": "a-burning-pyre-with-a-character-from-the-7bac29a0-2",
+      "serie": "archivo",
+      "orden": 24,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a burning pyre with a character from The Curiana watching fro",
+        "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569",
+        "variante": 2
+      },
+      "titulo": "A burning pyre with a character from The",
+      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#372921",
+      "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569"
+    },
+    {
+      "slug": "a-burning-pyre-with-a-character-from-the-7bac29a0-3",
+      "serie": "archivo",
+      "orden": 25,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a burning pyre with a character from The Curiana watching fro",
+        "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569",
+        "variante": 3
+      },
+      "titulo": "A burning pyre with a character from The",
+      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2d3d40",
+      "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569"
+    },
+    {
+      "slug": "a-character-with-blue-clothing-standing-next-to-d4901187-0",
+      "serie": "archivo",
+      "orden": 26,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a character with blue clothing standing next to a blue backgr",
+        "generacion": "d4901187-6a36-4d7b-bba6-cc8b3e65064c",
+        "variante": 0
+      },
+      "titulo": "A character with blue clothing standing next to",
+      "alt": "a character with blue clothing standing next to a blue backgr",
+      "w": 1024,
+      "h": 1120,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1f608d",
+      "generacion": "d4901187-6a36-4d7b-bba6-cc8b3e65064c"
+    },
+    {
+      "slug": "a-city-of-stilt-houses-submerged-in-crystal-clea-e70f25ae-1",
+      "serie": "archivo",
+      "orden": 27,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A city of stilt houses submerged in crystal-clear turquoise w",
+        "generacion": "e70f25ae-a584-4382-8393-a6b04b118125",
+        "variante": 1
+      },
+      "titulo": "A city of stilt houses submerged in crystal-clear",
+      "alt": "A city of stilt houses submerged in crystal-clear turquoise w",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#565d54",
+      "generacion": "e70f25ae-a584-4382-8393-a6b04b118125"
+    },
+    {
+      "slug": "a-close-up-of-a-face-and-hair-lying-5c5da1a4-0",
+      "serie": "archivo",
+      "orden": 28,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a close-up of a face and hair lying on the subjects back with",
+        "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c",
+        "variante": 0
+      },
+      "titulo": "A close-up of a face and hair lying",
+      "alt": "a close-up of a face and hair lying on the subjects back with",
+      "w": 1184,
+      "h": 1008,
+      "anchos": [
+        400,
+        800,
+        1184
+      ],
+      "color": "#2f2826",
+      "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c"
+    },
+    {
+      "slug": "a-close-up-of-a-face-and-hair-lying-5c5da1a4-3",
+      "serie": "archivo",
+      "orden": 29,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a close-up of a face and hair lying on the subjects back with",
+        "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c",
+        "variante": 3
+      },
+      "titulo": "A close-up of a face and hair lying",
+      "alt": "a close-up of a face and hair lying on the subjects back with",
+      "w": 1184,
+      "h": 1008,
+      "anchos": [
+        400,
+        800,
+        1184
+      ],
+      "color": "#261a16",
+      "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c"
+    },
+    {
+      "slug": "a-couple-in-medieval-costumes-are-standing-on-8b1eff8b-0",
+      "serie": "archivo",
+      "orden": 30,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a couple in medieval costumes are standing on a balcony looki",
+        "generacion": "8b1eff8b-86b7-4b05-87d2-a1b055543ab8",
+        "variante": 0
+      },
+      "titulo": "A couple in medieval costumes are standing on",
+      "alt": "a couple in medieval costumes are standing on a balcony looki",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#716d67",
+      "generacion": "8b1eff8b-86b7-4b05-87d2-a1b055543ab8"
+    },
+    {
+      "slug": "a-ethereal-portrait-of-an-androgynous-entity-wit-5334f21b-1",
+      "serie": "archivo",
+      "orden": 31,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A ethereal portrait of an androgynous entity with Mediterrane",
+        "generacion": "5334f21b-36ce-4cce-a069-8989cb3f8098",
+        "variante": 1
+      },
+      "titulo": "A ethereal portrait of an androgynous entity with",
+      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2890ac",
+      "generacion": "5334f21b-36ce-4cce-a069-8989cb3f8098"
+    },
+    {
+      "slug": "a-ethereal-portrait-of-an-androgynous-entity-wit-6bcda6b9-0",
+      "serie": "archivo",
+      "orden": 32,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A ethereal portrait of an androgynous entity with Mediterrane",
+        "generacion": "6bcda6b9-8da9-4d20-a4ff-1f09899e4763",
+        "variante": 0
+      },
+      "titulo": "A ethereal portrait of an androgynous entity with",
+      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#575c40",
+      "generacion": "6bcda6b9-8da9-4d20-a4ff-1f09899e4763"
+    },
+    {
+      "slug": "a-ethereal-portrait-of-an-androgynous-entity-wit-c6c72ecd-3",
+      "serie": "archivo",
+      "orden": 33,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A ethereal portrait of an androgynous entity with Mediterrane",
+        "generacion": "c6c72ecd-c49a-4c0b-8fcf-224ad2d05de2",
+        "variante": 3
+      },
+      "titulo": "A ethereal portrait of an androgynous entity with",
+      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3d3131",
+      "generacion": "c6c72ecd-c49a-4c0b-8fcf-224ad2d05de2"
+    },
+    {
+      "slug": "a-ethereal-portrait-of-an-androgynous-entity-wit-d366181b-3",
+      "serie": "archivo",
+      "orden": 34,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A ethereal portrait of an androgynous entity with Mediterrane",
+        "generacion": "d366181b-f041-4ec7-ac65-af4065487095",
+        "variante": 3
+      },
+      "titulo": "A ethereal portrait of an androgynous entity with",
+      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b6a6b",
+      "generacion": "d366181b-f041-4ec7-ac65-af4065487095"
+    },
+    {
+      "slug": "a-fishing-boat-at-the-distance-in-a-6557c402-1",
+      "serie": "archivo",
+      "orden": 35,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a fishing boat at the distance in a panoramic view of the sea",
+        "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c",
+        "variante": 1
+      },
+      "titulo": "A fishing boat at the distance in a",
+      "alt": "a fishing boat at the distance in a panoramic view of the sea",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#476180",
+      "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c"
+    },
+    {
+      "slug": "a-fishing-boat-at-the-distance-in-a-6557c402-3",
+      "serie": "archivo",
+      "orden": 36,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a fishing boat at the distance in a panoramic view of the sea",
+        "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c",
+        "variante": 3
+      },
+      "titulo": "A fishing boat at the distance in a",
+      "alt": "a fishing boat at the distance in a panoramic view of the sea",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#387190",
+      "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c"
+    },
+    {
+      "slug": "a-full-body-portrait-of-a-caqueto-native-america-a96d2253-3",
+      "serie": "archivo",
+      "orden": 37,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A full-body portrait of a Caqueto native American from the 16",
+        "generacion": "a96d2253-9451-4208-99d7-e19f177d6b8b",
+        "variante": 3
+      },
+      "titulo": "A full-body portrait of a Caqueto native American",
+      "alt": "A full-body portrait of a Caqueto native American from the 16",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4c5d67",
+      "generacion": "a96d2253-9451-4208-99d7-e19f177d6b8b"
+    },
+    {
+      "slug": "a-full-body-portrait-of-a-caqueto-native-america-f617711a-2",
+      "serie": "archivo",
+      "orden": 38,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A full-body portrait of a Caqueto native American from the 16",
+        "generacion": "f617711a-b983-48d4-a347-c3c4ec56ff68",
+        "variante": 2
+      },
+      "titulo": "A full-body portrait of a Caqueto native American",
+      "alt": "A full-body portrait of a Caqueto native American from the 16",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#9b826d",
+      "generacion": "f617711a-b983-48d4-a347-c3c4ec56ff68"
+    },
+    {
+      "slug": "a-golden-shark-swimming-under-the-rock-among-1115a773-0",
+      "serie": "archivo",
+      "orden": 39,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A golden shark swimming under the rock among a reef filled wi",
+        "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606",
+        "variante": 0
+      },
+      "titulo": "A golden shark swimming under the rock among",
+      "alt": "A golden shark swimming under the rock among a reef filled wi",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#58483d",
+      "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606"
+    },
+    {
+      "slug": "a-golden-shark-swimming-under-the-rock-among-1115a773-1",
+      "serie": "archivo",
+      "orden": 40,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A golden shark swimming under the rock among a reef filled wi",
+        "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606",
+        "variante": 1
+      },
+      "titulo": "A golden shark swimming under the rock among",
+      "alt": "A golden shark swimming under the rock among a reef filled wi",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#16171a",
+      "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606"
+    },
+    {
+      "slug": "a-group-of-men-and-women-siting-around-061277f0-0",
+      "serie": "archivo",
+      "orden": 41,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a group of men and women siting around outside of a coffee Vi",
+        "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e",
+        "variante": 0
+      },
+      "titulo": "A group of men and women siting around",
+      "alt": "a group of men and women siting around outside of a coffee Vi",
+      "w": 1280,
+      "h": 944,
+      "anchos": [
+        400,
+        800,
+        1280
+      ],
+      "color": "#3d3421",
+      "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e"
+    },
+    {
+      "slug": "a-group-of-men-and-women-siting-around-061277f0-3",
+      "serie": "archivo",
+      "orden": 42,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a group of men and women siting around outside of a coffee Vi",
+        "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e",
+        "variante": 3
+      },
+      "titulo": "A group of men and women siting around",
+      "alt": "a group of men and women siting around outside of a coffee Vi",
+      "w": 1280,
+      "h": 944,
+      "anchos": [
+        400,
+        800,
+        1280
+      ],
+      "color": "#534738",
+      "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e"
+    },
+    {
+      "slug": "a-group-of-men-siting-around-outside-of-04bcbef9-2",
+      "serie": "archivo",
+      "orden": 43,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a group of men siting around outside of a cafe in Caracas in",
+        "generacion": "04bcbef9-0177-4de4-92d8-ca3a3445b4d8",
+        "variante": 2
+      },
+      "titulo": "A group of men siting around outside of",
+      "alt": "a group of men siting around outside of a cafe in Caracas in",
+      "w": 1280,
+      "h": 944,
+      "anchos": [
+        400,
+        800,
+        1280
+      ],
+      "color": "#4a4237",
+      "generacion": "04bcbef9-0177-4de4-92d8-ca3a3445b4d8"
+    },
+    {
+      "slug": "a-group-of-men-siting-around-outside-of-9815e5d2-2",
+      "serie": "archivo",
+      "orden": 44,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a group of men siting around outside of a cafe in Caracas in",
+        "generacion": "9815e5d2-2b89-440f-833d-366bb70c7e03",
+        "variante": 2
+      },
+      "titulo": "A group of men siting around outside of",
+      "alt": "a group of men siting around outside of a cafe in Caracas in",
+      "w": 1280,
+      "h": 944,
+      "anchos": [
+        400,
+        800,
+        1280
+      ],
+      "color": "#6a6a6a",
+      "generacion": "9815e5d2-2b89-440f-833d-366bb70c7e03"
+    },
+    {
+      "slug": "a-illustration-of-a-man-with-a-parrot-5c858b86-0",
+      "serie": "archivo",
+      "orden": 45,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a illustration of a man with a parrot standing on his shoulde",
+        "generacion": "5c858b86-ec77-433c-8a4a-486e2d03f9ae",
+        "variante": 0
+      },
+      "titulo": "A illustration of a man with a parrot",
+      "alt": "a illustration of a man with a parrot standing on his shoulde",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#aea697",
+      "generacion": "5c858b86-ec77-433c-8a4a-486e2d03f9ae"
+    },
+    {
+      "slug": "a-illustration-of-a-man-with-a-parrot-ae72417a-3",
+      "serie": "archivo",
+      "orden": 46,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a illustration of a man with a parrot in the style of dark cr",
+        "generacion": "ae72417a-d556-4f47-9614-550e9d4dd4ac",
+        "variante": 3
+      },
+      "titulo": "A illustration of a man with a parrot",
+      "alt": "a illustration of a man with a parrot in the style of dark cr",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8b8078",
+      "generacion": "ae72417a-d556-4f47-9614-550e9d4dd4ac"
+    },
+    {
+      "slug": "a-image-showing-the-water-lines-at-the-6d883756-0",
+      "serie": "archivo",
+      "orden": 47,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a image showing the water lines at the sunset in the style of",
+        "generacion": "6d883756-8501-4b16-a9ef-18cf96d57b87",
+        "variante": 0
+      },
+      "titulo": "A image showing the water lines at the",
+      "alt": "a image showing the water lines at the sunset in the style of",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#915765",
+      "generacion": "6d883756-8501-4b16-a9ef-18cf96d57b87"
+    },
+    {
+      "slug": "a-man-opening-a-portal-to-an-alternate-276c80ab-0",
+      "serie": "archivo",
+      "orden": 48,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A man opening a portal to an alternate psychedelic dimension",
+        "generacion": "276c80ab-9a72-4019-972b-2bd45a8200e0",
+        "variante": 0
+      },
+      "titulo": "A man opening a portal to an alternate",
+      "alt": "A man opening a portal to an alternate psychedelic dimension",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#413b37",
+      "generacion": "276c80ab-9a72-4019-972b-2bd45a8200e0"
+    },
+    {
+      "slug": "a-man-wearing-a-colorful-outfit-and-surrounded-3a64d32a-1",
+      "serie": "archivo",
+      "orden": 49,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a man wearing a colorful outfit and surrounded by stars in th",
+        "generacion": "3a64d32a-0bcb-40e0-b674-bd194df89f53",
+        "variante": 1
+      },
+      "titulo": "A man wearing a colorful outfit and surrounded",
+      "alt": "a man wearing a colorful outfit and surrounded by stars in th",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#424a43",
+      "generacion": "3a64d32a-0bcb-40e0-b674-bd194df89f53"
+    },
+    {
+      "slug": "a-man-wearing-a-red-shirt-is-holding-082e0a75-1",
+      "serie": "archivo",
+      "orden": 50,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a man wearing a red shirt is holding an parrot in the style o",
+        "generacion": "082e0a75-c718-406f-8012-bbb48b4e52ef",
+        "variante": 1
+      },
+      "titulo": "A man wearing a red shirt is holding",
+      "alt": "a man wearing a red shirt is holding an parrot in the style o",
+      "w": 800,
+      "h": 1385,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#a55f64",
+      "generacion": "082e0a75-c718-406f-8012-bbb48b4e52ef"
+    },
+    {
+      "slug": "a-man-with-a-blue-glowing-eye-floating-0af09855-0",
+      "serie": "archivo",
+      "orden": 51,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A man with a blue glowing eye floating in space with orange a",
+        "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc",
+        "variante": 0
+      },
+      "titulo": "A man with a blue glowing eye floating",
+      "alt": "A man with a blue glowing eye floating in space with orange a",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#231e17",
+      "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc"
+    },
+    {
+      "slug": "a-man-with-a-blue-glowing-eye-floating-0af09855-3",
+      "serie": "archivo",
+      "orden": 52,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A man with a blue glowing eye floating in space with orange a",
+        "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc",
+        "variante": 3
+      },
+      "titulo": "A man with a blue glowing eye floating",
+      "alt": "A man with a blue glowing eye floating in space with orange a",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1a1713",
+      "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc"
+    },
+    {
+      "slug": "a-man-with-a-blue-glowing-eye-orange-3f654dde-2",
+      "serie": "archivo",
+      "orden": 53,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A man with a blue glowing eye orange skin and a starry sky ba",
+        "generacion": "3f654dde-14cf-428a-aa72-363c3972aa3a",
+        "variante": 2
+      },
+      "titulo": "A man with a blue glowing eye orange",
+      "alt": "A man with a blue glowing eye orange skin and a starry sky ba",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#0f3643",
+      "generacion": "3f654dde-14cf-428a-aa72-363c3972aa3a"
+    },
+    {
+      "slug": "a-mans-face-with-an-eye-that-glows-ec48ae3b-0",
+      "serie": "archivo",
+      "orden": 54,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A mans face with an eye that glows like the night sky close-u",
+        "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559",
+        "variante": 0
+      },
+      "titulo": "A mans face with an eye that glows",
+      "alt": "A mans face with an eye that glows like the night sky close-u",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#332317",
+      "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559"
+    },
+    {
+      "slug": "a-mans-face-with-an-eye-that-glows-ec48ae3b-3",
+      "serie": "archivo",
+      "orden": 55,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A mans face with an eye that glows like the night sky close-u",
+        "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559",
+        "variante": 3
+      },
+      "titulo": "A mans face with an eye that glows",
+      "alt": "A mans face with an eye that glows like the night sky close-u",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#473c31",
+      "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559"
+    },
+    {
+      "slug": "a-movie-still-of-two-men-standing-next-8c9060ba-0",
+      "serie": "archivo",
+      "orden": 56,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a movie still of two men standing next to an exploding bonfir",
+        "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a",
+        "variante": 0
+      },
+      "titulo": "A movie still of two men standing next",
+      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#334953",
+      "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a"
+    },
+    {
+      "slug": "a-movie-still-of-two-men-standing-next-8c9060ba-1",
+      "serie": "archivo",
+      "orden": 57,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a movie still of two men standing next to an exploding bonfir",
+        "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a",
+        "variante": 1
+      },
+      "titulo": "A movie still of two men standing next",
+      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#462631",
+      "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a"
+    },
+    {
+      "slug": "a-movie-still-of-two-men-standing-next-ebe8d497-1",
+      "serie": "archivo",
+      "orden": 58,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a movie still of two men standing next to an exploding bonfir",
+        "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
+        "variante": 1
+      },
+      "titulo": "A movie still of two men standing next",
+      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3a3251",
+      "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a"
+    },
+    {
+      "slug": "a-movie-still-of-two-men-standing-next-ebe8d497-2",
+      "serie": "archivo",
+      "orden": 59,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a movie still of two men standing next to an exploding bonfir",
+        "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
+        "variante": 2
+      },
+      "titulo": "A movie still of two men standing next",
+      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#433752",
+      "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a"
+    },
+    {
+      "slug": "a-movie-still-of-two-men-standing-next-ebe8d497-3",
+      "serie": "archivo",
+      "orden": 60,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a movie still of two men standing next to an exploding bonfir",
+        "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
+        "variante": 3
+      },
+      "titulo": "A movie still of two men standing next",
+      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "w": 1400,
+      "h": 768,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4b3639",
+      "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a"
+    },
+    {
+      "slug": "a-newspaper-press-image-of-venezuelan-farmers-in-fc93100c-0",
+      "serie": "archivo",
+      "orden": 61,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a newspaper press image of venezuelan farmers in 1836 for the",
+        "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
+        "variante": 0
+      },
+      "titulo": "A newspaper press image of venezuelan farmers in",
+      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "w": 1376,
+      "h": 864,
+      "anchos": [
+        400,
+        800,
+        1376
+      ],
+      "color": "#78756a",
+      "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c"
+    },
+    {
+      "slug": "a-newspaper-press-image-of-venezuelan-farmers-in-fc93100c-1",
+      "serie": "archivo",
+      "orden": 62,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a newspaper press image of venezuelan farmers in 1836 for the",
+        "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
+        "variante": 1
+      },
+      "titulo": "A newspaper press image of venezuelan farmers in",
+      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "w": 1376,
+      "h": 864,
+      "anchos": [
+        400,
+        800,
+        1376
+      ],
+      "color": "#bea790",
+      "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c"
+    },
+    {
+      "slug": "a-newspaper-press-image-of-venezuelan-farmers-in-fc93100c-2",
+      "serie": "archivo",
+      "orden": 63,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a newspaper press image of venezuelan farmers in 1836 for the",
+        "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
+        "variante": 2
+      },
+      "titulo": "A newspaper press image of venezuelan farmers in",
+      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "w": 1376,
+      "h": 864,
+      "anchos": [
+        400,
+        800,
+        1376
+      ],
+      "color": "#645b4b",
+      "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c"
+    },
+    {
+      "slug": "a-painting-of-soldiers-in-uniform-fighting-in-05209ceb-0",
+      "serie": "archivo",
+      "orden": 64,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a painting of soldiers in uniform fighting in the style of vi",
+        "generacion": "05209ceb-7716-4755-9e61-88bc03beffb1",
+        "variante": 0
+      },
+      "titulo": "A painting of soldiers in uniform fighting in",
+      "alt": "a painting of soldiers in uniform fighting in the style of vi",
+      "w": 1400,
+      "h": 679,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#816247",
+      "generacion": "05209ceb-7716-4755-9e61-88bc03beffb1"
+    },
+    {
+      "slug": "a-painting-shows-the-inside-view-of-a-e38b9d5d-0",
+      "serie": "archivo",
+      "orden": 65,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A painting shows the inside view of a space station in orbit",
+        "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65",
+        "variante": 0
+      },
+      "titulo": "A painting shows the inside view of a",
+      "alt": "A painting shows the inside view of a space station in orbit",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#54535c",
+      "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65"
+    },
+    {
+      "slug": "a-painting-shows-the-inside-view-of-a-e38b9d5d-1",
+      "serie": "archivo",
+      "orden": 66,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A painting shows the inside view of a space station in orbit",
+        "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65",
+        "variante": 1
+      },
+      "titulo": "A painting shows the inside view of a",
+      "alt": "A painting shows the inside view of a space station in orbit",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#494956",
+      "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-featur-2e6dce78-0",
+      "serie": "archivo",
+      "orden": 67,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest featuring native in",
+        "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607",
+        "variante": 0
+      },
+      "titulo": "A panoramic view of the Amazon rainforest featuring",
+      "alt": "A panoramic view of the Amazon rainforest featuring native in",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#41352f",
+      "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-featur-2e6dce78-3",
+      "serie": "archivo",
+      "orden": 68,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest featuring native in",
+        "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest featuring",
+      "alt": "A panoramic view of the Amazon rainforest featuring native in",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#485c3f",
+      "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-0a8104a1-2",
+      "serie": "archivo",
+      "orden": 69,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "0a8104a1-956e-4d87-bd75-20474b190df3",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#57623f",
+      "generacion": "0a8104a1-956e-4d87-bd75-20474b190df3"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-0ae726c5-0",
+      "serie": "archivo",
+      "orden": 70,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
+        "variante": 0
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#434958",
+      "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-0ae726c5-1",
+      "serie": "archivo",
+      "orden": 71,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#515a52",
+      "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-0ae726c5-2",
+      "serie": "archivo",
+      "orden": 72,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#444951",
+      "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-0b4d111c-1",
+      "serie": "archivo",
+      "orden": 73,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "0b4d111c-ca9e-42ee-850d-c307e741f20f",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#b5b580",
+      "generacion": "0b4d111c-ca9e-42ee-850d-c307e741f20f"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-367d86c3-1",
+      "serie": "archivo",
+      "orden": 74,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "367d86c3-7841-476a-8189-7989062c6bfa",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#353c3e",
+      "generacion": "367d86c3-7841-476a-8189-7989062c6bfa"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-367d86c3-2",
+      "serie": "archivo",
+      "orden": 75,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "367d86c3-7841-476a-8189-7989062c6bfa",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3c4a55",
+      "generacion": "367d86c3-7841-476a-8189-7989062c6bfa"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-708bc812-0",
+      "serie": "archivo",
+      "orden": 76,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "708bc812-8883-4007-b4f8-058897fa7860",
+        "variante": 0
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3a4761",
+      "generacion": "708bc812-8883-4007-b4f8-058897fa7860"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-77621c9a-1",
+      "serie": "archivo",
+      "orden": 77,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#556150",
+      "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-77621c9a-2",
+      "serie": "archivo",
+      "orden": 78,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#383731",
+      "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-77621c9a-3",
+      "serie": "archivo",
+      "orden": 79,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4e5d44",
+      "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-7fa7aa1a-0",
+      "serie": "archivo",
+      "orden": 80,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
+        "variante": 0
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#174950",
+      "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-7fa7aa1a-1",
+      "serie": "archivo",
+      "orden": 81,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#384242",
+      "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-7fa7aa1a-3",
+      "serie": "archivo",
+      "orden": 82,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#49463f",
+      "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-9a3a4809-2",
+      "serie": "archivo",
+      "orden": 83,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "9a3a4809-b373-4b39-999e-4b6cb904ca8b",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#394433",
+      "generacion": "9a3a4809-b373-4b39-999e-4b6cb904ca8b"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-bce6a3ab-0",
+      "serie": "archivo",
+      "orden": 84,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
+        "variante": 0
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4a4c3b",
+      "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-bce6a3ab-1",
+      "serie": "archivo",
+      "orden": 85,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#46412b",
+      "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-bce6a3ab-2",
+      "serie": "archivo",
+      "orden": 86,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3d402d",
+      "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-bce6a3ab-3",
+      "serie": "archivo",
+      "orden": 87,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4b4a37",
+      "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-ef803288-1",
+      "serie": "archivo",
+      "orden": 88,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "ef803288-afc1-4ece-8615-40c839eb7926",
+        "variante": 1
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#384131",
+      "generacion": "ef803288-afc1-4ece-8615-40c839eb7926"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-ef803288-3",
+      "serie": "archivo",
+      "orden": 89,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "ef803288-afc1-4ece-8615-40c839eb7926",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#909565",
+      "generacion": "ef803288-afc1-4ece-8615-40c839eb7926"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-f53f213f-2",
+      "serie": "archivo",
+      "orden": 90,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8",
+        "variante": 2
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#384344",
+      "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8"
+    },
+    {
+      "slug": "a-panoramic-view-of-the-amazon-rainforest-in-f53f213f-3",
+      "serie": "archivo",
+      "orden": 91,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A panoramic view of the Amazon rainforest in the 16th century",
+        "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8",
+        "variante": 3
+      },
+      "titulo": "A panoramic view of the Amazon rainforest in",
+      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#424848",
+      "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8"
+    },
+    {
+      "slug": "a-photo-of-the-first-person-virtual-reality-e49fedc8-0",
+      "serie": "archivo",
+      "orden": 92,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A photo of the first person virtual reality headset designed",
+        "generacion": "e49fedc8-ee64-4814-ad49-74120091ae72",
+        "variante": 0
+      },
+      "titulo": "A photo of the first person virtual reality",
+      "alt": "A photo of the first person virtual reality headset designed",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#44474c",
+      "generacion": "e49fedc8-ee64-4814-ad49-74120091ae72"
+    },
+    {
+      "slug": "a-photograph-of-an-attractive-woman-lying-on-fbb795d0-2",
+      "serie": "archivo",
+      "orden": 93,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a photograph of an attractive woman lying on her back from ab",
+        "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2",
+        "variante": 2
+      },
+      "titulo": "A photograph of an attractive woman lying on",
+      "alt": "a photograph of an attractive woman lying on her back from ab",
+      "w": 1184,
+      "h": 1008,
+      "anchos": [
+        400,
+        800,
+        1184
+      ],
+      "color": "#3d3522",
+      "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2"
+    },
+    {
+      "slug": "a-photograph-of-an-attractive-woman-lying-on-fbb795d0-3",
+      "serie": "archivo",
+      "orden": 94,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a photograph of an attractive woman lying on her back from ab",
+        "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2",
+        "variante": 3
+      },
+      "titulo": "A photograph of an attractive woman lying on",
+      "alt": "a photograph of an attractive woman lying on her back from ab",
+      "w": 1184,
+      "h": 1008,
+      "anchos": [
+        400,
+        800,
+        1184
+      ],
+      "color": "#362b1d",
+      "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2"
+    },
+    {
+      "slug": "a-photograph-of-an-underwater-stilte-9cbb9964-0",
+      "serie": "archivo",
+      "orden": 95,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a photograph of an underwater stilte",
+        "generacion": "9cbb9964-a368-4cde-970d-8f20beadf2c0",
+        "variante": 0
+      },
+      "titulo": "A photograph of an underwater stilte",
+      "alt": "a photograph of an underwater stilte",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#505e55",
+      "generacion": "9cbb9964-a368-4cde-970d-8f20beadf2c0"
+    },
+    {
+      "slug": "a-poster-for-the-movie-the-last-angel-449bdf69-3",
+      "serie": "archivo",
+      "orden": 96,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a poster for the movie the last angel in the style of jeff ea",
+        "generacion": "449bdf69-59b3-402c-b3b6-2923f36ad57a",
+        "variante": 3
+      },
+      "titulo": "A poster for the movie the last angel",
+      "alt": "a poster for the movie the last angel in the style of jeff ea",
+      "w": 1024,
+      "h": 1040,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6e4933",
+      "generacion": "449bdf69-59b3-402c-b3b6-2923f36ad57a"
+    },
+    {
+      "slug": "a-scientific-manuscript-from-the-renaissance-e27d9c25-2",
+      "serie": "archivo",
+      "orden": 97,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A scientific manuscript from the renaissance --ar 916 --raw -",
+        "generacion": "e27d9c25-0f19-4e92-8d52-0144c326feea",
+        "variante": 2
+      },
+      "titulo": "A scientific manuscript from the renaissance",
+      "alt": "A scientific manuscript from the renaissance",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#736a5f",
+      "generacion": "e27d9c25-0f19-4e92-8d52-0144c326feea"
+    },
+    {
+      "slug": "a-statue-in-desert-in-the-style-of-15f9872a-0",
+      "serie": "archivo",
+      "orden": 98,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a statue in desert in the style of bold saturation innovator",
+        "generacion": "15f9872a-951f-457d-b950-b8e00183ecd5",
+        "variante": 0
+      },
+      "titulo": "A statue in desert in the style of",
+      "alt": "a statue in desert in the style of bold saturation innovator",
+      "w": 800,
+      "h": 1131,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#7e3939",
+      "generacion": "15f9872a-951f-457d-b950-b8e00183ecd5"
+    },
+    {
+      "slug": "a-statue-in-stone-is-sitting-in-the-0ab1e22d-2",
+      "serie": "archivo",
+      "orden": 99,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a statue in stone is sitting in the desert next to colorful c",
+        "generacion": "0ab1e22d-f52e-44b3-8060-6c8a9f684585",
+        "variante": 2
+      },
+      "titulo": "A statue in stone is sitting in the",
+      "alt": "a statue in stone is sitting in the desert next to colorful c",
+      "w": 800,
+      "h": 1131,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#7f4b3f",
+      "generacion": "0ab1e22d-f52e-44b3-8060-6c8a9f684585"
+    },
+    {
+      "slug": "a-statue-in-stone-is-sitting-in-the-7e10606b-0",
+      "serie": "archivo",
+      "orden": 100,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a statue in stone is sitting in the desert next to colorful c",
+        "generacion": "7e10606b-a9cd-4055-bf2f-a50b2153052c",
+        "variante": 0
+      },
+      "titulo": "A statue in stone is sitting in the",
+      "alt": "a statue in stone is sitting in the desert next to colorful c",
+      "w": 800,
+      "h": 1131,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#875a53",
+      "generacion": "7e10606b-a9cd-4055-bf2f-a50b2153052c"
+    },
+    {
+      "slug": "a-stunning-panoramic-view-of-the-amazon-rainfore-68b7c25c-0",
+      "serie": "archivo",
+      "orden": 101,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A stunning panoramic view of the Amazon rainforest dense with",
+        "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
+        "variante": 0
+      },
+      "titulo": "A stunning panoramic view of the Amazon rainforest",
+      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2e3728",
+      "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561"
+    },
+    {
+      "slug": "a-stunning-panoramic-view-of-the-amazon-rainfore-68b7c25c-1",
+      "serie": "archivo",
+      "orden": 102,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A stunning panoramic view of the Amazon rainforest dense with",
+        "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
+        "variante": 1
+      },
+      "titulo": "A stunning panoramic view of the Amazon rainforest",
+      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#1d292a",
+      "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561"
+    },
+    {
+      "slug": "a-stunning-panoramic-view-of-the-amazon-rainfore-68b7c25c-2",
+      "serie": "archivo",
+      "orden": 103,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A stunning panoramic view of the Amazon rainforest dense with",
+        "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
+        "variante": 2
+      },
+      "titulo": "A stunning panoramic view of the Amazon rainforest",
+      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#1b392c",
+      "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561"
+    },
+    {
+      "slug": "a-wide-highly-realistic-painting-style-scene-of-6935c284-2",
+      "serie": "archivo",
+      "orden": 104,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "A wide highly realistic painting-style scene of the Amazon ra",
+        "generacion": "6935c284-0eb1-42c3-aa2c-78a800a04ec8",
+        "variante": 2
+      },
+      "titulo": "A wide highly realistic painting-style scene of the",
+      "alt": "A wide highly realistic painting-style scene of the Amazon ra",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#686239",
+      "generacion": "6935c284-0eb1-42c3-aa2c-78a800a04ec8"
+    },
+    {
+      "slug": "a-witches-covenant-dances-around-in-38c61c86-2",
+      "serie": "archivo",
+      "orden": 105,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a witches covenant dances around in",
+        "generacion": "38c61c86-4737-4ece-82c1-715643ce963a",
+        "variante": 2
+      },
+      "titulo": "A witches covenant dances around in",
+      "alt": "a witches covenant dances around in",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b7481",
+      "generacion": "38c61c86-4737-4ece-82c1-715643ce963a"
+    },
+    {
+      "slug": "a-witches-covenant-dances-around-in-adf8f0b4-3",
+      "serie": "archivo",
+      "orden": 106,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a witches covenant dances around in",
+        "generacion": "adf8f0b4-3989-4bcf-95d8-d935b8a529e5",
+        "variante": 3
+      },
+      "titulo": "A witches covenant dances around in",
+      "alt": "a witches covenant dances around in",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#677e82",
+      "generacion": "adf8f0b4-3989-4bcf-95d8-d935b8a529e5"
+    },
+    {
+      "slug": "a-witches-covenant-dances-around-in-circles-with-0b1de8a5-0",
+      "serie": "archivo",
+      "orden": 107,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a witches covenant dances around in circles with the main wit",
+        "generacion": "0b1de8a5-db0e-4dd7-b6b4-0a9f307576cb",
+        "variante": 0
+      },
+      "titulo": "A witches covenant dances around in circles with",
+      "alt": "a witches covenant dances around in circles with the main wit",
+      "w": 2048,
+      "h": 2048,
+      "anchos": [
+        400,
+        800,
+        1400,
+        2048
+      ],
+      "color": "#4c4f47",
+      "generacion": "0b1de8a5-db0e-4dd7-b6b4-0a9f307576cb"
+    },
+    {
+      "slug": "a-witches-covenant-dances-around-in-circles-with-9662a3ab-2",
+      "serie": "archivo",
+      "orden": 108,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a witches covenant dances around in circles with the main wit",
+        "generacion": "9662a3ab-0a0d-44f4-94b5-3dcb2ce8f061",
+        "variante": 2
+      },
+      "titulo": "A witches covenant dances around in circles with",
+      "alt": "a witches covenant dances around in circles with the main wit",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#605a41",
+      "generacion": "9662a3ab-0a0d-44f4-94b5-3dcb2ce8f061"
+    },
+    {
+      "slug": "a4bup4-spaceship-going-through-a-spacial-wo-4a09ab60-0",
+      "serie": "archivo",
+      "orden": 109,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a4bUp4 Spaceship going through a Spacial Wo",
+        "generacion": "4a09ab60-bcd9-4b8f-a93e-820962717430",
+        "variante": 0
+      },
+      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
+      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#736f6e",
+      "generacion": "4a09ab60-bcd9-4b8f-a93e-820962717430"
+    },
+    {
+      "slug": "a4bup4-spaceship-going-through-a-spacial-wo-c374e7ab-0",
+      "serie": "archivo",
+      "orden": 110,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a4bUp4 Spaceship going through a Spacial Wo",
+        "generacion": "c374e7ab-e3ea-438e-828b-81ad3952de4f",
+        "variante": 0
+      },
+      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
+      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#50655a",
+      "generacion": "c374e7ab-e3ea-438e-828b-81ad3952de4f"
+    },
+    {
+      "slug": "a4bup4-spaceship-going-through-a-spacial-wo-e0394adf-1",
+      "serie": "archivo",
+      "orden": 111,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a4bUp4 Spaceship going through a Spacial Wo",
+        "generacion": "e0394adf-b46b-4d1e-8a0c-c25091d57622",
+        "variante": 1
+      },
+      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
+      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#58aed1",
+      "generacion": "e0394adf-b46b-4d1e-8a0c-c25091d57622"
+    },
+    {
+      "slug": "a4bup4-spaceship-going-through-a-spacial-wo-e1f55ea6-2",
+      "serie": "archivo",
+      "orden": 112,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "a4bUp4 Spaceship going through a Spacial Wo",
+        "generacion": "e1f55ea6-93a3-4f95-a9e2-413949e85049",
+        "variante": 2
+      },
+      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
+      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#438d5c",
+      "generacion": "e1f55ea6-93a3-4f95-a9e2-413949e85049"
+    },
+    {
+      "slug": "album-cover-of-a-desert-caravan-tuareg-nomad-2c100109-3",
+      "serie": "archivo",
+      "orden": 113,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+        "generacion": "2c100109-7f0d-4256-9c55-acb78e864f8e",
+        "variante": 3
+      },
+      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
+      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#414346",
+      "generacion": "2c100109-7f0d-4256-9c55-acb78e864f8e"
+    },
+    {
+      "slug": "album-cover-of-a-desert-caravan-tuareg-nomad-956e1767-1",
+      "serie": "archivo",
+      "orden": 114,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+        "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8",
+        "variante": 1
+      },
+      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
+      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b382c",
+      "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8"
+    },
+    {
+      "slug": "album-cover-of-a-desert-caravan-tuareg-nomad-956e1767-3",
+      "serie": "archivo",
+      "orden": 115,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+        "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8",
+        "variante": 3
+      },
+      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
+      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#55382d",
+      "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8"
+    },
+    {
+      "slug": "album-cover-of-a-desert-caravan-tuareg-nomad-cf75e38b-0",
+      "serie": "archivo",
+      "orden": 116,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+        "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529",
+        "variante": 0
+      },
+      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
+      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#513627",
+      "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529"
+    },
+    {
+      "slug": "album-cover-of-a-desert-caravan-tuareg-nomad-cf75e38b-2",
+      "serie": "archivo",
+      "orden": 117,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+        "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529",
+        "variante": 2
+      },
+      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
+      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#583a2d",
+      "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529"
+    },
+    {
+      "slug": "alternative-rock-album-cover-art-with-latin-amer-b273ea04-2",
+      "serie": "archivo",
+      "orden": 118,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "alternative rock album cover art with Latin american boy with",
+        "generacion": "b273ea04-25d3-486c-bb6f-b9815b7c47b0",
+        "variante": 2
+      },
+      "titulo": "Alternative rock album cover art with Latin american",
+      "alt": "alternative rock album cover art with Latin american boy with",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#353c3d",
+      "generacion": "b273ea04-25d3-486c-bb6f-b9815b7c47b0"
+    },
+    {
+      "slug": "alternative-rock-album-cover-art-with-latin-amer-d1218760-2",
+      "serie": "archivo",
+      "orden": 119,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "alternative rock album cover art with Latin american boy with",
+        "generacion": "d1218760-3e2d-43e1-a458-fb84bd3a6ab8",
+        "variante": 2
+      },
+      "titulo": "Alternative rock album cover art with Latin american",
+      "alt": "alternative rock album cover art with Latin american boy with",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#433a38",
+      "generacion": "d1218760-3e2d-43e1-a458-fb84bd3a6ab8"
+    },
+    {
+      "slug": "alternative-rock-album-cover-with-latin-american-bbb5bc58-0",
+      "serie": "archivo",
+      "orden": 120,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "alternative rock album cover with Latin american boy with an",
+        "generacion": "bbb5bc58-7cdf-44d9-ac96-f428e2dd3adb",
+        "variante": 0
+      },
+      "titulo": "Alternative rock album cover with Latin american boy",
+      "alt": "alternative rock album cover with Latin american boy with an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f3931",
+      "generacion": "bbb5bc58-7cdf-44d9-ac96-f428e2dd3adb"
+    },
+    {
+      "slug": "an-asian-girl-holding-a-cigarette-in-a-47a3c46f-3",
+      "serie": "archivo",
+      "orden": 121,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "an asian girl holding a cigarette in a chair in the style of",
+        "generacion": "47a3c46f-8cc6-464d-ad5d-d29a2d82f8de",
+        "variante": 3
+      },
+      "titulo": "An asian girl holding a cigarette in a",
+      "alt": "an asian girl holding a cigarette in a chair in the style of",
+      "w": 1024,
+      "h": 1184,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b5240",
+      "generacion": "47a3c46f-8cc6-464d-ad5d-d29a2d82f8de"
+    },
+    {
+      "slug": "an-oil-painting-of-a-surreal-world-a-a8c27f5c-3",
+      "serie": "archivo",
+      "orden": 122,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "An Oil painting of a surreal world a white rabbit with red ey",
+        "generacion": "a8c27f5c-4331-4d56-b487-7bea6fc85c07",
+        "variante": 3
+      },
+      "titulo": "An Oil painting of a surreal world a",
+      "alt": "An Oil painting of a surreal world a white rabbit with red ey",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4c4237",
+      "generacion": "a8c27f5c-4331-4d56-b487-7bea6fc85c07"
+    },
+    {
+      "slug": "an-oil-painting-of-an-artificial-creature-with-174e70bc-0",
+      "serie": "archivo",
+      "orden": 123,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "an oil painting of an artificial creature with blue clothing",
+        "generacion": "174e70bc-915f-4c5c-b5f9-1ec96a105387",
+        "variante": 0
+      },
+      "titulo": "An oil painting of an artificial creature with",
+      "alt": "an oil painting of an artificial creature with blue clothing",
+      "w": 1024,
+      "h": 1120,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#355b8b",
+      "generacion": "174e70bc-915f-4c5c-b5f9-1ec96a105387"
+    },
+    {
+      "slug": "ancient-arawak-symbol-of-buchibe-ac0acb64-3",
+      "serie": "archivo",
+      "orden": 124,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ancient Arawak Symbol of Buchibe --sref",
+        "generacion": "ac0acb64-7a6a-458a-af42-41163c998f79",
+        "variante": 3
+      },
+      "titulo": "Ancient Arawak Symbol of Buchibe",
+      "alt": "Ancient Arawak Symbol of Buchibe",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#0f1c48",
+      "generacion": "ac0acb64-7a6a-458a-af42-41163c998f79"
+    },
+    {
+      "slug": "ancient-mayan-symbol-of-buchibe-0f6a3f01-0",
+      "serie": "archivo",
+      "orden": 125,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ancient Mayan Symbol of Buchibe --sref",
+        "generacion": "0f6a3f01-25a0-465e-9407-371700aff702",
+        "variante": 0
+      },
+      "titulo": "Ancient Mayan Symbol of Buchibe",
+      "alt": "Ancient Mayan Symbol of Buchibe",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1d1c3e",
+      "generacion": "0f6a3f01-25a0-465e-9407-371700aff702"
+    },
+    {
+      "slug": "anthropomorfic-capybara-in-a-funky-70s-attire-fr-3eee0cc1-1",
+      "serie": "archivo",
+      "orden": 126,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+        "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
+        "variante": 1
+      },
+      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
+      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f384a",
+      "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f"
+    },
+    {
+      "slug": "anthropomorfic-capybara-in-a-funky-70s-attire-fr-3eee0cc1-2",
+      "serie": "archivo",
+      "orden": 127,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+        "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
+        "variante": 2
+      },
+      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
+      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#36373f",
+      "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f"
+    },
+    {
+      "slug": "anthropomorfic-capybara-in-a-funky-70s-attire-fr-3eee0cc1-3",
+      "serie": "archivo",
+      "orden": 128,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+        "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
+        "variante": 3
+      },
+      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
+      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#33363b",
+      "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f"
+    },
+    {
+      "slug": "anthropomorfic-capybara-in-a-funky-70s-attire-wi-c77d28f5-3",
+      "serie": "archivo",
+      "orden": 129,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Anthropomorfic capybara in a funky 70s attire with grovvy gla",
+        "generacion": "c77d28f5-80cd-400c-a21c-6417815935c0",
+        "variante": 3
+      },
+      "titulo": "Anthropomorfic capybara in a funky 70s attire with",
+      "alt": "Anthropomorfic capybara in a funky 70s attire with grovvy gla",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2b342e",
+      "generacion": "c77d28f5-80cd-400c-a21c-6417815935c0"
+    },
+    {
+      "slug": "artwork-cover-featuring-an-orchestra-5a42a435-2",
+      "serie": "archivo",
+      "orden": 130,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "artwork cover featuring an orchestra",
+        "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c",
+        "variante": 2
+      },
+      "titulo": "Artwork cover featuring an orchestra",
+      "alt": "artwork cover featuring an orchestra",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#514539",
+      "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c"
+    },
+    {
+      "slug": "artwork-cover-featuring-an-orchestra-5a42a435-3",
+      "serie": "archivo",
+      "orden": 131,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "artwork cover featuring an orchestra",
+        "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c",
+        "variante": 3
+      },
+      "titulo": "Artwork cover featuring an orchestra",
+      "alt": "artwork cover featuring an orchestra",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#453325",
+      "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c"
+    },
+    {
+      "slug": "award-winning-logo-design-for-curian-bd400d8d-3",
+      "serie": "archivo",
+      "orden": 132,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Award winning logo design for Curian",
+        "generacion": "bd400d8d-2d50-420b-9486-27ac98513ae1",
+        "variante": 3
+      },
+      "titulo": "Award winning logo design for Curian",
+      "alt": "Award winning logo design for Curian",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#c9c9c8",
+      "generacion": "bd400d8d-2d50-420b-9486-27ac98513ae1"
+    },
+    {
+      "slug": "aztec-ritual-7ca5a234-0",
+      "serie": "archivo",
+      "orden": 133,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Aztec Ritual --sref --v 6",
+        "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
+        "variante": 0
+      },
+      "titulo": "Aztec Ritual",
+      "alt": "Aztec Ritual",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#b8ab8c",
+      "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1"
+    },
+    {
+      "slug": "aztec-ritual-7ca5a234-1",
+      "serie": "archivo",
+      "orden": 134,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Aztec Ritual --sref --v 6",
+        "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
+        "variante": 1
+      },
+      "titulo": "Aztec Ritual",
+      "alt": "Aztec Ritual",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#a79a84",
+      "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1"
+    },
+    {
+      "slug": "aztec-ritual-7ca5a234-3",
+      "serie": "archivo",
+      "orden": 135,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Aztec Ritual --sref --v 6",
+        "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
+        "variante": 3
+      },
+      "titulo": "Aztec Ritual",
+      "alt": "Aztec Ritual",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#b09e7f",
+      "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1"
+    },
+    {
+      "slug": "belorus-benthicus-perched-on-the-top-of-cactus-054efa4b-3",
+      "serie": "archivo",
+      "orden": 136,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "belorus benthicus perched on the top of cactus in the style o",
+        "generacion": "054efa4b-83ab-4a07-b154-fcd2ef38b3a7",
+        "variante": 3
+      },
+      "titulo": "Belorus benthicus perched on the top of cactus",
+      "alt": "belorus benthicus perched on the top of cactus in the style o",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#545b4d",
+      "generacion": "054efa4b-83ab-4a07-b154-fcd2ef38b3a7"
+    },
+    {
+      "slug": "birds-eye-view-of-simn-bolvar-in-his-79d21059-2",
+      "serie": "archivo",
+      "orden": 137,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+        "generacion": "79d21059-fc90-4232-85cd-034190ca90b2",
+        "variante": 2
+      },
+      "titulo": "Birds Eye View of Simn Bolvar in his",
+      "alt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+      "w": 768,
+      "h": 512,
+      "anchos": [
+        400,
+        768
+      ],
+      "color": "#31433f",
+      "generacion": "79d21059-fc90-4232-85cd-034190ca90b2"
+    },
+    {
+      "slug": "birds-eye-view-of-simn-bolvar-in-his-f25b94cb-0",
+      "serie": "archivo",
+      "orden": 138,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+        "generacion": "f25b94cb-6c1c-4589-82d8-fbd36b9b9e64",
+        "variante": 0
+      },
+      "titulo": "Birds Eye View of Simn Bolvar in his",
+      "alt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+      "w": 1400,
+      "h": 933,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2c3b3c",
+      "generacion": "f25b94cb-6c1c-4589-82d8-fbd36b9b9e64"
+    },
+    {
+      "slug": "black-and-white-photo-of-an-albino-african-2336f400-0",
+      "serie": "archivo",
+      "orden": 139,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "black and white photo of an albino african man with short hai",
+        "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db",
+        "variante": 0
+      },
+      "titulo": "Black and white photo of an albino african",
+      "alt": "black and white photo of an albino african man with short hai",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#212121",
+      "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db"
+    },
+    {
+      "slug": "black-and-white-photo-of-an-albino-african-2336f400-3",
+      "serie": "archivo",
+      "orden": 140,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "black and white photo of an albino african man with short hai",
+        "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db",
+        "variante": 3
+      },
+      "titulo": "Black and white photo of an albino african",
+      "alt": "black and white photo of an albino african man with short hai",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#212120",
+      "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db"
+    },
+    {
+      "slug": "black-and-white-photography-of-young-black-man-97ee7a87-3",
+      "serie": "archivo",
+      "orden": 141,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "black and white photography of young black man with short cur",
+        "generacion": "97ee7a87-27e9-461f-a72a-582039698f83",
+        "variante": 3
+      },
+      "titulo": "Black and white photography of young black man",
+      "alt": "black and white photography of young black man with short cur",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#919190",
+      "generacion": "97ee7a87-27e9-461f-a72a-582039698f83"
+    },
+    {
+      "slug": "black-woman-with-short-blonde-hair-side-view-da806bcd-0",
+      "serie": "archivo",
+      "orden": 142,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "black woman with short blonde hair side view black t shirt an",
+        "generacion": "da806bcd-b383-4779-b92f-78ac33cf1a54",
+        "variante": 0
+      },
+      "titulo": "Black woman with short blonde hair side view",
+      "alt": "black woman with short blonde hair side view black t shirt an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5e9153",
+      "generacion": "da806bcd-b383-4779-b92f-78ac33cf1a54"
+    },
+    {
+      "slug": "blue-chivo-arawak-chaman-pixel-art-s-c6cc4308-1",
+      "serie": "archivo",
+      "orden": 143,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Blue chivo arawak chaman pixel art s",
+        "generacion": "c6cc4308-0a06-427a-9f0e-17652ea0769d",
+        "variante": 1
+      },
+      "titulo": "Blue chivo arawak chaman pixel art s",
+      "alt": "Blue chivo arawak chaman pixel art s",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#625641",
+      "generacion": "c6cc4308-0a06-427a-9f0e-17652ea0769d"
+    },
+    {
+      "slug": "blue-chivo-arawak-chaman-pixel-art-s-fef0cd6f-1",
+      "serie": "archivo",
+      "orden": 144,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Blue chivo arawak chaman pixel art s",
+        "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3",
+        "variante": 1
+      },
+      "titulo": "Blue chivo arawak chaman pixel art s",
+      "alt": "Blue chivo arawak chaman pixel art s",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#a69451",
+      "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3"
+    },
+    {
+      "slug": "blue-chivo-arawak-chaman-pixel-art-s-fef0cd6f-2",
+      "serie": "archivo",
+      "orden": 145,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Blue chivo arawak chaman pixel art s",
+        "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3",
+        "variante": 2
+      },
+      "titulo": "Blue chivo arawak chaman pixel art s",
+      "alt": "Blue chivo arawak chaman pixel art s",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#8f8363",
+      "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3"
+    },
+    {
+      "slug": "blue-orange-and-yellow-lines-in-water-at-9b658c20-0",
+      "serie": "archivo",
+      "orden": 146,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "blue orange and yellow lines in water at sunset in the style",
+        "generacion": "9b658c20-a0a5-4f49-b4b0-cbe3beb2b39e",
+        "variante": 0
+      },
+      "titulo": "Blue orange and yellow lines in water at",
+      "alt": "blue orange and yellow lines in water at sunset in the style",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#835975",
+      "generacion": "9b658c20-a0a5-4f49-b4b0-cbe3beb2b39e"
+    },
+    {
+      "slug": "blurry-surreal-photograph-of-a-white-unicorn-gal-dd18d582-2",
+      "serie": "archivo",
+      "orden": 147,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Blurry surreal photograph of a white unicorn galloping in a d",
+        "generacion": "dd18d582-6646-4235-a676-0fc241cf7365",
+        "variante": 2
+      },
+      "titulo": "Blurry surreal photograph of a white unicorn galloping",
+      "alt": "Blurry surreal photograph of a white unicorn galloping in a d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5d8077",
+      "generacion": "dd18d582-6646-4235-a676-0fc241cf7365"
+    },
+    {
+      "slug": "blurry-surreal-wide-photo-of-a-white-unicorn-7cba75b2-0",
+      "serie": "archivo",
+      "orden": 148,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Blurry surreal wide photo of a white unicorn galloping in a d",
+        "generacion": "7cba75b2-d685-47b8-b31f-ba0779090720",
+        "variante": 0
+      },
+      "titulo": "Blurry surreal wide photo of a white unicorn",
+      "alt": "Blurry surreal wide photo of a white unicorn galloping in a d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#625b54",
+      "generacion": "7cba75b2-d685-47b8-b31f-ba0779090720"
+    },
+    {
+      "slug": "booming-market-in-stilt-city-over-crystal-clear-6c23226c-2",
+      "serie": "archivo",
+      "orden": 149,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Booming market in stilt city over crystal-clear turquoise wat",
+        "generacion": "6c23226c-2d63-426e-a047-a7ff61b9bf4a",
+        "variante": 2
+      },
+      "titulo": "Booming market in stilt city over crystal-clear turquoise",
+      "alt": "Booming market in stilt city over crystal-clear turquoise wat",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#42525b",
+      "generacion": "6c23226c-2d63-426e-a047-a7ff61b9bf4a"
+    },
+    {
+      "slug": "both-men-are-dressed-in-medieval-costume-in-8622bb83-1",
+      "serie": "archivo",
+      "orden": 150,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "both men are dressed in medieval costume in the style of movi",
+        "generacion": "8622bb83-1a57-4bc7-85c7-b7a2531db86b",
+        "variante": 1
+      },
+      "titulo": "Both men are dressed in medieval costume in",
+      "alt": "both men are dressed in medieval costume in the style of movi",
+      "w": 1360,
+      "h": 880,
+      "anchos": [
+        400,
+        800,
+        1360
+      ],
+      "color": "#5e5d69",
+      "generacion": "8622bb83-1a57-4bc7-85c7-b7a2531db86b"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-05511883-0",
+      "serie": "archivo",
+      "orden": 151,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "05511883-87be-47a2-af4f-422dfaaee9bd",
+        "variante": 0
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#473533",
+      "generacion": "05511883-87be-47a2-af4f-422dfaaee9bd"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-14606671-3",
+      "serie": "archivo",
+      "orden": 152,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "14606671-5fe6-4f28-b50a-c5fb3ae1ddfd",
+        "variante": 3
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4a516f",
+      "generacion": "14606671-5fe6-4f28-b50a-c5fb3ae1ddfd"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-22d6874b-1",
+      "serie": "archivo",
+      "orden": 153,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "22d6874b-3c5b-412a-8427-28f51258a856",
+        "variante": 1
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5c505c",
+      "generacion": "22d6874b-3c5b-412a-8427-28f51258a856"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-22d6874b-3",
+      "serie": "archivo",
+      "orden": 154,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "22d6874b-3c5b-412a-8427-28f51258a856",
+        "variante": 3
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#353f5f",
+      "generacion": "22d6874b-3c5b-412a-8427-28f51258a856"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-52ff9540-2",
+      "serie": "archivo",
+      "orden": 155,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "52ff9540-8b71-442f-999c-3a252d46d30b",
+        "variante": 2
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5c342b",
+      "generacion": "52ff9540-8b71-442f-999c-3a252d46d30b"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-6d81203d-3",
+      "serie": "archivo",
+      "orden": 156,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "6d81203d-f4db-48f3-8362-dc02a669518c",
+        "variante": 3
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2a4067",
+      "generacion": "6d81203d-f4db-48f3-8362-dc02a669518c"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-6f2101fe-1",
+      "serie": "archivo",
+      "orden": 157,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "6f2101fe-8fe8-4add-a4a2-efc25fb1cd95",
+        "variante": 1
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#31376b",
+      "generacion": "6f2101fe-8fe8-4add-a4a2-efc25fb1cd95"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-8a9ca760-2",
+      "serie": "archivo",
+      "orden": 158,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "8a9ca760-0b5c-4c52-ac64-b7df1e7f418d",
+        "variante": 2
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#304463",
+      "generacion": "8a9ca760-0b5c-4c52-ac64-b7df1e7f418d"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-9a8ef513-0",
+      "serie": "archivo",
+      "orden": 159,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "9a8ef513-4b66-4f26-b64c-e1cc6feeefb2",
+        "variante": 0
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#23476c",
+      "generacion": "9a8ef513-4b66-4f26-b64c-e1cc6feeefb2"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-9f12fb2a-0",
+      "serie": "archivo",
+      "orden": 160,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666",
+        "variante": 0
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#32334c",
+      "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666"
+    },
+    {
+      "slug": "buchibe-the-last-manaure-of-the-caquetios-son-9f12fb2a-3",
+      "serie": "archivo",
+      "orden": 161,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+        "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666",
+        "variante": 3
+      },
+      "titulo": "Buchibe the last Manaure of the Caquetios Son",
+      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3b3e4f",
+      "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666"
+    },
+    {
+      "slug": "c-beams-glittering-in-the-dark-in-deep-6450fa89-0",
+      "serie": "archivo",
+      "orden": 162,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "C Beams glittering in the dark in deep space near the Tannhau",
+        "generacion": "6450fa89-dc6c-40b3-955d-48f95eb13340",
+        "variante": 0
+      },
+      "titulo": "C Beams glittering in the dark in deep",
+      "alt": "C Beams glittering in the dark in deep space near the Tannhau",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#1c323d",
+      "generacion": "6450fa89-dc6c-40b3-955d-48f95eb13340"
+    },
+    {
+      "slug": "cachicamo-diciendole-al-morrocoy-conchuo-0df2e34e-0",
+      "serie": "archivo",
+      "orden": 163,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cachicamo diciendole al morrocoy conchuo --v 3",
+        "generacion": "0df2e34e-44a6-4bbf-b1c4-5c7269da9804",
+        "variante": 0
+      },
+      "titulo": "Cachicamo diciendole al morrocoy conchuo",
+      "alt": "cachicamo diciendole al morrocoy conchuo",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4c6659",
+      "generacion": "0df2e34e-44a6-4bbf-b1c4-5c7269da9804"
+    },
+    {
+      "slug": "cachicamo-diciendole-al-morrocoy-conchuo-4cf50304-0",
+      "serie": "archivo",
+      "orden": 164,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cachicamo diciendole al morrocoy conchuo --v 3",
+        "generacion": "4cf50304-c39e-4cb0-944c-aae41383cc24",
+        "variante": 0
+      },
+      "titulo": "Cachicamo diciendole al morrocoy conchuo",
+      "alt": "cachicamo diciendole al morrocoy conchuo",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#a83920",
+      "generacion": "4cf50304-c39e-4cb0-944c-aae41383cc24"
+    },
+    {
+      "slug": "character-walking-in-the-street-in-paraguan-with-6c27f1b0-1",
+      "serie": "archivo",
+      "orden": 165,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "character walking in the street in Paraguan with an oil refin",
+        "generacion": "6c27f1b0-1687-49bd-82c5-17befd1d10a3",
+        "variante": 1
+      },
+      "titulo": "Character walking in the street in Paraguan with",
+      "alt": "character walking in the street in Paraguan with an oil refin",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#546d6f",
+      "generacion": "6c27f1b0-1687-49bd-82c5-17befd1d10a3"
+    },
+    {
+      "slug": "character-walking-in-the-street-slice-of-life-32b747d9-0",
+      "serie": "archivo",
+      "orden": 166,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "character walking in the street Slice of life in Paraguan --",
+        "generacion": "32b747d9-25c4-4b65-a621-8f7a2d575d15",
+        "variante": 0
+      },
+      "titulo": "Character walking in the street Slice of life",
+      "alt": "character walking in the street Slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#43534d",
+      "generacion": "32b747d9-25c4-4b65-a621-8f7a2d575d15"
+    },
+    {
+      "slug": "cimatica-tambor",
+      "titulo": "Cimática del tambor",
+      "alt": "Primer plano de arena vibrando sobre la piel de un tambor, formando figuras geométricas concéntricas bajo luz tenue.",
+      "serie": "umbral",
+      "orden": 167,
+      "estado": "pendiente",
+      "tags": [
+        "abstracto",
+        "sonido",
+        "textura"
+      ],
+      "licencia": "cc-by-nc",
+      "w": null,
+      "h": null,
+      "anchos": [],
+      "color": "#4f3e35",
+      "concepto": "Textura abstracta. Arena vibrando sobre una membrana de tambor hasta formar patrones geométricos exactos. Iluminación tenue e íntima: bioluminiscencia o vela.",
+      "anio": 2025,
+      "licenciaDetalle": {
+        "tipo": "cc-by-nc",
+        "print": true
+      },
+      "procedencia": {
+        "herramienta": "Midjourney"
+      },
+      "edicion": "01"
+    },
+    {
+      "slug": "cinematic-m-2e8f16ba-3",
+      "serie": "archivo",
+      "orden": 168,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cinematic M",
+        "generacion": "2e8f16ba-5e70-402d-a3f2-17fee4edebad",
+        "variante": 3
+      },
+      "titulo": "Cinematic M",
+      "alt": "Cinematic M",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#a59085",
+      "generacion": "2e8f16ba-5e70-402d-a3f2-17fee4edebad"
+    },
+    {
+      "slug": "cinematic-m-3f6aebe8-0",
+      "serie": "archivo",
+      "orden": 169,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cinematic M",
+        "generacion": "3f6aebe8-561e-4e69-a4c6-ee352e6c6c41",
+        "variante": 0
+      },
+      "titulo": "Cinematic M",
+      "alt": "Cinematic M",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#71819f",
+      "generacion": "3f6aebe8-561e-4e69-a4c6-ee352e6c6c41"
+    },
+    {
+      "slug": "cinematic-m-8d56dec9-0",
+      "serie": "archivo",
+      "orden": 170,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cinematic M",
+        "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d",
+        "variante": 0
+      },
+      "titulo": "Cinematic M",
+      "alt": "Cinematic M",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#84776d",
+      "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d"
+    },
+    {
+      "slug": "cinematic-m-8d56dec9-3",
+      "serie": "archivo",
+      "orden": 171,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cinematic M",
+        "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d",
+        "variante": 3
+      },
+      "titulo": "Cinematic M",
+      "alt": "Cinematic M",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#7d7d80",
+      "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d"
+    },
+    {
+      "slug": "close-up-po-ee43ad82-0",
+      "serie": "archivo",
+      "orden": 172,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Close-up po",
+        "generacion": "ee43ad82-05b0-4cd3-8683-dd06bdbd106b",
+        "variante": 0
+      },
+      "titulo": "Close-up po",
+      "alt": "Close-up po",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#596452",
+      "generacion": "ee43ad82-05b0-4cd3-8683-dd06bdbd106b"
+    },
+    {
+      "slug": "close-up-portrait-cinematic-lighting-of-an-andro-184d0463-3",
+      "serie": "archivo",
+      "orden": 173,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Close-up portrait cinematic lighting of an androgynous digita",
+        "generacion": "184d0463-dd38-4ea9-82f0-fa146d883b05",
+        "variante": 3
+      },
+      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
+      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4b443f",
+      "generacion": "184d0463-dd38-4ea9-82f0-fa146d883b05"
+    },
+    {
+      "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-0",
+      "serie": "archivo",
+      "orden": 174,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Close-up portrait cinematic lighting of an androgynous digita",
+        "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
+        "variante": 0
+      },
+      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
+      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#065a54",
+      "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128"
+    },
+    {
+      "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-1",
+      "serie": "archivo",
+      "orden": 175,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Close-up portrait cinematic lighting of an androgynous digita",
+        "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
+        "variante": 1
+      },
+      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
+      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3a4b3d",
+      "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128"
+    },
+    {
+      "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-3",
+      "serie": "archivo",
+      "orden": 176,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Close-up portrait cinematic lighting of an androgynous digita",
+        "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
+        "variante": 3
+      },
+      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
+      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2d4e44",
+      "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128"
+    },
+    {
+      "slug": "coastal-waters-of-guinea-bissau-late-autumn-of-1-126fa0e0-0",
+      "serie": "archivo",
+      "orden": 177,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Coastal waters of Guinea-Bissau late autumn of 1467 during th",
+        "generacion": "126fa0e0-7b25-4468-91c0-53d4ae46ee94",
+        "variante": 0
+      },
+      "titulo": "Coastal waters of Guinea-Bissau late autumn of 1467",
+      "alt": "Coastal waters of Guinea-Bissau late autumn of 1467 during th",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#5a6050",
+      "generacion": "126fa0e0-7b25-4468-91c0-53d4ae46ee94"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-27e6053b-2",
+      "serie": "archivo",
+      "orden": 178,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "27e6053b-67c9-49d4-9f2e-1361212f413d",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#715e7a",
+      "generacion": "27e6053b-67c9-49d4-9f2e-1361212f413d"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-0",
+      "serie": "archivo",
+      "orden": 179,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
+        "variante": 0
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#955a64",
+      "generacion": "343ba58e-faa2-4504-b72f-60978f802834"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-1",
+      "serie": "archivo",
+      "orden": 180,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
+        "variante": 1
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#d8c5c3",
+      "generacion": "343ba58e-faa2-4504-b72f-60978f802834"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-2",
+      "serie": "archivo",
+      "orden": 181,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#b58990",
+      "generacion": "343ba58e-faa2-4504-b72f-60978f802834"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-3",
+      "serie": "archivo",
+      "orden": 182,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
+        "variante": 3
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#c98e72",
+      "generacion": "343ba58e-faa2-4504-b72f-60978f802834"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-464708df-2",
+      "serie": "archivo",
+      "orden": 183,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#9f9192",
+      "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-464708df-3",
+      "serie": "archivo",
+      "orden": 184,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f",
+        "variante": 3
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#818087",
+      "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-0",
+      "serie": "archivo",
+      "orden": 185,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
+        "variante": 0
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#837a85",
+      "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-1",
+      "serie": "archivo",
+      "orden": 186,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
+        "variante": 1
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8b9287",
+      "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-2",
+      "serie": "archivo",
+      "orden": 187,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#645f6e",
+      "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-3",
+      "serie": "archivo",
+      "orden": 188,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
+        "variante": 3
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3c2358",
+      "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-0",
+      "serie": "archivo",
+      "orden": 189,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
+        "variante": 0
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7980a0",
+      "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-2",
+      "serie": "archivo",
+      "orden": 190,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#60697e",
+      "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-3",
+      "serie": "archivo",
+      "orden": 191,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
+        "variante": 3
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#546147",
+      "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-96e5f65a-0",
+      "serie": "archivo",
+      "orden": 192,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "96e5f65a-0c0c-455b-97f9-e85c35b05a81",
+        "variante": 0
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#767f9b",
+      "generacion": "96e5f65a-0c0c-455b-97f9-e85c35b05a81"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-1",
+      "serie": "archivo",
+      "orden": 193,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
+        "variante": 1
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#795f4c",
+      "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-2",
+      "serie": "archivo",
+      "orden": 194,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
+        "variante": 2
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7685a0",
+      "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a"
+    },
+    {
+      "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-3",
+      "serie": "archivo",
+      "orden": 195,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "color field painting in the style of uhd image interference p",
+        "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
+        "variante": 3
+      },
+      "titulo": "Color field painting in the style of uhd",
+      "alt": "color field painting in the style of uhd image interference p",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6e6c7b",
+      "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-0",
+      "serie": "archivo",
+      "orden": 196,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
+        "variante": 0
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#323b36",
+      "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-1",
+      "serie": "archivo",
+      "orden": 197,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
+        "variante": 1
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#213431",
+      "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-2",
+      "serie": "archivo",
+      "orden": 198,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
+        "variante": 2
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#203337",
+      "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-3",
+      "serie": "archivo",
+      "orden": 199,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
+        "variante": 3
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#444132",
+      "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-7616fd8f-0",
+      "serie": "archivo",
+      "orden": 200,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d",
+        "variante": 0
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f3b37",
+      "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-7616fd8f-3",
+      "serie": "archivo",
+      "orden": 201,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d",
+        "variante": 3
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#34341f",
+      "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-8591efc0-0",
+      "serie": "archivo",
+      "orden": 202,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
+        "variante": 0
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#253b37",
+      "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-8591efc0-1",
+      "serie": "archivo",
+      "orden": 203,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
+        "variante": 1
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#34443b",
+      "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-8591efc0-3",
+      "serie": "archivo",
+      "orden": 204,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
+        "variante": 3
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#364034",
+      "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-ae1161b5-0",
+      "serie": "archivo",
+      "orden": 205,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340",
+        "variante": 0
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#273336",
+      "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-ae1161b5-3",
+      "serie": "archivo",
+      "orden": 206,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340",
+        "variante": 3
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#31372f",
+      "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340"
+    },
+    {
+      "slug": "cover-art-with-two-people-looking-at-each-d56fb0ea-1",
+      "serie": "archivo",
+      "orden": 207,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Cover art with Two people looking at each other with tenderne",
+        "generacion": "d56fb0ea-6841-4d6c-91ae-7ea18ef9adfb",
+        "variante": 1
+      },
+      "titulo": "Cover art with Two people looking at each",
+      "alt": "Cover art with Two people looking at each other with tenderne",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f4277",
+      "generacion": "d56fb0ea-6841-4d6c-91ae-7ea18ef9adfb"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-sty-302a7fe7-1",
+      "serie": "archivo",
+      "orden": 208,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the sty",
+        "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761",
+        "variante": 1
+      },
+      "titulo": "Cover of time travelers 7 in the sty",
+      "alt": "cover of time travelers 7 in the sty",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#716e6b",
+      "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-sty-302a7fe7-3",
+      "serie": "archivo",
+      "orden": 209,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the sty",
+        "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761",
+        "variante": 3
+      },
+      "titulo": "Cover of time travelers 7 in the sty",
+      "alt": "cover of time travelers 7 in the sty",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#62686b",
+      "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-sty-9d149f76-0",
+      "serie": "archivo",
+      "orden": 210,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the sty",
+        "generacion": "9d149f76-bc15-4c35-999d-a52019a7f4d3",
+        "variante": 0
+      },
+      "titulo": "Cover of time travelers 7 in the sty",
+      "alt": "cover of time travelers 7 in the sty",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#6f6e78",
+      "generacion": "9d149f76-bc15-4c35-999d-a52019a7f4d3"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-sty-e48ca045-1",
+      "serie": "archivo",
+      "orden": 211,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the sty",
+        "generacion": "e48ca045-fc47-45f1-9b66-2c02f99638f2",
+        "variante": 1
+      },
+      "titulo": "Cover of time travelers 7 in the sty",
+      "alt": "cover of time travelers 7 in the sty",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#756567",
+      "generacion": "e48ca045-fc47-45f1-9b66-2c02f99638f2"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-style-0e4afe5c-0",
+      "serie": "archivo",
+      "orden": 212,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the style of bruce pennington co",
+        "generacion": "0e4afe5c-395b-4d44-940d-ea89fcbfa9f7",
+        "variante": 0
+      },
+      "titulo": "Cover of time travelers 7 in the style",
+      "alt": "cover of time travelers 7 in the style of bruce pennington co",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#796e7b",
+      "generacion": "0e4afe5c-395b-4d44-940d-ea89fcbfa9f7"
+    },
+    {
+      "slug": "cover-of-time-travelers-7-in-the-style-9e7f44fc-1",
+      "serie": "archivo",
+      "orden": 213,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cover of time travelers 7 in the style of bruce pennington co",
+        "generacion": "9e7f44fc-1cdf-41ab-8995-78f74351b74c",
+        "variante": 1
+      },
+      "titulo": "Cover of time travelers 7 in the style",
+      "alt": "cover of time travelers 7 in the style of bruce pennington co",
+      "w": 1152,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1152
+      ],
+      "color": "#626f60",
+      "generacion": "9e7f44fc-1cdf-41ab-8995-78f74351b74c"
+    },
+    {
+      "slug": "cryochamber-where-intergalactic-trav-ba42f980-1",
+      "serie": "archivo",
+      "orden": 214,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cryochamber where intergalactic trav",
+        "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad",
+        "variante": 1
+      },
+      "titulo": "Cryochamber where intergalactic trav",
+      "alt": "cryochamber where intergalactic trav",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#26333b",
+      "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad"
+    },
+    {
+      "slug": "cryochamber-where-intergalactic-trav-ba42f980-3",
+      "serie": "archivo",
+      "orden": 215,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cryochamber where intergalactic trav",
+        "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad",
+        "variante": 3
+      },
+      "titulo": "Cryochamber where intergalactic trav",
+      "alt": "cryochamber where intergalactic trav",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#252d34",
+      "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad"
+    },
+    {
+      "slug": "cryochamber-where-intergalactic-travelers-enter-80bc2cc7-0",
+      "serie": "archivo",
+      "orden": 216,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cryochamber where intergalactic travelers enter cryosleep --s",
+        "generacion": "80bc2cc7-99ed-4f08-800c-47331f938989",
+        "variante": 0
+      },
+      "titulo": "Cryochamber where intergalactic travelers enter cryosleep",
+      "alt": "cryochamber where intergalactic travelers enter cryosleep",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#405656",
+      "generacion": "80bc2cc7-99ed-4f08-800c-47331f938989"
+    },
+    {
+      "slug": "cs65c-8bit-halftone-screen-with-the-word-p-6cfce9ea-0",
+      "serie": "archivo",
+      "orden": 217,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cs65c 8bit halftone screen with the word P",
+        "generacion": "6cfce9ea-3392-4f26-b8ca-57745e7d25e6",
+        "variante": 0
+      },
+      "titulo": "Cs65c 8bit halftone screen with the word P",
+      "alt": "cs65c 8bit halftone screen with the word P",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5e554a",
+      "generacion": "6cfce9ea-3392-4f26-b8ca-57745e7d25e6"
+    },
+    {
+      "slug": "cyberpunk-eye-shape-starship-with-a-45c70d99-0",
+      "serie": "archivo",
+      "orden": 218,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cyberpunk eye shape starship with a",
+        "generacion": "45c70d99-40b0-4f92-b873-623759998d5b",
+        "variante": 0
+      },
+      "titulo": "Cyberpunk eye shape starship with a",
+      "alt": "cyberpunk eye shape starship with a",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5e7265",
+      "generacion": "45c70d99-40b0-4f92-b873-623759998d5b"
+    },
+    {
+      "slug": "cydney-parker-photo-by-michael-odet-in-the-f2ca84df-3",
+      "serie": "archivo",
+      "orden": 219,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "cydney parker photo by michael odet in the style of polaroid",
+        "generacion": "f2ca84df-f697-476f-bcc2-e52bb7c12678",
+        "variante": 3
+      },
+      "titulo": "Cydney parker photo by michael odet in the",
+      "alt": "cydney parker photo by michael odet in the style of polaroid",
+      "w": 1024,
+      "h": 1184,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#9d9e7e",
+      "generacion": "f2ca84df-f697-476f-bcc2-e52bb7c12678"
+    },
+    {
+      "slug": "daily-life-in-a-stilt-houses-submerged-in-62ca7a63-0",
+      "serie": "archivo",
+      "orden": 220,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "daily life in a stilt houses submerged in crystal-clear turqu",
+        "generacion": "62ca7a63-2099-4e5b-a1a5-c45f74865cb9",
+        "variante": 0
+      },
+      "titulo": "Daily life in a stilt houses submerged in",
+      "alt": "daily life in a stilt houses submerged in crystal-clear turqu",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#385054",
+      "generacion": "62ca7a63-2099-4e5b-a1a5-c45f74865cb9"
+    },
+    {
+      "slug": "day-in-the-corporate-office-postcard-in-the-5c4f4208-3",
+      "serie": "archivo",
+      "orden": 221,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the corporate office postcard in the style of 1990s ar",
+        "generacion": "5c4f4208-dcc0-421e-8886-8df789e88846",
+        "variante": 3
+      },
+      "titulo": "Day in the corporate office postcard in the",
+      "alt": "Day in the corporate office postcard in the style of 1990s ar",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3d4b47",
+      "generacion": "5c4f4208-dcc0-421e-8886-8df789e88846"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-08b14f56-2",
+      "serie": "archivo",
+      "orden": 222,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "08b14f56-e25a-4e20-85f8-210af594582f",
+        "variante": 2
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#b2b289",
+      "generacion": "08b14f56-e25a-4e20-85f8-210af594582f"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-08b14f56-3",
+      "serie": "archivo",
+      "orden": 223,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "08b14f56-e25a-4e20-85f8-210af594582f",
+        "variante": 3
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#97ae81",
+      "generacion": "08b14f56-e25a-4e20-85f8-210af594582f"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-b9dc5818-2",
+      "serie": "archivo",
+      "orden": 224,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac",
+        "variante": 2
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6f7173",
+      "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-b9dc5818-3",
+      "serie": "archivo",
+      "orden": 225,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac",
+        "variante": 3
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#96828e",
+      "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-e4436906-2",
+      "serie": "archivo",
+      "orden": 226,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33",
+        "variante": 2
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#606955",
+      "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33"
+    },
+    {
+      "slug": "day-in-the-office-room-postcard-in-the-e4436906-3",
+      "serie": "archivo",
+      "orden": 227,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day in the office room postcard in the style of 1990s arawak",
+        "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33",
+        "variante": 3
+      },
+      "titulo": "Day in the office room postcard in the",
+      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#7f644c",
+      "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33"
+    },
+    {
+      "slug": "day-inside-the-corporate-office-room-busy-cubicl-1a592b03-0",
+      "serie": "archivo",
+      "orden": 228,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day inside the corporate office room busy cubicles postcard i",
+        "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1",
+        "variante": 0
+      },
+      "titulo": "Day inside the corporate office room busy cubicles",
+      "alt": "Day inside the corporate office room busy cubicles postcard i",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4e5a42",
+      "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1"
+    },
+    {
+      "slug": "day-inside-the-corporate-office-room-busy-cubicl-1a592b03-1",
+      "serie": "archivo",
+      "orden": 229,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day inside the corporate office room busy cubicles postcard i",
+        "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1",
+        "variante": 1
+      },
+      "titulo": "Day inside the corporate office room busy cubicles",
+      "alt": "Day inside the corporate office room busy cubicles postcard i",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8e8770",
+      "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1"
+    },
+    {
+      "slug": "day-with-the-fishermen-postcard-in-the-style-277187c6-0",
+      "serie": "archivo",
+      "orden": 230,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day with the fishermen postcard in the style of 1500s precolo",
+        "generacion": "277187c6-95dc-4281-bafa-7ef194ed707c",
+        "variante": 0
+      },
+      "titulo": "Day with the fishermen postcard in the style",
+      "alt": "Day with the fishermen postcard in the style of 1500s precolo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#757860",
+      "generacion": "277187c6-95dc-4281-bafa-7ef194ed707c"
+    },
+    {
+      "slug": "day-with-the-fishermen-postcard-in-the-style-2ced6dad-3",
+      "serie": "archivo",
+      "orden": 231,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Day with the fishermen postcard in the style of 1500 arawak s",
+        "generacion": "2ced6dad-12b0-4b9e-9425-bb964b738866",
+        "variante": 3
+      },
+      "titulo": "Day with the fishermen postcard in the style",
+      "alt": "Day with the fishermen postcard in the style of 1500 arawak s",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#35976e",
+      "generacion": "2ced6dad-12b0-4b9e-9425-bb964b738866"
+    },
+    {
+      "slug": "dcxg-a-fishing-b-10246a99-0",
+      "serie": "archivo",
+      "orden": 232,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg a fishing b",
+        "generacion": "10246a99-6fd3-4016-b0de-bb5444638f35",
+        "variante": 0
+      },
+      "titulo": "DCxg a fishing b",
+      "alt": "dCxg a fishing b",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#495e5c",
+      "generacion": "10246a99-6fd3-4016-b0de-bb5444638f35"
+    },
+    {
+      "slug": "dcxg-a-fishing-boat-at-the-distance-in-97fb414d-1",
+      "serie": "archivo",
+      "orden": 233,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg a fishing boat at the distance in a",
+        "generacion": "97fb414d-b33b-446c-90e3-027c379e551d",
+        "variante": 1
+      },
+      "titulo": "DCxg a fishing boat at the distance in",
+      "alt": "dCxg a fishing boat at the distance in a",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7a7e74",
+      "generacion": "97fb414d-b33b-446c-90e3-027c379e551d"
+    },
+    {
+      "slug": "dcxg-a-fishing-boat-at-the-distance-in-a69cc905-0",
+      "serie": "archivo",
+      "orden": 234,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg a fishing boat at the distance in a",
+        "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961",
+        "variante": 0
+      },
+      "titulo": "DCxg a fishing boat at the distance in",
+      "alt": "dCxg a fishing boat at the distance in a",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#827a71",
+      "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961"
+    },
+    {
+      "slug": "dcxg-a-fishing-boat-at-the-distance-in-a69cc905-2",
+      "serie": "archivo",
+      "orden": 235,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg a fishing boat at the distance in a",
+        "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961",
+        "variante": 2
+      },
+      "titulo": "DCxg a fishing boat at the distance in",
+      "alt": "dCxg a fishing boat at the distance in a",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7a888d",
+      "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-06e5aaf4-2",
+      "serie": "archivo",
+      "orden": 236,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "06e5aaf4-1ea3-44bc-91d7-920d3452e256",
+        "variante": 2
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#817d79",
+      "generacion": "06e5aaf4-1ea3-44bc-91d7-920d3452e256"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-0a30f04e-1",
+      "serie": "archivo",
+      "orden": 237,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "0a30f04e-78a6-4e5c-985f-655ab739c62e",
+        "variante": 1
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#575f66",
+      "generacion": "0a30f04e-78a6-4e5c-985f-655ab739c62e"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-12647c4e-3",
+      "serie": "archivo",
+      "orden": 238,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "12647c4e-64ee-4a2a-b1fc-7220bf795702",
+        "variante": 3
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#444949",
+      "generacion": "12647c4e-64ee-4a2a-b1fc-7220bf795702"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-1778e0f7-1",
+      "serie": "archivo",
+      "orden": 239,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "1778e0f7-553c-4eb0-abe9-92a4a8a27ac0",
+        "variante": 1
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6c797a",
+      "generacion": "1778e0f7-553c-4eb0-abe9-92a4a8a27ac0"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-267dff55-2",
+      "serie": "archivo",
+      "orden": 240,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "267dff55-a75d-43b5-a521-9127be73c960",
+        "variante": 2
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#415e80",
+      "generacion": "267dff55-a75d-43b5-a521-9127be73c960"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-3eb12ea5-2",
+      "serie": "archivo",
+      "orden": 241,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "3eb12ea5-29dd-43e1-b5c0-1f62e7305e63",
+        "variante": 2
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4d4b46",
+      "generacion": "3eb12ea5-29dd-43e1-b5c0-1f62e7305e63"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-42234bf1-1",
+      "serie": "archivo",
+      "orden": 242,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "42234bf1-fca8-41a9-aaf3-c5757bd8962f",
+        "variante": 1
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#74796a",
+      "generacion": "42234bf1-fca8-41a9-aaf3-c5757bd8962f"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-4b72baa4-3",
+      "serie": "archivo",
+      "orden": 243,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "4b72baa4-7c2a-485f-94ea-f30001c0b93d",
+        "variante": 3
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5e616b",
+      "generacion": "4b72baa4-7c2a-485f-94ea-f30001c0b93d"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-a9a6e656-0",
+      "serie": "archivo",
+      "orden": 244,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "a9a6e656-d988-4694-b663-a849d0dbe38c",
+        "variante": 0
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5c6d73",
+      "generacion": "a9a6e656-d988-4694-b663-a849d0dbe38c"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-cd08ef79-0",
+      "serie": "archivo",
+      "orden": 245,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "cd08ef79-71af-4bae-b9b9-0df22acdc92a",
+        "variante": 0
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4f7377",
+      "generacion": "cd08ef79-71af-4bae-b9b9-0df22acdc92a"
+    },
+    {
+      "slug": "dcxg-httpss-mj-r-cf10e7cb-0",
+      "serie": "archivo",
+      "orden": 246,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg httpss.mj.r",
+        "generacion": "cf10e7cb-7eaa-46a1-83ed-e648871ae987",
+        "variante": 0
+      },
+      "titulo": "DCxg httpss.mj.r",
+      "alt": "dCxg httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5c596f",
+      "generacion": "cf10e7cb-7eaa-46a1-83ed-e648871ae987"
+    },
+    {
+      "slug": "dcxg-slice-of-li-a404bb2f-3",
+      "serie": "archivo",
+      "orden": 247,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg Slice of li",
+        "generacion": "a404bb2f-3472-4f1f-8f51-6013b90d28c3",
+        "variante": 3
+      },
+      "titulo": "DCxg Slice of li",
+      "alt": "dCxg Slice of li",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4b4d48",
+      "generacion": "a404bb2f-3472-4f1f-8f51-6013b90d28c3"
+    },
+    {
+      "slug": "dcxg-slice-of-li-c08c9837-1",
+      "serie": "archivo",
+      "orden": 248,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg Slice of li",
+        "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed",
+        "variante": 1
+      },
+      "titulo": "DCxg Slice of li",
+      "alt": "dCxg Slice of li",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6d6b66",
+      "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed"
+    },
+    {
+      "slug": "dcxg-slice-of-li-c08c9837-2",
+      "serie": "archivo",
+      "orden": 249,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg Slice of li",
+        "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed",
+        "variante": 2
+      },
+      "titulo": "DCxg Slice of li",
+      "alt": "dCxg Slice of li",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#575953",
+      "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed"
+    },
+    {
+      "slug": "dcxg-slice-of-li-e1ea1286-1",
+      "serie": "archivo",
+      "orden": 250,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg Slice of li",
+        "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c",
+        "variante": 1
+      },
+      "titulo": "DCxg Slice of li",
+      "alt": "dCxg Slice of li",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#817b71",
+      "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c"
+    },
+    {
+      "slug": "dcxg-slice-of-li-e1ea1286-2",
+      "serie": "archivo",
+      "orden": 251,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dCxg Slice of li",
+        "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c",
+        "variante": 2
+      },
+      "titulo": "DCxg Slice of li",
+      "alt": "dCxg Slice of li",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#696f6a",
+      "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c"
+    },
+    {
+      "slug": "de-httpss-mj-r-0952c9b5-1",
+      "serie": "archivo",
+      "orden": 252,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "0952c9b5-b16b-4ddf-b01f-d91c64f6f521",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5e493e",
+      "generacion": "0952c9b5-b16b-4ddf-b01f-d91c64f6f521"
+    },
+    {
+      "slug": "de-httpss-mj-r-50375359-1",
+      "serie": "archivo",
+      "orden": 253,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "50375359-3845-4c4d-b256-7de30465167b",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#7d5525",
+      "generacion": "50375359-3845-4c4d-b256-7de30465167b"
+    },
+    {
+      "slug": "de-httpss-mj-r-5b4b01a8-3",
+      "serie": "archivo",
+      "orden": 254,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "5b4b01a8-3923-4680-a79f-c6804743d68c",
+        "variante": 3
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#60351b",
+      "generacion": "5b4b01a8-3923-4680-a79f-c6804743d68c"
+    },
+    {
+      "slug": "de-httpss-mj-r-7009380c-1",
+      "serie": "archivo",
+      "orden": 255,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "7009380c-fb82-483b-b891-3d3fdb1ee0e0",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5e4333",
+      "generacion": "7009380c-fb82-483b-b891-3d3fdb1ee0e0"
+    },
+    {
+      "slug": "de-httpss-mj-r-a38d24f9-1",
+      "serie": "archivo",
+      "orden": 256,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#73381c",
+      "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f"
+    },
+    {
+      "slug": "de-httpss-mj-r-a38d24f9-2",
+      "serie": "archivo",
+      "orden": 257,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f",
+        "variante": 2
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#775438",
+      "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f"
+    },
+    {
+      "slug": "de-httpss-mj-r-c469a44e-2",
+      "serie": "archivo",
+      "orden": 258,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "c469a44e-2a09-45eb-901c-4b9099ff51d2",
+        "variante": 2
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4d3828",
+      "generacion": "c469a44e-2a09-45eb-901c-4b9099ff51d2"
+    },
+    {
+      "slug": "de-httpss-mj-r-cc75e988-1",
+      "serie": "archivo",
+      "orden": 259,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "cc75e988-f6c0-4d01-8b06-b85c83d2843d",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4a351f",
+      "generacion": "cc75e988-f6c0-4d01-8b06-b85c83d2843d"
+    },
+    {
+      "slug": "de-httpss-mj-r-cebda612-1",
+      "serie": "archivo",
+      "orden": 260,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#261e1d",
+      "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d"
+    },
+    {
+      "slug": "de-httpss-mj-r-cebda612-2",
+      "serie": "archivo",
+      "orden": 261,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d",
+        "variante": 2
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#67341e",
+      "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d"
+    },
+    {
+      "slug": "de-httpss-mj-r-e8e9ea51-2",
+      "serie": "archivo",
+      "orden": 262,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "e8e9ea51-7291-4840-804c-196af43bf704",
+        "variante": 2
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#393425",
+      "generacion": "e8e9ea51-7291-4840-804c-196af43bf704"
+    },
+    {
+      "slug": "de-httpss-mj-r-e8e9ea51-3",
+      "serie": "archivo",
+      "orden": 263,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "e8e9ea51-7291-4840-804c-196af43bf704",
+        "variante": 3
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#393b27",
+      "generacion": "e8e9ea51-7291-4840-804c-196af43bf704"
+    },
+    {
+      "slug": "de-httpss-mj-r-eb39163d-2",
+      "serie": "archivo",
+      "orden": 264,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "eb39163d-402d-4dca-8640-ee9dbbf76c6e",
+        "variante": 2
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#3a291e",
+      "generacion": "eb39163d-402d-4dca-8640-ee9dbbf76c6e"
+    },
+    {
+      "slug": "de-httpss-mj-r-fc90690d-1",
+      "serie": "archivo",
+      "orden": 265,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4",
+        "variante": 1
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4a381f",
+      "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4"
+    },
+    {
+      "slug": "de-httpss-mj-r-fc90690d-3",
+      "serie": "archivo",
+      "orden": 266,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE httpss.mj.r",
+        "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4",
+        "variante": 3
+      },
+      "titulo": "DE httpss.mj.r",
+      "alt": "DE httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#45331b",
+      "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4"
+    },
+    {
+      "slug": "de-retrato-de-02ff3e12-0",
+      "serie": "archivo",
+      "orden": 267,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "DE Retrato de",
+        "generacion": "02ff3e12-d4a6-404f-a962-5335fba9075f",
+        "variante": 0
+      },
+      "titulo": "DE Retrato de",
+      "alt": "DE Retrato de",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#542a0e",
+      "generacion": "02ff3e12-d4a6-404f-a962-5335fba9075f"
+    },
+    {
+      "slug": "did-you-know-that-acuatic-dinosaurs-also-spawn-f1eac6ab-0",
+      "serie": "archivo",
+      "orden": 268,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Did you know that acuatic dinosaurs also spawn eggs just like",
+        "generacion": "f1eac6ab-99e7-476b-b5bf-2bf3f133b35f",
+        "variante": 0
+      },
+      "titulo": "Did you know that acuatic dinosaurs also spawn",
+      "alt": "Did you know that acuatic dinosaurs also spawn eggs just like",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#5d546b",
+      "generacion": "f1eac6ab-99e7-476b-b5bf-2bf3f133b35f"
+    },
+    {
+      "slug": "did-you-know-that-sharks-also-spawn-eggs-5704380b-3",
+      "serie": "archivo",
+      "orden": 269,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Did you know that sharks also spawn eggs just like coral Befo",
+        "generacion": "5704380b-855d-4b39-bd6a-9d40c48e9487",
+        "variante": 3
+      },
+      "titulo": "Did you know that sharks also spawn eggs",
+      "alt": "Did you know that sharks also spawn eggs just like coral Befo",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#5c769c",
+      "generacion": "5704380b-855d-4b39-bd6a-9d40c48e9487"
+    },
+    {
+      "slug": "did-you-know-that-sharks-also-spawn-eggs-81a5d6ea-1",
+      "serie": "archivo",
+      "orden": 270,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Did you know that sharks also spawn eggs just like coral Befo",
+        "generacion": "81a5d6ea-edf0-4ce9-9400-ef48da928f77",
+        "variante": 1
+      },
+      "titulo": "Did you know that sharks also spawn eggs",
+      "alt": "Did you know that sharks also spawn eggs just like coral Befo",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#462654",
+      "generacion": "81a5d6ea-edf0-4ce9-9400-ef48da928f77"
+    },
+    {
+      "slug": "did-you-know-that-starfish-and-brittle-stars-9abaf15c-3",
+      "serie": "archivo",
+      "orden": 271,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Did you know that starfish and brittle stars also spawn eggs",
+        "generacion": "9abaf15c-ed1f-4c45-923f-686b94286024",
+        "variante": 3
+      },
+      "titulo": "Did you know that starfish and brittle stars",
+      "alt": "Did you know that starfish and brittle stars also spawn eggs",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#363036",
+      "generacion": "9abaf15c-ed1f-4c45-923f-686b94286024"
+    },
+    {
+      "slug": "dqcokgi-cinematic-film-photo-close-up-of-per-8477f66b-1",
+      "serie": "archivo",
+      "orden": 272,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "dqCokGI Cinematic film photo close up of per",
+        "generacion": "8477f66b-9307-4e87-ad90-df5f9886a342",
+        "variante": 1
+      },
+      "titulo": "DqCokGI Cinematic film photo close up of per",
+      "alt": "dqCokGI Cinematic film photo close up of per",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#666e70",
+      "generacion": "8477f66b-9307-4e87-ad90-df5f9886a342"
+    },
+    {
+      "slug": "el-regal-este-bolero-lp-remastered-in-the-9793bbf9-0",
+      "serie": "archivo",
+      "orden": 273,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "el regal este bolero lp remastered in the style of playful h",
+        "generacion": "9793bbf9-e5e4-4d42-9c2e-51ed9b344c20",
+        "variante": 0
+      },
+      "titulo": "El regal este bolero lp remastered in the",
+      "alt": "el regal este bolero lp remastered in the style of playful h",
+      "w": 1040,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1040
+      ],
+      "color": "#5e4d39",
+      "generacion": "9793bbf9-e5e4-4d42-9c2e-51ed9b344c20"
+    },
+    {
+      "slug": "el-regal-este-bolero-lp-remastered-in-the-ec6f5647-3",
+      "serie": "archivo",
+      "orden": 274,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "el regal este bolero lp remastered in the style of playful h",
+        "generacion": "ec6f5647-fb21-46d6-937e-b32b1cb2b378",
+        "variante": 3
+      },
+      "titulo": "El regal este bolero lp remastered in the",
+      "alt": "el regal este bolero lp remastered in the style of playful h",
+      "w": 1040,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1040
+      ],
+      "color": "#7c7360",
+      "generacion": "ec6f5647-fb21-46d6-937e-b32b1cb2b378"
+    },
+    {
+      "slug": "elegant-jap-480ff122-2",
+      "serie": "archivo",
+      "orden": 275,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Elegant Jap",
+        "generacion": "480ff122-2425-4608-aa86-2badaf7da22a",
+        "variante": 2
+      },
+      "titulo": "Elegant Jap",
+      "alt": "Elegant Jap",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#354248",
+      "generacion": "480ff122-2425-4608-aa86-2badaf7da22a"
+    },
+    {
+      "slug": "elegant-jap-a3c612f9-2",
+      "serie": "archivo",
+      "orden": 276,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Elegant Jap",
+        "generacion": "a3c612f9-25ed-4108-bdd8-c618f92ea7f7",
+        "variante": 2
+      },
+      "titulo": "Elegant Jap",
+      "alt": "Elegant Jap",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#302b2b",
+      "generacion": "a3c612f9-25ed-4108-bdd8-c618f92ea7f7"
+    },
+    {
+      "slug": "epic-battle-between-aquiles-and-prince-hector-in-df7e0d6d-2",
+      "serie": "archivo",
+      "orden": 277,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Epic battle between Aquiles and Prince Hector in front of the",
+        "generacion": "df7e0d6d-5f03-4ae1-9930-c92cfc4347f0",
+        "variante": 2
+      },
+      "titulo": "Epic battle between Aquiles and Prince Hector in",
+      "alt": "Epic battle between Aquiles and Prince Hector in front of the",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#65685e",
+      "generacion": "df7e0d6d-5f03-4ae1-9930-c92cfc4347f0"
+    },
+    {
+      "slug": "eric-clapton-and-claude-jean-in-elvis-presleys-c451691a-2",
+      "serie": "archivo",
+      "orden": 278,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "eric clapton and claude jean in elvis presleys roman empire i",
+        "generacion": "c451691a-ff3a-4a5d-987f-f116a6b67051",
+        "variante": 2
+      },
+      "titulo": "Eric clapton and claude jean in elvis presleys",
+      "alt": "eric clapton and claude jean in elvis presleys roman empire i",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#829192",
+      "generacion": "c451691a-ff3a-4a5d-987f-f116a6b67051"
+    },
+    {
+      "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-5f57ec01-1",
+      "serie": "archivo",
+      "orden": 279,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+        "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b",
+        "variante": 1
+      },
+      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
+      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1e1509",
+      "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b"
+    },
+    {
+      "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-5f57ec01-3",
+      "serie": "archivo",
+      "orden": 280,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+        "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b",
+        "variante": 3
+      },
+      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
+      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2f1b16",
+      "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b"
+    },
+    {
+      "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-63694911-3",
+      "serie": "archivo",
+      "orden": 281,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+        "generacion": "63694911-9983-4a89-af3b-079745a93293",
+        "variante": 3
+      },
+      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
+      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#63443c",
+      "generacion": "63694911-9983-4a89-af3b-079745a93293"
+    },
+    {
+      "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-7b2c2125-0",
+      "serie": "archivo",
+      "orden": 282,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+        "generacion": "7b2c2125-d97f-43b3-953f-790f9ed4e871",
+        "variante": 0
+      },
+      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
+      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#603a24",
+      "generacion": "7b2c2125-d97f-43b3-953f-790f9ed4e871"
+    },
+    {
+      "slug": "escucha-profunda",
+      "titulo": "Escucha profunda",
+      "alt": "Retrato de perfil de una persona con los ojos cerrados, usando audífonos hechos de madera, conchas y tejido, unidos por hilos de fibra óptica.",
+      "serie": "umbral",
+      "orden": 283,
+      "estado": "pendiente",
+      "tags": [
+        "retrato",
+        "híbrido",
+        "escucha"
+      ],
+      "licencia": "editorial",
+      "w": null,
+      "h": null,
+      "anchos": [],
+      "color": "#4f3e35",
+      "concepto": "Primer plano de perfil. Una figura caquetía contemporánea escucha con los ojos cerrados. Los audífonos son de madera, conchas y tejido, conectados por fibra óptica.",
+      "anio": 2025,
+      "licenciaDetalle": {
+        "tipo": "editorial",
+        "print": false,
+        "notas": "Retrato: revisar derechos antes de cualquier uso comercial."
+      },
+      "procedencia": {
+        "herramienta": "Midjourney"
+      },
+      "edicion": "01"
+    },
+    {
+      "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-26c39d33-0",
+      "serie": "archivo",
+      "orden": 284,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "ethereal vistas from paraguan with indigenous references goat",
+        "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50",
+        "variante": 0
+      },
+      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
+      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#394543",
+      "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50"
+    },
+    {
+      "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-26c39d33-2",
+      "serie": "archivo",
+      "orden": 285,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "ethereal vistas from paraguan with indigenous references goat",
+        "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50",
+        "variante": 2
+      },
+      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
+      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2e3128",
+      "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50"
+    },
+    {
+      "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-1",
+      "serie": "archivo",
+      "orden": 286,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "ethereal vistas from paraguan with indigenous references goat",
+        "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
+        "variante": 1
+      },
+      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
+      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#394253",
+      "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2"
+    },
+    {
+      "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-2",
+      "serie": "archivo",
+      "orden": 287,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "ethereal vistas from paraguan with indigenous references goat",
+        "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
+        "variante": 2
+      },
+      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
+      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3a413d",
+      "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2"
+    },
+    {
+      "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-3",
+      "serie": "archivo",
+      "orden": 288,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "ethereal vistas from paraguan with indigenous references goat",
+        "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
+        "variante": 3
+      },
+      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
+      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#38342d",
+      "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2"
+    },
+    {
+      "slug": "extreme-close-up-on-retro-analog-control-panel-07ee67aa-0",
+      "serie": "archivo",
+      "orden": 289,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "extreme close up on retro analog control panel of Space freig",
+        "generacion": "07ee67aa-4fa8-4a10-9838-95a596d47b8d",
+        "variante": 0
+      },
+      "titulo": "Extreme close up on retro analog control panel",
+      "alt": "extreme close up on retro analog control panel of Space freig",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#252224",
+      "generacion": "07ee67aa-4fa8-4a10-9838-95a596d47b8d"
+    },
+    {
+      "slug": "felix-vallottons-painting-slice-of-life-in-carac-ffd0fd28-0",
+      "serie": "archivo",
+      "orden": 290,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Felix Vallottons painting slice of life in caracas masterpiec",
+        "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9",
+        "variante": 0
+      },
+      "titulo": "Felix Vallottons painting slice of life in caracas",
+      "alt": "Felix Vallottons painting slice of life in caracas masterpiec",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#261f16",
+      "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9"
+    },
+    {
+      "slug": "felix-vallottons-painting-slice-of-life-in-carac-ffd0fd28-3",
+      "serie": "archivo",
+      "orden": 291,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Felix Vallottons painting slice of life in caracas masterpiec",
+        "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9",
+        "variante": 3
+      },
+      "titulo": "Felix Vallottons painting slice of life in caracas",
+      "alt": "Felix Vallottons painting slice of life in caracas masterpiec",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#252823",
+      "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9"
+    },
+    {
+      "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-0",
+      "serie": "archivo",
+      "orden": 292,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+        "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
+        "variante": 0
+      },
+      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#575f5e",
+      "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357"
+    },
+    {
+      "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-1",
+      "serie": "archivo",
+      "orden": 293,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+        "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
+        "variante": 1
+      },
+      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#506b6f",
+      "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357"
+    },
+    {
+      "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-2",
+      "serie": "archivo",
+      "orden": 294,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+        "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
+        "variante": 2
+      },
+      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#606962",
+      "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357"
+    },
+    {
+      "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-3",
+      "serie": "archivo",
+      "orden": 295,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+        "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
+        "variante": 3
+      },
+      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#5c625c",
+      "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357"
+    },
+    {
+      "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-fdc77c5a-2",
+      "serie": "archivo",
+      "orden": 296,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+        "generacion": "fdc77c5a-4f15-40a6-837c-a31ae9a72be9",
+        "variante": 2
+      },
+      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#506268",
+      "generacion": "fdc77c5a-4f15-40a6-837c-a31ae9a72be9"
+    },
+    {
+      "slug": "first-class-spacefreighter-docked-to-02ec42f2-2",
+      "serie": "archivo",
+      "orden": 297,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "first class spacefreighter docked to",
+        "generacion": "02ec42f2-15de-408f-bb9a-2d975935236f",
+        "variante": 2
+      },
+      "titulo": "First class spacefreighter docked to",
+      "alt": "first class spacefreighter docked to",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#cbb59e",
+      "generacion": "02ec42f2-15de-408f-bb9a-2d975935236f"
+    },
+    {
+      "slug": "fishermen-in-a-fishing-boat-at-the-distance-0422a9d1-1",
+      "serie": "archivo",
+      "orden": 298,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Fishermen in a fishing boat at the distance slice of life in",
+        "generacion": "0422a9d1-95bc-4430-a0a2-d80c14ea3de4",
+        "variante": 1
+      },
+      "titulo": "Fishermen in a fishing boat at the distance",
+      "alt": "Fishermen in a fishing boat at the distance slice of life in",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#718186",
+      "generacion": "0422a9d1-95bc-4430-a0a2-d80c14ea3de4"
+    },
+    {
+      "slug": "frank-whittier-on-his-egyptian-expedition-1910-1-12cc7e4a-0",
+      "serie": "archivo",
+      "orden": 299,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "frank whittier on his egyptian expedition 1910 1912 ca 1940 i",
+        "generacion": "12cc7e4a-43b3-4be7-8d9b-ab7439497a96",
+        "variante": 0
+      },
+      "titulo": "Frank whittier on his egyptian expedition 1910 1912",
+      "alt": "frank whittier on his egyptian expedition 1910 1912 ca 1940 i",
+      "w": 1232,
+      "h": 976,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#786a59",
+      "generacion": "12cc7e4a-43b3-4be7-8d9b-ab7439497a96"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-count-1a12a89c-1",
+      "serie": "archivo",
+      "orden": 300,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Front shot Scene of venezuelan count",
+        "generacion": "1a12a89c-2061-43a6-b4c4-a7e3de605ea0",
+        "variante": 1
+      },
+      "titulo": "Front shot Scene of venezuelan count",
+      "alt": "Front shot Scene of venezuelan count",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#645441",
+      "generacion": "1a12a89c-2061-43a6-b4c4-a7e3de605ea0"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-count-4f326c24-1",
+      "serie": "archivo",
+      "orden": 301,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Front shot Scene of venezuelan count",
+        "generacion": "4f326c24-2518-4cad-8ee1-1f5e858b5570",
+        "variante": 1
+      },
+      "titulo": "Front shot Scene of venezuelan count",
+      "alt": "Front shot Scene of venezuelan count",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4c504b",
+      "generacion": "4f326c24-2518-4cad-8ee1-1f5e858b5570"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-country-folk-hors-667b37a5-2",
+      "serie": "archivo",
+      "orden": 302,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "front shot Scene of venezuelan country folk horseman charging",
+        "generacion": "667b37a5-e4aa-40fb-a5df-2778acf8f16e",
+        "variante": 2
+      },
+      "titulo": "Front shot Scene of venezuelan country folk horseman",
+      "alt": "front shot Scene of venezuelan country folk horseman charging",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#745e46",
+      "generacion": "667b37a5-e4aa-40fb-a5df-2778acf8f16e"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-country-folk-hors-8734ce23-3",
+      "serie": "archivo",
+      "orden": 303,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Front shot Scene of venezuelan country folk horseman charging",
+        "generacion": "8734ce23-3746-41c8-b3f1-c54cb7d2c06a",
+        "variante": 3
+      },
+      "titulo": "Front shot Scene of venezuelan country folk horseman",
+      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#7ea3af",
+      "generacion": "8734ce23-3746-41c8-b3f1-c54cb7d2c06a"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-country-folk-hors-e460132f-1",
+      "serie": "archivo",
+      "orden": 304,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Front shot Scene of venezuelan country folk horseman charging",
+        "generacion": "e460132f-3aff-4744-8faf-0de4b9eb51fa",
+        "variante": 1
+      },
+      "titulo": "Front shot Scene of venezuelan country folk horseman",
+      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#795231",
+      "generacion": "e460132f-3aff-4744-8faf-0de4b9eb51fa"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-country-folk-hors-fb9cd5fb-2",
+      "serie": "archivo",
+      "orden": 305,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "front shot Scene of venezuelan country folk horseman charging",
+        "generacion": "fb9cd5fb-197c-4f4d-8afe-a6b86531a03c",
+        "variante": 2
+      },
+      "titulo": "Front shot Scene of venezuelan country folk horseman",
+      "alt": "front shot Scene of venezuelan country folk horseman charging",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#483526",
+      "generacion": "fb9cd5fb-197c-4f4d-8afe-a6b86531a03c"
+    },
+    {
+      "slug": "front-shot-scene-of-venezuelan-country-folk-hors-ffdda037-1",
+      "serie": "archivo",
+      "orden": 306,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Front shot Scene of venezuelan country folk horseman charging",
+        "generacion": "ffdda037-43d4-4abb-9de9-f640a4ce6d8a",
+        "variante": 1
+      },
+      "titulo": "Front shot Scene of venezuelan country folk horseman",
+      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#7ca3b9",
+      "generacion": "ffdda037-43d4-4abb-9de9-f640a4ce6d8a"
+    },
+    {
+      "slug": "full-body-front-shot-portrait-of-a-middle-1c787ec6-3",
+      "serie": "archivo",
+      "orden": 307,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body front shot portrait of a middle aged person who wor",
+        "generacion": "1c787ec6-1db3-4610-b8d9-f33a1b655e7a",
+        "variante": 3
+      },
+      "titulo": "Full body front shot portrait of a middle",
+      "alt": "full body front shot portrait of a middle aged person who wor",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#685e44",
+      "generacion": "1c787ec6-1db3-4610-b8d9-f33a1b655e7a"
+    },
+    {
+      "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-0",
+      "serie": "archivo",
+      "orden": 308,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body front shot portrait of a middle aged person who wor",
+        "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
+        "variante": 0
+      },
+      "titulo": "Full body front shot portrait of a middle",
+      "alt": "full body front shot portrait of a middle aged person who wor",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#3e2d25",
+      "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668"
+    },
+    {
+      "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-2",
+      "serie": "archivo",
+      "orden": 309,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body front shot portrait of a middle aged person who wor",
+        "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
+        "variante": 2
+      },
+      "titulo": "Full body front shot portrait of a middle",
+      "alt": "full body front shot portrait of a middle aged person who wor",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5d473c",
+      "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668"
+    },
+    {
+      "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-3",
+      "serie": "archivo",
+      "orden": 310,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body front shot portrait of a middle aged person who wor",
+        "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
+        "variante": 3
+      },
+      "titulo": "Full body front shot portrait of a middle",
+      "alt": "full body front shot portrait of a middle aged person who wor",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#393c22",
+      "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668"
+    },
+    {
+      "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-1",
+      "serie": "archivo",
+      "orden": 311,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body photography of African teenager with short blonde h",
+        "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
+        "variante": 1
+      },
+      "titulo": "Full body photography of African teenager with short",
+      "alt": "full body photography of African teenager with short blonde h",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#984819",
+      "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5"
+    },
+    {
+      "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-2",
+      "serie": "archivo",
+      "orden": 312,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body photography of African teenager with short blonde h",
+        "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
+        "variante": 2
+      },
+      "titulo": "Full body photography of African teenager with short",
+      "alt": "full body photography of African teenager with short blonde h",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#a92817",
+      "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5"
+    },
+    {
+      "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-3",
+      "serie": "archivo",
+      "orden": 313,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body photography of African teenager with short blonde h",
+        "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
+        "variante": 3
+      },
+      "titulo": "Full body photography of African teenager with short",
+      "alt": "full body photography of African teenager with short blonde h",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#971113",
+      "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5"
+    },
+    {
+      "slug": "full-body-picture-of-a-man-with-a-0dd88675-3",
+      "serie": "archivo",
+      "orden": 314,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body picture of a man with a red and black detailed moor",
+        "generacion": "0dd88675-5599-4da9-a0ee-5c5aa2f5c1c6",
+        "variante": 3
+      },
+      "titulo": "Full body picture of a man with a",
+      "alt": "full body picture of a man with a red and black detailed moor",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4c5d52",
+      "generacion": "0dd88675-5599-4da9-a0ee-5c5aa2f5c1c6"
+    },
+    {
+      "slug": "full-body-picture-of-a-man-with-a-c00da319-1",
+      "serie": "archivo",
+      "orden": 315,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body picture of a man with a red and black detailed moor",
+        "generacion": "c00da319-aa1f-468a-8434-7ee9b325547f",
+        "variante": 1
+      },
+      "titulo": "Full body picture of a man with a",
+      "alt": "full body picture of a man with a red and black detailed moor",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#9d9591",
+      "generacion": "c00da319-aa1f-468a-8434-7ee9b325547f"
+    },
+    {
+      "slug": "full-body-picture-of-a-man-with-a-f8a97c19-0",
+      "serie": "archivo",
+      "orden": 316,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body picture of a man with a red and black detailed moor",
+        "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d",
+        "variante": 0
+      },
+      "titulo": "Full body picture of a man with a",
+      "alt": "full body picture of a man with a red and black detailed moor",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8e9093",
+      "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d"
+    },
+    {
+      "slug": "full-body-picture-of-a-man-with-a-f8a97c19-3",
+      "serie": "archivo",
+      "orden": 317,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body picture of a man with a red and black detailed moor",
+        "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d",
+        "variante": 3
+      },
+      "titulo": "Full body picture of a man with a",
+      "alt": "full body picture of a man with a red and black detailed moor",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#a29793",
+      "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d"
+    },
+    {
+      "slug": "full-body-picture-of-buchibe-the-last-manaure-e953e0cf-2",
+      "serie": "archivo",
+      "orden": 318,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full body picture of Buchibe the last Manaure of the Caquetio",
+        "generacion": "e953e0cf-9f95-445f-b330-5fb79a4cf046",
+        "variante": 2
+      },
+      "titulo": "Full body picture of Buchibe the last Manaure",
+      "alt": "Full body picture of Buchibe the last Manaure of the Caquetio",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#3d4665",
+      "generacion": "e953e0cf-9f95-445f-b330-5fb79a4cf046"
+    },
+    {
+      "slug": "full-body-portrait-of-a-young-soilder-conquistad-0d6148cc-2",
+      "serie": "archivo",
+      "orden": 319,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "full body portrait of a young soilder conquistador from the X",
+        "generacion": "0d6148cc-c146-4742-9895-596c8190a0df",
+        "variante": 2
+      },
+      "titulo": "Full body portrait of a young soilder conquistador",
+      "alt": "full body portrait of a young soilder conquistador from the X",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#574532",
+      "generacion": "0d6148cc-c146-4742-9895-596c8190a0df"
+    },
+    {
+      "slug": "full-shot-of-japanese-geisha-wearing-0fb0dd46-1",
+      "serie": "archivo",
+      "orden": 320,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full shot of Japanese Geisha wearing",
+        "generacion": "0fb0dd46-4493-40b4-a06d-dba6da08ddee",
+        "variante": 1
+      },
+      "titulo": "Full shot of Japanese Geisha wearing",
+      "alt": "Full shot of Japanese Geisha wearing",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1e414c",
+      "generacion": "0fb0dd46-4493-40b4-a06d-dba6da08ddee"
+    },
+    {
+      "slug": "full-shot-of-japanese-geisha-wearing-a-colorful-64aa9b47-0",
+      "serie": "archivo",
+      "orden": 321,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full shot of Japanese Geisha wearing a colorful kimono and an",
+        "generacion": "64aa9b47-f395-4257-9946-40722bbdf1ca",
+        "variante": 0
+      },
+      "titulo": "Full shot of Japanese Geisha wearing a colorful",
+      "alt": "Full shot of Japanese Geisha wearing a colorful kimono and an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#313655",
+      "generacion": "64aa9b47-f395-4257-9946-40722bbdf1ca"
+    },
+    {
+      "slug": "full-shot-of-japanese-geisha-wearing-f3a8fe57-3",
+      "serie": "archivo",
+      "orden": 322,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full shot of Japanese Geisha wearing",
+        "generacion": "f3a8fe57-1cee-4baa-b59c-7afad4aaf1f7",
+        "variante": 3
+      },
+      "titulo": "Full shot of Japanese Geisha wearing",
+      "alt": "Full shot of Japanese Geisha wearing",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#19293a",
+      "generacion": "f3a8fe57-1cee-4baa-b59c-7afad4aaf1f7"
+    },
+    {
+      "slug": "full-view-o-89e0a919-3",
+      "serie": "archivo",
+      "orden": 323,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full view o",
+        "generacion": "89e0a919-ff8d-491d-9514-6fcfc6965399",
+        "variante": 3
+      },
+      "titulo": "Full view o",
+      "alt": "Full view o",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#172122",
+      "generacion": "89e0a919-ff8d-491d-9514-6fcfc6965399"
+    },
+    {
+      "slug": "full-view-of-cinematographic-scene-o-ea321999-1",
+      "serie": "archivo",
+      "orden": 324,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Full view of cinematographic scene o",
+        "generacion": "ea321999-4104-4377-b78a-1427889c0f70",
+        "variante": 1
+      },
+      "titulo": "Full view of cinematographic scene o",
+      "alt": "Full view of cinematographic scene o",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1c292d",
+      "generacion": "ea321999-4104-4377-b78a-1427889c0f70"
+    },
+    {
+      "slug": "futuristic-city-inside-a-dome-in-pla-774ab977-0",
+      "serie": "archivo",
+      "orden": 325,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic City inside a Dome in Pla",
+        "generacion": "774ab977-24d3-454c-8f99-756f6c76e625",
+        "variante": 0
+      },
+      "titulo": "Futuristic City inside a Dome in Pla",
+      "alt": "Futuristic City inside a Dome in Pla",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#593f29",
+      "generacion": "774ab977-24d3-454c-8f99-756f6c76e625"
+    },
+    {
+      "slug": "futuristic-city-inside-a-dome-in-planet-mars-03b89f48-0",
+      "serie": "archivo",
+      "orden": 326,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+        "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d",
+        "variante": 0
+      },
+      "titulo": "Futuristic City inside a Dome in Planet Mars",
+      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#34343d",
+      "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d"
+    },
+    {
+      "slug": "futuristic-city-inside-a-dome-in-planet-mars-03b89f48-2",
+      "serie": "archivo",
+      "orden": 327,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+        "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d",
+        "variante": 2
+      },
+      "titulo": "Futuristic City inside a Dome in Planet Mars",
+      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#393944",
+      "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d"
+    },
+    {
+      "slug": "futuristic-city-inside-a-dome-in-planet-mars-890dd33d-2",
+      "serie": "archivo",
+      "orden": 328,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+        "generacion": "890dd33d-ee3f-4546-9278-01457a9c074e",
+        "variante": 2
+      },
+      "titulo": "Futuristic City inside a Dome in Planet Mars",
+      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8e622d",
+      "generacion": "890dd33d-ee3f-4546-9278-01457a9c074e"
+    },
+    {
+      "slug": "futuristic-retro-of-an-orbital-spacestation-in-s-6b4f4d63-1",
+      "serie": "archivo",
+      "orden": 329,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic Retro of an orbital spacestation in Saturns ring c",
+        "generacion": "6b4f4d63-b97e-4a55-8ef0-02fbd08d712b",
+        "variante": 1
+      },
+      "titulo": "Futuristic Retro of an orbital spacestation in Saturns",
+      "alt": "Futuristic Retro of an orbital spacestation in Saturns ring c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3d5b5a",
+      "generacion": "6b4f4d63-b97e-4a55-8ef0-02fbd08d712b"
+    },
+    {
+      "slug": "futuristic-retro-poster-of-orbital-spacestation-12c48e17-0",
+      "serie": "archivo",
+      "orden": 330,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+        "generacion": "12c48e17-2e12-40a2-922f-470a165172f3",
+        "variante": 0
+      },
+      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "w": 1024,
+      "h": 1536,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2c2c2a",
+      "generacion": "12c48e17-2e12-40a2-922f-470a165172f3"
+    },
+    {
+      "slug": "futuristic-retro-poster-of-orbital-spacestation-2bf81f57-2",
+      "serie": "archivo",
+      "orden": 331,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+        "generacion": "2bf81f57-ea8c-4162-95b4-e1dc4996b571",
+        "variante": 2
+      },
+      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#474848",
+      "generacion": "2bf81f57-ea8c-4162-95b4-e1dc4996b571"
+    },
+    {
+      "slug": "futuristic-retro-poster-of-orbital-spacestation-fb9fe24c-0",
+      "serie": "archivo",
+      "orden": 332,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+        "generacion": "fb9fe24c-9a62-47c9-bdb3-cb50597302f6",
+        "variante": 0
+      },
+      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "w": 1024,
+      "h": 1536,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3a303a",
+      "generacion": "fb9fe24c-9a62-47c9-bdb3-cb50597302f6"
+    },
+    {
+      "slug": "gazing-at-earth-through-a-large-circ-dcd48366-0",
+      "serie": "archivo",
+      "orden": 333,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "gazing at Earth through a large circ",
+        "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a",
+        "variante": 0
+      },
+      "titulo": "Gazing at Earth through a large circ",
+      "alt": "gazing at Earth through a large circ",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#394046",
+      "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a"
+    },
+    {
+      "slug": "gazing-at-earth-through-a-large-circ-dcd48366-2",
+      "serie": "archivo",
+      "orden": 334,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "gazing at Earth through a large circ",
+        "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a",
+        "variante": 2
+      },
+      "titulo": "Gazing at Earth through a large circ",
+      "alt": "gazing at Earth through a large circ",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#353f4a",
+      "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a"
+    },
+    {
+      "slug": "gazing-at-earth-through-a-large-circular-window-a39b6706-0",
+      "serie": "archivo",
+      "orden": 335,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "gazing at Earth through a large circular window in his spaces",
+        "generacion": "a39b6706-a920-4f8d-b842-2829cfaf632e",
+        "variante": 0
+      },
+      "titulo": "Gazing at Earth through a large circular window",
+      "alt": "gazing at Earth through a large circular window in his spaces",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#908476",
+      "generacion": "a39b6706-a920-4f8d-b842-2829cfaf632e"
+    },
+    {
+      "slug": "grainy-overexposed-photo-of-scene-of-argentinian-207dcfd5-0",
+      "serie": "archivo",
+      "orden": 336,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Grainy overexposed photo of Scene of argentinian public trans",
+        "generacion": "207dcfd5-fcd1-498f-b209-848c1339e7b9",
+        "variante": 0
+      },
+      "titulo": "Grainy overexposed photo of Scene of argentinian public",
+      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#68414e",
+      "generacion": "207dcfd5-fcd1-498f-b209-848c1339e7b9"
+    },
+    {
+      "slug": "grainy-overexposed-photo-of-scene-of-argentinian-69961938-2",
+      "serie": "archivo",
+      "orden": 337,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Grainy overexposed photo of Scene of argentinian public trans",
+        "generacion": "69961938-b634-4146-8e6d-527107b7790a",
+        "variante": 2
+      },
+      "titulo": "Grainy overexposed photo of Scene of argentinian public",
+      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#625d56",
+      "generacion": "69961938-b634-4146-8e6d-527107b7790a"
+    },
+    {
+      "slug": "grainy-overexposed-photo-of-scene-of-argentinian-cf464c66-0",
+      "serie": "archivo",
+      "orden": 338,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Grainy overexposed photo of Scene of argentinian public trans",
+        "generacion": "cf464c66-b90b-4a4e-82b6-48845cf6aa7c",
+        "variante": 0
+      },
+      "titulo": "Grainy overexposed photo of Scene of argentinian public",
+      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#555361",
+      "generacion": "cf464c66-b90b-4a4e-82b6-48845cf6aa7c"
+    },
+    {
+      "slug": "grainy-overexposed-photo-of-scene-of-argentinian-dd26f839-0",
+      "serie": "archivo",
+      "orden": 339,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Grainy overexposed photo of Scene of argentinian public trans",
+        "generacion": "dd26f839-469b-4587-b9a6-07d47cf95089",
+        "variante": 0
+      },
+      "titulo": "Grainy overexposed photo of Scene of argentinian public",
+      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#9e6971",
+      "generacion": "dd26f839-469b-4587-b9a6-07d47cf95089"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-242cacc4-2",
+      "serie": "archivo",
+      "orden": 340,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "242cacc4-12f6-49b4-bdcf-c410dbf6059f",
+        "variante": 2
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#262d25",
+      "generacion": "242cacc4-12f6-49b4-bdcf-c410dbf6059f"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-31b29143-0",
+      "serie": "archivo",
+      "orden": 341,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "31b29143-b4c5-41ef-91a1-91b515f2fcc7",
+        "variante": 0
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#34433e",
+      "generacion": "31b29143-b4c5-41ef-91a1-91b515f2fcc7"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-3a996db7-2",
+      "serie": "archivo",
+      "orden": 342,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "3a996db7-d942-459b-bbdf-810e80ac69a2",
+        "variante": 2
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#1a3849",
+      "generacion": "3a996db7-d942-459b-bbdf-810e80ac69a2"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-4eb2ce92-2",
+      "serie": "archivo",
+      "orden": 343,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47",
+        "variante": 2
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#383c4d",
+      "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-4eb2ce92-3",
+      "serie": "archivo",
+      "orden": 344,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47",
+        "variante": 3
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#393d3b",
+      "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-a3c44b74-1",
+      "serie": "archivo",
+      "orden": 345,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "a3c44b74-e425-42a8-a4b1-7503f28a843b",
+        "variante": 1
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#283647",
+      "generacion": "a3c44b74-e425-42a8-a4b1-7503f28a843b"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-aa613638-0",
+      "serie": "archivo",
+      "orden": 346,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3",
+        "variante": 0
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#324b4c",
+      "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-aa613638-1",
+      "serie": "archivo",
+      "orden": 347,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3",
+        "variante": 1
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#414d56",
+      "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-1",
+      "serie": "archivo",
+      "orden": 348,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
+        "variante": 1
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#122a45",
+      "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-2",
+      "serie": "archivo",
+      "orden": 349,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
+        "variante": 2
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#25474f",
+      "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487"
+    },
+    {
+      "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-3",
+      "serie": "archivo",
+      "orden": 350,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "grim shot arrows and bows floating underwater next to submer",
+        "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
+        "variante": 3
+      },
+      "titulo": "Grim shot arrows and bows floating underwater next",
+      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1d3037",
+      "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487"
+    },
+    {
+      "slug": "grungy-analog-photo-of-man-playing-call-of-bac3420e-0",
+      "serie": "archivo",
+      "orden": 351,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Grungy analog photo of man playing Call of Duty on a Playstat",
+        "generacion": "bac3420e-780c-4af6-8e0e-5f963a703c05",
+        "variante": 0
+      },
+      "titulo": "Grungy analog photo of man playing Call of",
+      "alt": "Grungy analog photo of man playing Call of Duty on a Playstat",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4b5445",
+      "generacion": "bac3420e-780c-4af6-8e0e-5f963a703c05"
+    },
+    {
+      "slug": "gzlv4dp1s-panoramic-view-of-a-city-of-stilt-8f551616-1",
+      "serie": "archivo",
+      "orden": 352,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "GZLV4DP1s Panoramic view of a city of stilt ho",
+        "generacion": "8f551616-88a8-42ee-91bf-5b27fc8859ba",
+        "variante": 1
+      },
+      "titulo": "GZLV4DP1s Panoramic view of a city of stilt",
+      "alt": "GZLV4DP1s Panoramic view of a city of stilt ho",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#737a76",
+      "generacion": "8f551616-88a8-42ee-91bf-5b27fc8859ba"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-5856b9f0-0",
+      "serie": "archivo",
+      "orden": 353,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c",
+        "variante": 0
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#3e4241",
+      "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-5856b9f0-2",
+      "serie": "archivo",
+      "orden": 354,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c",
+        "variante": 2
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#62524c",
+      "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-5cf798de-0",
+      "serie": "archivo",
+      "orden": 355,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
+        "variante": 0
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4b4a46",
+      "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-5cf798de-2",
+      "serie": "archivo",
+      "orden": 356,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
+        "variante": 2
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4c4138",
+      "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-5cf798de-3",
+      "serie": "archivo",
+      "orden": 357,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
+        "variante": 3
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5c4839",
+      "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-0",
+      "serie": "archivo",
+      "orden": 358,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
+        "variante": 0
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#554e4a",
+      "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-1",
+      "serie": "archivo",
+      "orden": 359,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
+        "variante": 1
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#3c3c40",
+      "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-3",
+      "serie": "archivo",
+      "orden": 360,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
+        "variante": 3
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#5e5a6e",
+      "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-0",
+      "serie": "archivo",
+      "orden": 361,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
+        "variante": 0
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#574f4d",
+      "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-1",
+      "serie": "archivo",
+      "orden": 362,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
+        "variante": 1
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4f4544",
+      "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-3",
+      "serie": "archivo",
+      "orden": 363,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
+        "variante": 3
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4a453e",
+      "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc"
+    },
+    {
+      "slug": "hgpo2myyw-httpss-mj-r-ef8cb3eb-1",
+      "serie": "archivo",
+      "orden": 364,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "hgPO2mYYw httpss.mj.r",
+        "generacion": "ef8cb3eb-0742-4c18-8221-d2fc605c234c",
+        "variante": 1
+      },
+      "titulo": "HgPO2mYYw httpss.mj.r",
+      "alt": "hgPO2mYYw httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#967765",
+      "generacion": "ef8cb3eb-0742-4c18-8221-d2fc605c234c"
+    },
+    {
+      "slug": "high-heel-over-the-knee-boots-with-platform-1b8b6a94-0",
+      "serie": "archivo",
+      "orden": 365,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "high heel over the knee boots with platform and clear sole bl",
+        "generacion": "1b8b6a94-1748-417f-b4cc-e38093b42d50",
+        "variante": 0
+      },
+      "titulo": "High heel over the knee boots with platform",
+      "alt": "high heel over the knee boots with platform and clear sole bl",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5e5645",
+      "generacion": "1b8b6a94-1748-417f-b4cc-e38093b42d50"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-34f26cb7-2",
+      "serie": "archivo",
+      "orden": 366,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "34f26cb7-d409-41f7-a724-a85b0049a128",
+        "variante": 2
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#38375c",
+      "generacion": "34f26cb7-d409-41f7-a724-a85b0049a128"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-56bdc61e-1",
+      "serie": "archivo",
+      "orden": 367,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "56bdc61e-afd4-4e63-b721-3e8e5783979b",
+        "variante": 1
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2c293b",
+      "generacion": "56bdc61e-afd4-4e63-b721-3e8e5783979b"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-5a953274-0",
+      "serie": "archivo",
+      "orden": 368,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "5a953274-3daa-488c-a8d2-9939f1617730",
+        "variante": 0
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4b4d50",
+      "generacion": "5a953274-3daa-488c-a8d2-9939f1617730"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-64e69518-1",
+      "serie": "archivo",
+      "orden": 369,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "64e69518-ef28-4371-a5f4-294e94e76a98",
+        "variante": 1
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#493936",
+      "generacion": "64e69518-ef28-4371-a5f4-294e94e76a98"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-725932c9-0",
+      "serie": "archivo",
+      "orden": 370,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e",
+        "variante": 0
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#353039",
+      "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-725932c9-1",
+      "serie": "archivo",
+      "orden": 371,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e",
+        "variante": 1
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#48525d",
+      "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-7dbf7e10-3",
+      "serie": "archivo",
+      "orden": 372,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a mind",
+        "generacion": "7dbf7e10-4300-4d7e-9b0a-03db205f1ff4",
+        "variante": 3
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a mind",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#312e3d",
+      "generacion": "7dbf7e10-4300-4d7e-9b0a-03db205f1ff4"
+    },
+    {
+      "slug": "high-tech-operating-room-a-cyborg-doctor-is-923a241c-1",
+      "serie": "archivo",
+      "orden": 373,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech operating room a cyborg doctor is inserting a heari",
+        "generacion": "923a241c-4601-4469-b526-73b4c8904d58",
+        "variante": 1
+      },
+      "titulo": "High tech operating room a cyborg doctor is",
+      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4a433f",
+      "generacion": "923a241c-4601-4469-b526-73b4c8904d58"
+    },
+    {
+      "slug": "high-tech-operating-room-the-doctor-inserts-a-b52724d8-3",
+      "serie": "archivo",
+      "orden": 374,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "High tech Operating Room the doctor inserts a hearing modific",
+        "generacion": "b52724d8-5dbe-4cd5-af49-d93d04db360b",
+        "variante": 3
+      },
+      "titulo": "High tech Operating Room the doctor inserts a",
+      "alt": "High tech Operating Room the doctor inserts a hearing modific",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#5d2b1c",
+      "generacion": "b52724d8-5dbe-4cd5-af49-d93d04db360b"
+    },
+    {
+      "slug": "httpss-mj-r-16baf748-0",
+      "serie": "archivo",
+      "orden": 375,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "16baf748-d34b-4652-8864-0510e6c0185b",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#454238",
+      "generacion": "16baf748-d34b-4652-8864-0510e6c0185b"
+    },
+    {
+      "slug": "httpss-mj-r-1f4f0793-0",
+      "serie": "archivo",
+      "orden": 376,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1f4f0793-5a81-468c-bb70-5651b8660c81",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#31373a",
+      "generacion": "1f4f0793-5a81-468c-bb70-5651b8660c81"
+    },
+    {
+      "slug": "httpss-mj-r-1f8924b6-1",
+      "serie": "archivo",
+      "orden": 377,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6e4635",
+      "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105"
+    },
+    {
+      "slug": "httpss-mj-r-1f8924b6-2",
+      "serie": "archivo",
+      "orden": 378,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
+        "variante": 2
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#68483c",
+      "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105"
+    },
+    {
+      "slug": "httpss-mj-r-1f8924b6-3",
+      "serie": "archivo",
+      "orden": 379,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#74604d",
+      "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105"
+    },
+    {
+      "slug": "httpss-mj-r-1fd50f6c-1",
+      "serie": "archivo",
+      "orden": 380,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3f4248",
+      "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422"
+    },
+    {
+      "slug": "httpss-mj-r-1fd50f6c-3",
+      "serie": "archivo",
+      "orden": 381,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#364b6c",
+      "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422"
+    },
+    {
+      "slug": "httpss-mj-r-26a96291-0",
+      "serie": "archivo",
+      "orden": 382,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#39342e",
+      "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a"
+    },
+    {
+      "slug": "httpss-mj-r-26a96291-1",
+      "serie": "archivo",
+      "orden": 383,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#201e18",
+      "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a"
+    },
+    {
+      "slug": "httpss-mj-r-2d12c98d-3",
+      "serie": "archivo",
+      "orden": 384,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "2d12c98d-6d52-472a-b4ee-6bd7a075797d",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#7a562f",
+      "generacion": "2d12c98d-6d52-472a-b4ee-6bd7a075797d"
+    },
+    {
+      "slug": "httpss-mj-r-3b4bc54d-0",
+      "serie": "archivo",
+      "orden": 385,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2a2f28",
+      "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d"
+    },
+    {
+      "slug": "httpss-mj-r-3b4bc54d-2",
+      "serie": "archivo",
+      "orden": 386,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
+        "variante": 2
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#303832",
+      "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d"
+    },
+    {
+      "slug": "httpss-mj-r-3b4bc54d-3",
+      "serie": "archivo",
+      "orden": 387,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3a3c4f",
+      "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d"
+    },
+    {
+      "slug": "httpss-mj-r-43f24e50-1",
+      "serie": "archivo",
+      "orden": 388,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3b4941",
+      "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b"
+    },
+    {
+      "slug": "httpss-mj-r-43f24e50-2",
+      "serie": "archivo",
+      "orden": 389,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
+        "variante": 2
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#313a3a",
+      "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b"
+    },
+    {
+      "slug": "httpss-mj-r-43f24e50-3",
+      "serie": "archivo",
+      "orden": 390,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#463b2e",
+      "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b"
+    },
+    {
+      "slug": "httpss-mj-r-4be9a7f3-0",
+      "serie": "archivo",
+      "orden": 391,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#316a6f",
+      "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f"
+    },
+    {
+      "slug": "httpss-mj-r-4be9a7f3-3",
+      "serie": "archivo",
+      "orden": 392,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#436560",
+      "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f"
+    },
+    {
+      "slug": "httpss-mj-r-4c015cd6-0",
+      "serie": "archivo",
+      "orden": 393,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#765c3f",
+      "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db"
+    },
+    {
+      "slug": "httpss-mj-r-4c015cd6-2",
+      "serie": "archivo",
+      "orden": 394,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
+        "variante": 2
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6a4936",
+      "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db"
+    },
+    {
+      "slug": "httpss-mj-r-4c015cd6-3",
+      "serie": "archivo",
+      "orden": 395,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#62534b",
+      "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db"
+    },
+    {
+      "slug": "httpss-mj-r-551e89c3-0",
+      "serie": "archivo",
+      "orden": 396,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "551e89c3-af18-4a85-9880-b5fdff559b8d",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#263d3a",
+      "generacion": "551e89c3-af18-4a85-9880-b5fdff559b8d"
+    },
+    {
+      "slug": "httpss-mj-r-6a1ad429-0",
+      "serie": "archivo",
+      "orden": 397,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4f4133",
+      "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4"
+    },
+    {
+      "slug": "httpss-mj-r-6a1ad429-1",
+      "serie": "archivo",
+      "orden": 398,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5a534f",
+      "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4"
+    },
+    {
+      "slug": "httpss-mj-r-7d86befe-0",
+      "serie": "archivo",
+      "orden": 399,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "7d86befe-22ca-44b7-8cce-27fd92aa1eb0",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#346166",
+      "generacion": "7d86befe-22ca-44b7-8cce-27fd92aa1eb0"
+    },
+    {
+      "slug": "httpss-mj-r-7f39f421-3",
+      "serie": "archivo",
+      "orden": 400,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "7f39f421-5b9e-4467-b574-9e0188f6ced2",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#524c4b",
+      "generacion": "7f39f421-5b9e-4467-b574-9e0188f6ced2"
+    },
+    {
+      "slug": "httpss-mj-r-8fd2b300-0",
+      "serie": "archivo",
+      "orden": 401,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "8fd2b300-c707-41b4-ad96-6eb053b51616",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3b3e43",
+      "generacion": "8fd2b300-c707-41b4-ad96-6eb053b51616"
+    },
+    {
+      "slug": "httpss-mj-r-a03a000f-0",
+      "serie": "archivo",
+      "orden": 402,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "a03a000f-02fd-455b-b323-9d86909c0f9e",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#374249",
+      "generacion": "a03a000f-02fd-455b-b323-9d86909c0f9e"
+    },
+    {
+      "slug": "httpss-mj-r-b55e571f-3",
+      "serie": "archivo",
+      "orden": 403,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "b55e571f-c0f7-482b-9053-1adb0e4bf862",
+        "variante": 3
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3b392d",
+      "generacion": "b55e571f-c0f7-482b-9053-1adb0e4bf862"
+    },
+    {
+      "slug": "httpss-mj-r-baf42107-0",
+      "serie": "archivo",
+      "orden": 404,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#543e2e",
+      "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58"
+    },
+    {
+      "slug": "httpss-mj-r-baf42107-1",
+      "serie": "archivo",
+      "orden": 405,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#59483d",
+      "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58"
+    },
+    {
+      "slug": "httpss-mj-r-baf42107-2",
+      "serie": "archivo",
+      "orden": 406,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
+        "variante": 2
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4f4238",
+      "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58"
+    },
+    {
+      "slug": "httpss-mj-r-cc768606-1",
+      "serie": "archivo",
+      "orden": 407,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "cc768606-4f8f-492d-be5b-45120af5f783",
+        "variante": 1
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3c493f",
+      "generacion": "cc768606-4f8f-492d-be5b-45120af5f783"
+    },
+    {
+      "slug": "httpss-mj-r-f4a20894-0",
+      "serie": "archivo",
+      "orden": 408,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "httpss.mj.r",
+        "generacion": "f4a20894-3b4f-4724-86b9-7de04259d468",
+        "variante": 0
+      },
+      "titulo": "Httpss.mj.r",
+      "alt": "httpss.mj.r",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#36423b",
+      "generacion": "f4a20894-3b4f-4724-86b9-7de04259d468"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-057075f5-0",
+      "serie": "archivo",
+      "orden": 409,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "057075f5-7fd8-4da8-8303-45cdb243badc",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3a4045",
+      "generacion": "057075f5-7fd8-4da8-8303-45cdb243badc"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-237116cf-1",
+      "serie": "archivo",
+      "orden": 410,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "237116cf-69c6-4db5-9eb9-f28a646f7577",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#505b71",
+      "generacion": "237116cf-69c6-4db5-9eb9-f28a646f7577"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-59616bc8-3",
+      "serie": "archivo",
+      "orden": 411,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "59616bc8-067f-41f8-8e32-dd883dde7e73",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#171819",
+      "generacion": "59616bc8-067f-41f8-8e32-dd883dde7e73"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-780fcb70-1",
+      "serie": "archivo",
+      "orden": 412,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6f786f",
+      "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-780fcb70-2",
+      "serie": "archivo",
+      "orden": 413,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6e736d",
+      "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-84c04a57-2",
+      "serie": "archivo",
+      "orden": 414,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "84c04a57-897f-4151-a505-7f04e0ffafda",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#554d59",
+      "generacion": "84c04a57-897f-4151-a505-7f04e0ffafda"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-8a539940-3",
+      "serie": "archivo",
+      "orden": 415,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "8a539940-494c-46bd-afd2-0da61296e669",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#444e6d",
+      "generacion": "8a539940-494c-46bd-afd2-0da61296e669"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-a0e6e495-1",
+      "serie": "archivo",
+      "orden": 416,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "a0e6e495-417d-47cb-8e45-54983fb36ca7",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#676a6c",
+      "generacion": "a0e6e495-417d-47cb-8e45-54983fb36ca7"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-b9ab3891-0",
+      "serie": "archivo",
+      "orden": 417,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "b9ab3891-83b1-40e4-9236-f4c33eba0324",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#505956",
+      "generacion": "b9ab3891-83b1-40e4-9236-f4c33eba0324"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-ba586301-0",
+      "serie": "archivo",
+      "orden": 418,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#443c51",
+      "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-ba586301-3",
+      "serie": "archivo",
+      "orden": 419,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#322e3c",
+      "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-ca5f5381-0",
+      "serie": "archivo",
+      "orden": 420,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "ca5f5381-1d51-42ee-b309-fdd5e1bdfed0",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3b475a",
+      "generacion": "ca5f5381-1d51-42ee-b309-fdd5e1bdfed0"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-e1a2747f-3",
+      "serie": "archivo",
+      "orden": 421,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "e1a2747f-cac6-4a68-b451-cf9ac974eadf",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f393a",
+      "generacion": "e1a2747f-cac6-4a68-b451-cf9ac974eadf"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-d-fc9c8ad9-2",
+      "serie": "archivo",
+      "orden": 422,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium d",
+        "generacion": "fc9c8ad9-ce0a-401d-a2b7-3f7039798c9d",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium d",
+      "alt": "Juan de La Torre from Cadiz Medium d",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#275465",
+      "generacion": "fc9c8ad9-ce0a-401d-a2b7-3f7039798c9d"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-22a985ea-2",
+      "serie": "archivo",
+      "orden": 423,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "22a985ea-418a-4431-b940-b1535d2ff610",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8a856a",
+      "generacion": "22a985ea-418a-4431-b940-b1535d2ff610"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-22a985ea-3",
+      "serie": "archivo",
+      "orden": 424,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "22a985ea-418a-4431-b940-b1535d2ff610",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#a7a79a",
+      "generacion": "22a985ea-418a-4431-b940-b1535d2ff610"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-26bb487d-3",
+      "serie": "archivo",
+      "orden": 425,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "26bb487d-0347-43bd-abec-9bc03cfdbdf9",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#434c50",
+      "generacion": "26bb487d-0347-43bd-abec-9bc03cfdbdf9"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-35560008-0",
+      "serie": "archivo",
+      "orden": 426,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "35560008-b3e3-45d2-b05d-adff705e73cf",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#221812",
+      "generacion": "35560008-b3e3-45d2-b05d-adff705e73cf"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-4450a4b7-0",
+      "serie": "archivo",
+      "orden": 427,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3a4f51",
+      "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-4450a4b7-1",
+      "serie": "archivo",
+      "orden": 428,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#353b42",
+      "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-455b8ad3-0",
+      "serie": "archivo",
+      "orden": 429,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "455b8ad3-a701-46b8-8ab2-8ed687549bbe",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8a7a8d",
+      "generacion": "455b8ad3-a701-46b8-8ab2-8ed687549bbe"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-4bd650fe-2",
+      "serie": "archivo",
+      "orden": 430,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "4bd650fe-bcd0-4294-bd92-289acf7eb3ae",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#63737d",
+      "generacion": "4bd650fe-bcd0-4294-bd92-289acf7eb3ae"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-5349d98a-2",
+      "serie": "archivo",
+      "orden": 431,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#70818f",
+      "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-5349d98a-3",
+      "serie": "archivo",
+      "orden": 432,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#949698",
+      "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-5a509ab8-2",
+      "serie": "archivo",
+      "orden": 433,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "5a509ab8-c968-44c4-aac1-e5517115fa11",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7c797c",
+      "generacion": "5a509ab8-c968-44c4-aac1-e5517115fa11"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-70810425-1",
+      "serie": "archivo",
+      "orden": 434,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "70810425-686a-4cea-851e-770584dfe42a",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5c6079",
+      "generacion": "70810425-686a-4cea-851e-770584dfe42a"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-799e10c0-0",
+      "serie": "archivo",
+      "orden": 435,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#71637b",
+      "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-799e10c0-3",
+      "serie": "archivo",
+      "orden": 436,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5f606d",
+      "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-87322e48-0",
+      "serie": "archivo",
+      "orden": 437,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "87322e48-bdb8-4e74-98b2-1399ed214157",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6d747c",
+      "generacion": "87322e48-bdb8-4e74-98b2-1399ed214157"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-87d936de-2",
+      "serie": "archivo",
+      "orden": 438,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "87d936de-a46c-45b4-9f7e-66f97d64b0fd",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2e3c34",
+      "generacion": "87d936de-a46c-45b4-9f7e-66f97d64b0fd"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-a836637d-1",
+      "serie": "archivo",
+      "orden": 439,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "a836637d-5728-464a-8329-ec1f033b62c7",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7f8999",
+      "generacion": "a836637d-5728-464a-8329-ec1f033b62c7"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-ad8cc8ed-1",
+      "serie": "archivo",
+      "orden": 440,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "ad8cc8ed-c502-4719-9418-71f07bb679a4",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#70696a",
+      "generacion": "ad8cc8ed-c502-4719-9418-71f07bb679a4"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-af5396cf-2",
+      "serie": "archivo",
+      "orden": 441,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "af5396cf-a8c0-4a66-895d-54db37a44b81",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#34252b",
+      "generacion": "af5396cf-a8c0-4a66-895d-54db37a44b81"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-c22eec5e-2",
+      "serie": "archivo",
+      "orden": 442,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "c22eec5e-f065-4a04-ac31-9b61112a4562",
+        "variante": 2
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#152431",
+      "generacion": "c22eec5e-f065-4a04-ac31-9b61112a4562"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-c4167ca9-0",
+      "serie": "archivo",
+      "orden": 443,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "c4167ca9-97bf-4265-8587-badfd7088616",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#255364",
+      "generacion": "c4167ca9-97bf-4265-8587-badfd7088616"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-c4b6cc2e-3",
+      "serie": "archivo",
+      "orden": 444,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "c4b6cc2e-18df-4072-99d8-9355b5035322",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#373a3a",
+      "generacion": "c4b6cc2e-18df-4072-99d8-9355b5035322"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-cdf3f12b-3",
+      "serie": "archivo",
+      "orden": 445,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "cdf3f12b-d33f-414a-b5fc-b17ad909a8fd",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#0c1319",
+      "generacion": "cdf3f12b-d33f-414a-b5fc-b17ad909a8fd"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-cf88fee8-1",
+      "serie": "archivo",
+      "orden": 446,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "cf88fee8-5b80-4ed2-9947-ccea9a4d18e5",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#37312f",
+      "generacion": "cf88fee8-5b80-4ed2-9947-ccea9a4d18e5"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-d634b332-0",
+      "serie": "archivo",
+      "orden": 447,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8d8f8e",
+      "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-d634b332-1",
+      "serie": "archivo",
+      "orden": 448,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#837e80",
+      "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-d77639d9-0",
+      "serie": "archivo",
+      "orden": 449,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "d77639d9-a0f9-4cba-9394-b6b0d8fc2ea6",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4a4e4f",
+      "generacion": "d77639d9-a0f9-4cba-9394-b6b0d8fc2ea6"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-dc5e217d-0",
+      "serie": "archivo",
+      "orden": 450,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "dc5e217d-a47d-4380-94d5-60cd57afb4b3",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#23251c",
+      "generacion": "dc5e217d-a47d-4380-94d5-60cd57afb4b3"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-de5308d8-0",
+      "serie": "archivo",
+      "orden": 451,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "de5308d8-67dd-4f3b-9382-a8f52ca165dc",
+        "variante": 0
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8591b0",
+      "generacion": "de5308d8-67dd-4f3b-9382-a8f52ca165dc"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-f8ba322e-1",
+      "serie": "archivo",
+      "orden": 452,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f",
+        "variante": 1
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#858787",
+      "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f"
+    },
+    {
+      "slug": "juan-de-la-torre-from-cadiz-medium-dark-f8ba322e-3",
+      "serie": "archivo",
+      "orden": 453,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+        "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f",
+        "variante": 3
+      },
+      "titulo": "Juan de La Torre from Cadiz Medium dark",
+      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#757c84",
+      "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f"
+    },
+    {
+      "slug": "kintsugi-digital",
+      "titulo": "Kintsugi digital",
+      "alt": "Vasija de barro antigua sobre fondo oscuro, con las grietas rellenas de luz y píxeles luminosos en lugar de oro.",
+      "serie": "umbral",
+      "orden": 454,
+      "estado": "pendiente",
+      "tags": [
+        "bodegón",
+        "cerámica",
+        "reparación"
+      ],
+      "licencia": "cc-by-nc",
+      "w": null,
+      "h": null,
+      "anchos": [],
+      "color": "#4f3e35",
+      "concepto": "Bodegón mínimo. Una vasija de barro antigua reparada con kintsugi digital: las grietas son luz y píxel en vez de oro.",
+      "anio": 2025,
+      "licenciaDetalle": {
+        "tipo": "cc-by-nc",
+        "print": true
+      },
+      "procedencia": {
+        "herramienta": "Midjourney"
+      },
+      "edicion": "01"
+    },
+    {
+      "slug": "latin-american-boy-with-an-alternative-nu-metal-61e3ec5c-1",
+      "serie": "archivo",
+      "orden": 455,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Latin american boy with an alternative nu-metal attire and vi",
+        "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070",
+        "variante": 1
+      },
+      "titulo": "Latin american boy with an alternative nu-metal attire",
+      "alt": "Latin american boy with an alternative nu-metal attire and vi",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#36402f",
+      "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070"
+    },
+    {
+      "slug": "latin-american-boy-with-an-alternative-nu-metal-61e3ec5c-2",
+      "serie": "archivo",
+      "orden": 456,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Latin american boy with an alternative nu-metal attire and vi",
+        "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070",
+        "variante": 2
+      },
+      "titulo": "Latin american boy with an alternative nu-metal attire",
+      "alt": "Latin american boy with an alternative nu-metal attire and vi",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3d4843",
+      "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070"
+    },
+    {
+      "slug": "latin-american-etnicity-moon-human-gazes-at-eart-95e801a2-0",
+      "serie": "archivo",
+      "orden": 457,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "latin american etnicity moon human gazes at Earth from the Mo",
+        "generacion": "95e801a2-53ac-4d18-a479-1f15622d3310",
+        "variante": 0
+      },
+      "titulo": "Latin american etnicity moon human gazes at Earth",
+      "alt": "latin american etnicity moon human gazes at Earth from the Mo",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#6e6b68",
+      "generacion": "95e801a2-53ac-4d18-a479-1f15622d3310"
+    },
+    {
+      "slug": "latin-american-etnicity-moon-human-gazes-at-eart-af07695a-3",
+      "serie": "archivo",
+      "orden": 458,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "latin american etnicity moon human gazes at Earth from the Mo",
+        "generacion": "af07695a-1dac-4acd-9b3f-1731b8baba39",
+        "variante": 3
+      },
+      "titulo": "Latin american etnicity moon human gazes at Earth",
+      "alt": "latin american etnicity moon human gazes at Earth from the Mo",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#a2af9b",
+      "generacion": "af07695a-1dac-4acd-9b3f-1731b8baba39"
+    },
+    {
+      "slug": "life-still-in-caracas-1830b0dd-1",
+      "serie": "archivo",
+      "orden": 459,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
+        "variante": 1
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#696662",
+      "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c"
+    },
+    {
+      "slug": "life-still-in-caracas-1830b0dd-2",
+      "serie": "archivo",
+      "orden": 460,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
+        "variante": 2
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#584845",
+      "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c"
+    },
+    {
+      "slug": "life-still-in-caracas-1830b0dd-3",
+      "serie": "archivo",
+      "orden": 461,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
+        "variante": 3
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5b7381",
+      "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c"
+    },
+    {
+      "slug": "life-still-in-caracas-1dc5ac9e-1",
+      "serie": "archivo",
+      "orden": 462,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24",
+        "variante": 1
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#625b5c",
+      "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24"
+    },
+    {
+      "slug": "life-still-in-caracas-1dc5ac9e-2",
+      "serie": "archivo",
+      "orden": 463,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24",
+        "variante": 2
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6a7177",
+      "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24"
+    },
+    {
+      "slug": "life-still-in-caracas-28e76c57-0",
+      "serie": "archivo",
+      "orden": 464,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "28e76c57-19d6-4b41-a6ff-1cc0e3465538",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5b5c45",
+      "generacion": "28e76c57-19d6-4b41-a6ff-1cc0e3465538"
+    },
+    {
+      "slug": "life-still-in-caracas-397d7ceb-1",
+      "serie": "archivo",
+      "orden": 465,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "397d7ceb-1ba0-4606-9109-63be3ef523bd",
+        "variante": 1
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#8b9270",
+      "generacion": "397d7ceb-1ba0-4606-9109-63be3ef523bd"
+    },
+    {
+      "slug": "life-still-in-caracas-4ea279aa-2",
+      "serie": "archivo",
+      "orden": 466,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "4ea279aa-1b48-4b1c-befb-9bf0225623f0",
+        "variante": 2
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5c6152",
+      "generacion": "4ea279aa-1b48-4b1c-befb-9bf0225623f0"
+    },
+    {
+      "slug": "life-still-in-caracas-946cf2ed-2",
+      "serie": "archivo",
+      "orden": 467,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "946cf2ed-0959-473b-9e10-0f7145dc9486",
+        "variante": 2
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#666471",
+      "generacion": "946cf2ed-0959-473b-9e10-0f7145dc9486"
+    },
+    {
+      "slug": "life-still-in-caracas-98f2844e-0",
+      "serie": "archivo",
+      "orden": 468,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7e8190",
+      "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b"
+    },
+    {
+      "slug": "life-still-in-caracas-98f2844e-1",
+      "serie": "archivo",
+      "orden": 469,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b",
+        "variante": 1
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5a4a40",
+      "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b"
+    },
+    {
+      "slug": "life-still-in-caracas-a13e96b0-0",
+      "serie": "archivo",
+      "orden": 470,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "a13e96b0-8dbe-49ee-b2a8-d0c4e0ba3b63",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#565c69",
+      "generacion": "a13e96b0-8dbe-49ee-b2a8-d0c4e0ba3b63"
+    },
+    {
+      "slug": "life-still-in-caracas-b86cf818-3",
+      "serie": "archivo",
+      "orden": 471,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --exp 15 --raw --sre",
+        "generacion": "b86cf818-8898-4232-8165-e1a877c2d679",
+        "variante": 3
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#66757c",
+      "generacion": "b86cf818-8898-4232-8165-e1a877c2d679"
+    },
+    {
+      "slug": "life-still-in-caracas-c0a2992f-0",
+      "serie": "archivo",
+      "orden": 472,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --profile v4ig8ww --",
+        "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3b3d27",
+      "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50"
+    },
+    {
+      "slug": "life-still-in-caracas-c0a2992f-1",
+      "serie": "archivo",
+      "orden": 473,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --profile v4ig8ww --",
+        "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50",
+        "variante": 1
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#292718",
+      "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50"
+    },
+    {
+      "slug": "life-still-in-caracas-d4cbe190-0",
+      "serie": "archivo",
+      "orden": 474,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "d4cbe190-b143-4406-abdf-e2b4bdcd4dd8",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6a5b5b",
+      "generacion": "d4cbe190-b143-4406-abdf-e2b4bdcd4dd8"
+    },
+    {
+      "slug": "life-still-in-caracas-e13c784e-3",
+      "serie": "archivo",
+      "orden": 475,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "e13c784e-922f-4601-ba1d-41c58d4f4d6c",
+        "variante": 3
+      },
+      "titulo": "Life still in Caracas",
+      "alt": "Life still in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#656259",
+      "generacion": "e13c784e-922f-4601-ba1d-41c58d4f4d6c"
+    },
+    {
+      "slug": "life-still-in-caracas-with-guacamayas-57e84694-0",
+      "serie": "archivo",
+      "orden": 476,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas with Guacamayas --chaos 10 --ar 32 --ex",
+        "generacion": "57e84694-ded5-4cd4-9b20-b34570301ee3",
+        "variante": 0
+      },
+      "titulo": "Life still in Caracas with Guacamayas",
+      "alt": "Life still in Caracas with Guacamayas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#465260",
+      "generacion": "57e84694-ded5-4cd4-9b20-b34570301ee3"
+    },
+    {
+      "slug": "life-still-in-caracas-with-guacamayas-5bfc12b2-2",
+      "serie": "archivo",
+      "orden": 477,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Caracas with Guacamayas --chaos 50 --ar 32 --ex",
+        "generacion": "5bfc12b2-8cf0-470e-9ca4-ae1b3196fd02",
+        "variante": 2
+      },
+      "titulo": "Life still in Caracas with Guacamayas",
+      "alt": "Life still in Caracas with Guacamayas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7c8b92",
+      "generacion": "5bfc12b2-8cf0-470e-9ca4-ae1b3196fd02"
+    },
+    {
+      "slug": "life-still-in-paraguan-055ea6b8-2",
+      "serie": "archivo",
+      "orden": 478,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Paraguan --chaos 10 --ar 32 --sref httpss.mj.ru",
+        "generacion": "055ea6b8-fe43-4726-9ffb-cc5ff136a295",
+        "variante": 2
+      },
+      "titulo": "Life still in Paraguan",
+      "alt": "Life still in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6e5c4a",
+      "generacion": "055ea6b8-fe43-4726-9ffb-cc5ff136a295"
+    },
+    {
+      "slug": "life-still-in-paraguan-7243af9b-1",
+      "serie": "archivo",
+      "orden": 479,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Paraguan --chaos 10 --ar 32 --sref httpss.mj.ru",
+        "generacion": "7243af9b-aecb-4e43-8333-94c9fb366501",
+        "variante": 1
+      },
+      "titulo": "Life still in Paraguan",
+      "alt": "Life still in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#524a38",
+      "generacion": "7243af9b-aecb-4e43-8333-94c9fb366501"
+    },
+    {
+      "slug": "life-still-in-paraguan-f47b6efe-1",
+      "serie": "archivo",
+      "orden": 480,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Paraguan --chaos 10 --ar 32 --sref httpss.mj.ru",
+        "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef",
+        "variante": 1
+      },
+      "titulo": "Life still in Paraguan",
+      "alt": "Life still in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#84787f",
+      "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef"
+    },
+    {
+      "slug": "life-still-in-paraguan-f47b6efe-2",
+      "serie": "archivo",
+      "orden": 481,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in Paraguan --chaos 10 --ar 32 --sref httpss.mj.ru",
+        "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef",
+        "variante": 2
+      },
+      "titulo": "Life still in Paraguan",
+      "alt": "Life still in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#676568",
+      "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-22bc6902-0",
+      "serie": "archivo",
+      "orden": 482,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "22bc6902-beaa-4477-868f-41450ecd58c9",
+        "variante": 0
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5d6b60",
+      "generacion": "22bc6902-beaa-4477-868f-41450ecd58c9"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-2592a93b-1",
+      "serie": "archivo",
+      "orden": 483,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "2592a93b-b323-42ce-b7c4-892b0185f79b",
+        "variante": 1
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#515457",
+      "generacion": "2592a93b-b323-42ce-b7c4-892b0185f79b"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-4487d810-2",
+      "serie": "archivo",
+      "orden": 484,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "4487d810-dd9d-4098-b6da-649037110a29",
+        "variante": 2
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#52514e",
+      "generacion": "4487d810-dd9d-4098-b6da-649037110a29"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-7384e7bf-1",
+      "serie": "archivo",
+      "orden": 485,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "7384e7bf-82b1-4089-9d1c-e5ccb3bf6b10",
+        "variante": 1
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#876c61",
+      "generacion": "7384e7bf-82b1-4089-9d1c-e5ccb3bf6b10"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-ba90e8ae-2",
+      "serie": "archivo",
+      "orden": 486,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe",
+        "variante": 2
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#575c5c",
+      "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe"
+    },
+    {
+      "slug": "life-still-in-the-metro-of-caracas-ba90e8ae-3",
+      "serie": "archivo",
+      "orden": 487,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Life still in the metro of Caracas --chaos 10 --ar 32 --sref",
+        "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe",
+        "variante": 3
+      },
+      "titulo": "Life still in the metro of Caracas",
+      "alt": "Life still in the metro of Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4e493f",
+      "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe"
+    },
+    {
+      "slug": "liminal-image-of-a-restaurant-postcard-in-the-e9155478-0",
+      "serie": "archivo",
+      "orden": 488,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "liminal image of a restaurant postcard in the style of 1990s",
+        "generacion": "e9155478-a48f-47ec-91ee-0d24d2540d4d",
+        "variante": 0
+      },
+      "titulo": "Liminal image of a restaurant postcard in the",
+      "alt": "liminal image of a restaurant postcard in the style of 1990s",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#71625f",
+      "generacion": "e9155478-a48f-47ec-91ee-0d24d2540d4d"
+    },
+    {
+      "slug": "liminal-image-of-a-restaurant-postcard-in-the-ef172ec5-2",
+      "serie": "archivo",
+      "orden": 489,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "liminal image of a restaurant postcard in the style of 1990s",
+        "generacion": "ef172ec5-fbe5-483e-8b13-309ad254218a",
+        "variante": 2
+      },
+      "titulo": "Liminal image of a restaurant postcard in the",
+      "alt": "liminal image of a restaurant postcard in the style of 1990s",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#53413b",
+      "generacion": "ef172ec5-fbe5-483e-8b13-309ad254218a"
+    },
+    {
+      "slug": "low-shot-of-3d6e4044-2",
+      "serie": "archivo",
+      "orden": 490,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of",
+        "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392",
+        "variante": 2
+      },
+      "titulo": "Low shot of",
+      "alt": "Low shot of",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#191816",
+      "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392"
+    },
+    {
+      "slug": "low-shot-of-3d6e4044-3",
+      "serie": "archivo",
+      "orden": 491,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of",
+        "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392",
+        "variante": 3
+      },
+      "titulo": "Low shot of",
+      "alt": "Low shot of",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3b3c36",
+      "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392"
+    },
+    {
+      "slug": "low-shot-of-7b37ca9b-2",
+      "serie": "archivo",
+      "orden": 492,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of",
+        "generacion": "7b37ca9b-1f7f-4829-8f33-396433eea4c8",
+        "variante": 2
+      },
+      "titulo": "Low shot of",
+      "alt": "Low shot of",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2a2420",
+      "generacion": "7b37ca9b-1f7f-4829-8f33-396433eea4c8"
+    },
+    {
+      "slug": "low-shot-of-c969b056-0",
+      "serie": "archivo",
+      "orden": 493,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of",
+        "generacion": "c969b056-b482-4232-840d-87865b01c3d1",
+        "variante": 0
+      },
+      "titulo": "Low shot of",
+      "alt": "Low shot of",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#1e1f23",
+      "generacion": "c969b056-b482-4232-840d-87865b01c3d1"
+    },
+    {
+      "slug": "low-shot-of-martian-film-the-scene-shows-2ad60863-1",
+      "serie": "archivo",
+      "orden": 494,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of martian film the scene shows a man in formal atti",
+        "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163",
+        "variante": 1
+      },
+      "titulo": "Low shot of martian film the scene shows",
+      "alt": "Low shot of martian film the scene shows a man in formal atti",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2a271f",
+      "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163"
+    },
+    {
+      "slug": "low-shot-of-martian-film-the-scene-shows-2ad60863-3",
+      "serie": "archivo",
+      "orden": 495,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of martian film the scene shows a man in formal atti",
+        "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163",
+        "variante": 3
+      },
+      "titulo": "Low shot of martian film the scene shows",
+      "alt": "Low shot of martian film the scene shows a man in formal atti",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2b2824",
+      "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163"
+    },
+    {
+      "slug": "low-shot-of-student-in-formal-attire-from-f0eed234-1",
+      "serie": "archivo",
+      "orden": 496,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Low shot of student in formal attire from the martian navy sc",
+        "generacion": "f0eed234-165d-4750-9da3-29691eda4ae6",
+        "variante": 1
+      },
+      "titulo": "Low shot of student in formal attire from",
+      "alt": "Low shot of student in formal attire from the martian navy sc",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#23181c",
+      "generacion": "f0eed234-165d-4750-9da3-29691eda4ae6"
+    },
+    {
+      "slug": "lunar-punk-green-goblin-under-a-big-red-4c5b73b1-0",
+      "serie": "archivo",
+      "orden": 497,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Lunar Punk Green Goblin under a Big Red and Green mushroom --",
+        "generacion": "4c5b73b1-7e00-4c4c-b3f3-c6a944162896",
+        "variante": 0
+      },
+      "titulo": "Lunar Punk Green Goblin under a Big Red",
+      "alt": "Lunar Punk Green Goblin under a Big Red and Green mushroom",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6f4b7b",
+      "generacion": "4c5b73b1-7e00-4c4c-b3f3-c6a944162896"
+    },
+    {
+      "slug": "magazine-font-title-for-curiana-radio-90s-print-9f8a2b1e-1",
+      "serie": "archivo",
+      "orden": 498,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Magazine font title for Curiana Radio 90s print style --ar 32",
+        "generacion": "9f8a2b1e-a1e7-4529-ab54-058162c2ff26",
+        "variante": 1
+      },
+      "titulo": "Magazine font title for Curiana Radio 90s print",
+      "alt": "Magazine font title for Curiana Radio 90s print style",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1e241f",
+      "generacion": "9f8a2b1e-a1e7-4529-ab54-058162c2ff26"
+    },
+    {
+      "slug": "main-deck-of-a-intergalactic-freighter-navigatio-794b6938-0",
+      "serie": "archivo",
+      "orden": 499,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+        "generacion": "794b6938-e74e-4405-b01e-f861d447e8a3",
+        "variante": 0
+      },
+      "titulo": "Main deck of a Intergalactic Freighter Navigation chart",
+      "alt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+      "w": 1400,
+      "h": 700,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#141b1e",
+      "generacion": "794b6938-e74e-4405-b01e-f861d447e8a3"
+    },
+    {
+      "slug": "main-deck-of-a-intergalactic-freighter-navigatio-b7931fda-0",
+      "serie": "archivo",
+      "orden": 500,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+        "generacion": "b7931fda-ebab-4c8f-8119-1946280088b9",
+        "variante": 0
+      },
+      "titulo": "Main deck of a Intergalactic Freighter Navigation chart",
+      "alt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#40413d",
+      "generacion": "b7931fda-ebab-4c8f-8119-1946280088b9"
+    },
+    {
+      "slug": "man-practicing-kung-fu-in-a-traditional-shaolin-42d93de0-3",
+      "serie": "archivo",
+      "orden": 501,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Man practicing Kung Fu in a Traditional Shaolin Dojo in the s",
+        "generacion": "42d93de0-5ba1-49fa-a639-884cb7119e4f",
+        "variante": 3
+      },
+      "titulo": "Man practicing Kung Fu in a Traditional Shaolin",
+      "alt": "Man practicing Kung Fu in a Traditional Shaolin Dojo in the s",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#ab421e",
+      "generacion": "42d93de0-5ba1-49fa-a639-884cb7119e4f"
+    },
+    {
+      "slug": "medanos-circuito",
+      "titulo": "Médanos, circuito",
+      "alt": "Dunas de arena al atardecer con patrones de circuito impresos en la superficie y una antena de barro y cobre en el horizonte.",
+      "serie": "umbral",
+      "orden": 502,
+      "estado": "pendiente",
+      "tags": [
+        "paisaje",
+        "solarpunk",
+        "desierto",
+        "señal"
+      ],
+      "licencia": "cc-by-nc",
+      "w": null,
+      "h": null,
+      "anchos": [],
+      "color": "#4f3e35",
+      "concepto": "Paisaje de los Médanos de Coro al atardecer. La arena lleva impresos patrones de circuito y ondas de sonido. En el horizonte, una antena solarpunk de barro y cobre silueteada contra un sol naranja.",
+      "anio": 2025,
+      "licenciaDetalle": {
+        "tipo": "cc-by-nc",
+        "print": true
+      },
+      "procedencia": {
+        "herramienta": "Midjourney"
+      },
+      "edicion": "01"
+    },
+    {
+      "slug": "men-in-hats-standing-on-snow-next-to-940f9ae4-1",
+      "serie": "archivo",
+      "orden": 503,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "men in hats standing on snow next to mountains in the style o",
+        "generacion": "940f9ae4-6d68-4d13-82ef-05a7d5862d0f",
+        "variante": 1
+      },
+      "titulo": "Men in hats standing on snow next to",
+      "alt": "men in hats standing on snow next to mountains in the style o",
+      "w": 1264,
+      "h": 944,
+      "anchos": [
+        400,
+        800,
+        1264
+      ],
+      "color": "#8a8a8a",
+      "generacion": "940f9ae4-6d68-4d13-82ef-05a7d5862d0f"
+    },
+    {
+      "slug": "minimalist-logo-for-pulse-an-asistant-for-keepin-5448c501-3",
+      "serie": "archivo",
+      "orden": 504,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "minimalist logo for pulse an asistant for keeping track your",
+        "generacion": "5448c501-cdee-4905-8edd-26100961919e",
+        "variante": 3
+      },
+      "titulo": "Minimalist logo for pulse an asistant for keeping",
+      "alt": "minimalist logo for pulse an asistant for keeping track your",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#355687",
+      "generacion": "5448c501-cdee-4905-8edd-26100961919e"
+    },
+    {
+      "slug": "minimalist-logo-in-the-shape-of-wave-lenghts-abfc611c-0",
+      "serie": "archivo",
+      "orden": 505,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "minimalist logo in the shape of wave lenghts with quirky and",
+        "generacion": "abfc611c-0a19-493d-adc5-6a7728a30c4d",
+        "variante": 0
+      },
+      "titulo": "Minimalist logo in the shape of wave lenghts",
+      "alt": "minimalist logo in the shape of wave lenghts with quirky and",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#070809",
+      "generacion": "abfc611c-0a19-493d-adc5-6a7728a30c4d"
+    },
+    {
+      "slug": "minimalist-monochromatic-for-pulse-an-asistant-f-94d3370b-1",
+      "serie": "archivo",
+      "orden": 506,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "minimalist monochromatic for pulse an asistant for keeping tr",
+        "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341",
+        "variante": 1
+      },
+      "titulo": "Minimalist monochromatic for pulse an asistant for keeping",
+      "alt": "minimalist monochromatic for pulse an asistant for keeping tr",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2a5073",
+      "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341"
+    },
+    {
+      "slug": "minimalist-monochromatic-for-pulse-an-asistant-f-94d3370b-2",
+      "serie": "archivo",
+      "orden": 507,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "minimalist monochromatic for pulse an asistant for keeping tr",
+        "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341",
+        "variante": 2
+      },
+      "titulo": "Minimalist monochromatic for pulse an asistant for keeping",
+      "alt": "minimalist monochromatic for pulse an asistant for keeping tr",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3e4153",
+      "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341"
+    },
+    {
+      "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-0",
+      "serie": "archivo",
+      "orden": 508,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Minimalist science fiction magazine cover photography --ar 16",
+        "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
+        "variante": 0
+      },
+      "titulo": "Minimalist science fiction magazine cover photography",
+      "alt": "Minimalist science fiction magazine cover photography",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#616b55",
+      "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245"
+    },
+    {
+      "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-1",
+      "serie": "archivo",
+      "orden": 509,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Minimalist science fiction magazine cover photography --ar 16",
+        "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
+        "variante": 1
+      },
+      "titulo": "Minimalist science fiction magazine cover photography",
+      "alt": "Minimalist science fiction magazine cover photography",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#526f61",
+      "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245"
+    },
+    {
+      "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-2",
+      "serie": "archivo",
+      "orden": 510,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Minimalist science fiction magazine cover photography --ar 16",
+        "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
+        "variante": 2
+      },
+      "titulo": "Minimalist science fiction magazine cover photography",
+      "alt": "Minimalist science fiction magazine cover photography",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#6a6a5f",
+      "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245"
+    },
+    {
+      "slug": "minimalist-science-fiction-magazine-cover-photog-53702410-2",
+      "serie": "archivo",
+      "orden": 511,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Minimalist science fiction magazine cover photography --ar 16",
+        "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c",
+        "variante": 2
+      },
+      "titulo": "Minimalist science fiction magazine cover photography",
+      "alt": "Minimalist science fiction magazine cover photography",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#4c4b4b",
+      "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c"
+    },
+    {
+      "slug": "minimalist-science-fiction-magazine-cover-photog-53702410-3",
+      "serie": "archivo",
+      "orden": 512,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Minimalist science fiction magazine cover photography --ar 16",
+        "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c",
+        "variante": 3
+      },
+      "titulo": "Minimalist science fiction magazine cover photography",
+      "alt": "Minimalist science fiction magazine cover photography",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#488b95",
+      "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c"
+    },
+    {
+      "slug": "movie-cinematic-still-of-a-medium-sh-2c992c98-0",
+      "serie": "archivo",
+      "orden": 513,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie cinematic still of a medium sh",
+        "generacion": "2c992c98-303e-4c56-8e9b-8fa822fb4df3",
+        "variante": 0
+      },
+      "titulo": "Movie cinematic still of a medium sh",
+      "alt": "Movie cinematic still of a medium sh",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#1c3341",
+      "generacion": "2c992c98-303e-4c56-8e9b-8fa822fb4df3"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-08b62b1e-3",
+      "serie": "archivo",
+      "orden": 514,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "08b62b1e-aa5a-4fca-ae44-af596fecbe00",
+        "variante": 3
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#372c33",
+      "generacion": "08b62b1e-aa5a-4fca-ae44-af596fecbe00"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-3f7f6f89-1",
+      "serie": "archivo",
+      "orden": 515,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82",
+        "variante": 1
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#37232f",
+      "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-3f7f6f89-3",
+      "serie": "archivo",
+      "orden": 516,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82",
+        "variante": 3
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#27262b",
+      "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-4ae21d91-0",
+      "serie": "archivo",
+      "orden": 517,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "4ae21d91-3328-4b9c-adc0-7be61f5f3374",
+        "variante": 0
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#2d3138",
+      "generacion": "4ae21d91-3328-4b9c-adc0-7be61f5f3374"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-6ca482c8-0",
+      "serie": "archivo",
+      "orden": 518,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "6ca482c8-4536-4657-b5ba-eaef74169a3a",
+        "variante": 0
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#252028",
+      "generacion": "6ca482c8-4536-4657-b5ba-eaef74169a3a"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-8df90112-1",
+      "serie": "archivo",
+      "orden": 519,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "8df90112-475a-416b-8a79-690972131c3b",
+        "variante": 1
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#231d1e",
+      "generacion": "8df90112-475a-416b-8a79-690972131c3b"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-d49b413f-2",
+      "serie": "archivo",
+      "orden": 520,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "d49b413f-6e77-4d2d-99ea-12f5d6a71cdb",
+        "variante": 2
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#221f25",
+      "generacion": "d49b413f-6e77-4d2d-99ea-12f5d6a71cdb"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-sc-f33e029e-3",
+      "serie": "archivo",
+      "orden": 521,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim sc",
+        "generacion": "f33e029e-7429-47dd-94fb-f5a7a5a44519",
+        "variante": 3
+      },
+      "titulo": "Movie still of a medium shot grim sc",
+      "alt": "Movie still of a medium shot grim sc",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#1c2126",
+      "generacion": "f33e029e-7429-47dd-94fb-f5a7a5a44519"
+    },
+    {
+      "slug": "movie-still-of-a-medium-shot-grim-scene-7d1a34b0-0",
+      "serie": "archivo",
+      "orden": 522,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Movie still of a medium shot grim scene a hairy terrifying an",
+        "generacion": "7d1a34b0-9126-451a-8bc0-bae578a12c12",
+        "variante": 0
+      },
+      "titulo": "Movie still of a medium shot grim scene",
+      "alt": "Movie still of a medium shot grim scene a hairy terrifying an",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#131c21",
+      "generacion": "7d1a34b0-9126-451a-8bc0-bae578a12c12"
+    },
+    {
+      "slug": "mulato-man-with-dark-skin-wears-a-vintage-30802e38-2",
+      "serie": "archivo",
+      "orden": 523,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+        "generacion": "30802e38-5fec-4fd3-9672-d6896b97f6f9",
+        "variante": 2
+      },
+      "titulo": "Mulato Man with dark skin wears a vintage",
+      "alt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#81848d",
+      "generacion": "30802e38-5fec-4fd3-9672-d6896b97f6f9"
+    },
+    {
+      "slug": "mulato-man-with-dark-skin-wears-a-vintage-3ae49587-1",
+      "serie": "archivo",
+      "orden": 524,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+        "generacion": "3ae49587-138d-4618-b088-54749c8dedc6",
+        "variante": 1
+      },
+      "titulo": "Mulato Man with dark skin wears a vintage",
+      "alt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#92a3ba",
+      "generacion": "3ae49587-138d-4618-b088-54749c8dedc6"
+    },
+    {
+      "slug": "music-magazine-cover-of-a-futuristic-caqueto-wom-a1101b34-0",
+      "serie": "archivo",
+      "orden": 525,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+        "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba",
+        "variante": 0
+      },
+      "titulo": "Music Magazine cover of a futuristic Caqueto Woman",
+      "alt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#27251f",
+      "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba"
+    },
+    {
+      "slug": "music-magazine-cover-of-a-futuristic-caqueto-wom-a1101b34-3",
+      "serie": "archivo",
+      "orden": 526,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+        "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba",
+        "variante": 3
+      },
+      "titulo": "Music Magazine cover of a futuristic Caqueto Woman",
+      "alt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#382319",
+      "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba"
+    },
+    {
+      "slug": "music-magazine-curiana-radio-title-type-in-90s-dc2600db-3",
+      "serie": "archivo",
+      "orden": 527,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Music Magazine Curiana Radio title type in 90s style - --ar 3",
+        "generacion": "dc2600db-f27a-4e30-af7c-6470afce0c3a",
+        "variante": 3
+      },
+      "titulo": "Music Magazine Curiana Radio title type in 90s",
+      "alt": "Music Magazine Curiana Radio title type in 90s style -",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#414135",
+      "generacion": "dc2600db-f27a-4e30-af7c-6470afce0c3a"
+    },
+    {
+      "slug": "music-magazine-titled-curiana-radio-ce96d707-3",
+      "serie": "archivo",
+      "orden": 528,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Music Magazine titled Curiana Radio",
+        "generacion": "ce96d707-2dca-4858-b7f2-baae83bfd8d2",
+        "variante": 3
+      },
+      "titulo": "Music Magazine titled Curiana Radio",
+      "alt": "Music Magazine titled Curiana Radio",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#7b8174",
+      "generacion": "ce96d707-2dca-4858-b7f2-baae83bfd8d2"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-06c61482-1",
+      "serie": "archivo",
+      "orden": 529,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 2000s arawak socei",
+        "generacion": "06c61482-495c-4a2f-93a9-f52c6ff58ecc",
+        "variante": 1
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#756067",
+      "generacion": "06c61482-495c-4a2f-93a9-f52c6ff58ecc"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-0d45fa0b-0",
+      "serie": "archivo",
+      "orden": 530,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s arawak socei",
+        "generacion": "0d45fa0b-5eb6-4f01-98e3-4cab0721464b",
+        "variante": 0
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#63726c",
+      "generacion": "0d45fa0b-5eb6-4f01-98e3-4cab0721464b"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-1cf26918-1",
+      "serie": "archivo",
+      "orden": 531,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 2000s arawak socei",
+        "generacion": "1cf26918-afe3-4d55-9408-067af333cd09",
+        "variante": 1
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#402116",
+      "generacion": "1cf26918-afe3-4d55-9408-067af333cd09"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-1cf26918-2",
+      "serie": "archivo",
+      "orden": 532,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 2000s arawak socei",
+        "generacion": "1cf26918-afe3-4d55-9408-067af333cd09",
+        "variante": 2
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1c242f",
+      "generacion": "1cf26918-afe3-4d55-9408-067af333cd09"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-398b77bf-1",
+      "serie": "archivo",
+      "orden": 533,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 2000s arawak socei",
+        "generacion": "398b77bf-98cb-4f6e-b588-aa7609a52adf",
+        "variante": 1
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#a14f41",
+      "generacion": "398b77bf-98cb-4f6e-b588-aa7609a52adf"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-85c7980f-3",
+      "serie": "archivo",
+      "orden": 534,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s japanese pho",
+        "generacion": "85c7980f-5ace-498f-8d46-5bda23a6728c",
+        "variante": 3
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#49422b",
+      "generacion": "85c7980f-5ace-498f-8d46-5bda23a6728c"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-9a5e59c0-0",
+      "serie": "archivo",
+      "orden": 535,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s venezuelan p",
+        "generacion": "9a5e59c0-5e33-4ca3-8801-e7a6cd89d3f2",
+        "variante": 0
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s venezuelan p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#7a4f34",
+      "generacion": "9a5e59c0-5e33-4ca3-8801-e7a6cd89d3f2"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-9dc8b50c-2",
+      "serie": "archivo",
+      "orden": 536,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 2000s arawak socei",
+        "generacion": "9dc8b50c-68ce-46e6-9d4e-f363aa695651",
+        "variante": 2
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b221b",
+      "generacion": "9dc8b50c-68ce-46e6-9d4e-f363aa695651"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-a1069948-2",
+      "serie": "archivo",
+      "orden": 537,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s japanese pho",
+        "generacion": "a1069948-d882-4469-840b-8e3d1c2bbeac",
+        "variante": 2
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#697767",
+      "generacion": "a1069948-d882-4469-840b-8e3d1c2bbeac"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-cf4db9a0-3",
+      "serie": "archivo",
+      "orden": 538,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s venezuelan p",
+        "generacion": "cf4db9a0-90b7-45c3-986a-696b70774dba",
+        "variante": 3
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s venezuelan p",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#513634",
+      "generacion": "cf4db9a0-90b7-45c3-986a-696b70774dba"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-e117d47b-2",
+      "serie": "archivo",
+      "orden": 539,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s arawak socei",
+        "generacion": "e117d47b-22df-4129-8735-da73bb249e18",
+        "variante": 2
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s arawak socei",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#30363c",
+      "generacion": "e117d47b-22df-4129-8735-da73bb249e18"
+    },
+    {
+      "slug": "night-in-the-city-postcard-in-the-style-f2cfba9b-2",
+      "serie": "archivo",
+      "orden": 540,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the city postcard in the style of 1970s japanese pho",
+        "generacion": "f2cfba9b-5587-4951-9bf4-6df6467d23b7",
+        "variante": 2
+      },
+      "titulo": "Night in the city postcard in the style",
+      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#938984",
+      "generacion": "f2cfba9b-5587-4951-9bf4-6df6467d23b7"
+    },
+    {
+      "slug": "night-in-the-sea-postcard-in-the-style-020002d0-2",
+      "serie": "archivo",
+      "orden": 541,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "night in the sea postcard in the style of 2000s arawak soceit",
+        "generacion": "020002d0-d027-4a46-af2c-552c8ccc170e",
+        "variante": 2
+      },
+      "titulo": "Night in the sea postcard in the style",
+      "alt": "night in the sea postcard in the style of 2000s arawak soceit",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4f6e84",
+      "generacion": "020002d0-d027-4a46-af2c-552c8ccc170e"
+    },
+    {
+      "slug": "noche-de-desierto",
+      "titulo": "Noche de desierto",
+      "alt": "Desierto nocturno panorámico bajo un cielo de estrellas densas, con una única luz diminuta encendida a lo lejos.",
+      "serie": "umbral",
+      "orden": 542,
+      "estado": "pendiente",
+      "tags": [
+        "paisaje",
+        "noche",
+        "desierto"
+      ],
+      "licencia": "cc-by-nc",
+      "w": null,
+      "h": null,
+      "anchos": [],
+      "color": "#4f3e35",
+      "concepto": "El desierto de noche bajo un cielo estrellado denso. Una sola luz pequeña —fogata o LED— sostiene la inmensidad.",
+      "anio": 2025,
+      "licenciaDetalle": {
+        "tipo": "cc-by-nc",
+        "print": true
+      },
+      "procedencia": {
+        "herramienta": "Midjourney"
+      },
+      "edicion": "01"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-0ce8227e-3",
+      "serie": "archivo",
+      "orden": 543,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "0ce8227e-dbef-45f1-bd15-c799fb15ff51",
+        "variante": 3
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#776d66",
+      "generacion": "0ce8227e-dbef-45f1-bd15-c799fb15ff51"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-1192c8a4-2",
+      "serie": "archivo",
+      "orden": 544,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "1192c8a4-0c39-48d2-8e2f-f5dc03dce2a4",
+        "variante": 2
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#69604c",
+      "generacion": "1192c8a4-0c39-48d2-8e2f-f5dc03dce2a4"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-1a6caa8a-3",
+      "serie": "archivo",
+      "orden": 545,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "1a6caa8a-730d-4672-b797-efc7614364ee",
+        "variante": 3
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6a5442",
+      "generacion": "1a6caa8a-730d-4672-b797-efc7614364ee"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-775591d8-0",
+      "serie": "archivo",
+      "orden": 546,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "775591d8-3271-4dbd-bda6-97cb784d6dcd",
+        "variante": 0
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#5a3626",
+      "generacion": "775591d8-3271-4dbd-bda6-97cb784d6dcd"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-7866ae51-0",
+      "serie": "archivo",
+      "orden": 547,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "7866ae51-0f8a-48f5-a413-73dd41d44e0a",
+        "variante": 0
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 1400,
+      "h": 2498,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#69604d",
+      "generacion": "7866ae51-0f8a-48f5-a413-73dd41d44e0a"
+    },
+    {
+      "slug": "non-binary-character-with-caribbean-ancestry-a-b-acbe3176-2",
+      "serie": "archivo",
+      "orden": 548,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "non binary character with Caribbean ancestry a bionic arm and",
+        "generacion": "acbe3176-37e1-4505-9099-b10417890bb9",
+        "variante": 2
+      },
+      "titulo": "Non binary character with Caribbean ancestry a bionic",
+      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#463927",
+      "generacion": "acbe3176-37e1-4505-9099-b10417890bb9"
+    },
+    {
+      "slug": "nw22o-httpss-mj-r-4af9de2d-3",
+      "serie": "archivo",
+      "orden": 549,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "nw22o httpss.mj.r",
+        "generacion": "4af9de2d-4e00-449d-a133-24ba9c551851",
+        "variante": 3
+      },
+      "titulo": "Nw22o httpss.mj.r",
+      "alt": "nw22o httpss.mj.r",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2b2a27",
+      "generacion": "4af9de2d-4e00-449d-a133-24ba9c551851"
+    },
+    {
+      "slug": "nw22o-httpss-mj-r-ae8608b6-3",
+      "serie": "archivo",
+      "orden": 550,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "nw22o httpss.mj.r",
+        "generacion": "ae8608b6-ec30-4c67-be93-faec2ffc380b",
+        "variante": 3
+      },
+      "titulo": "Nw22o httpss.mj.r",
+      "alt": "nw22o httpss.mj.r",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#302c28",
+      "generacion": "ae8608b6-ec30-4c67-be93-faec2ffc380b"
+    },
+    {
+      "slug": "o6k-futuristic-city-inside-a-dome-in-pla-2af63a93-1",
+      "serie": "archivo",
+      "orden": 551,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "O6k Futuristic City inside a Dome in Pla",
+        "generacion": "2af63a93-a99f-4026-943e-e5e7ff629947",
+        "variante": 1
+      },
+      "titulo": "O6k Futuristic City inside a Dome in Pla",
+      "alt": "O6k Futuristic City inside a Dome in Pla",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#211c1c",
+      "generacion": "2af63a93-a99f-4026-943e-e5e7ff629947"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-171de610-3",
+      "serie": "archivo",
+      "orden": 552,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "171de610-1932-48a6-8a7f-00d9ffcc3197",
+        "variante": 3
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#534228",
+      "generacion": "171de610-1932-48a6-8a7f-00d9ffcc3197"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-17dc456a-3",
+      "serie": "archivo",
+      "orden": 553,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "17dc456a-ea30-416f-b151-240a2204a810",
+        "variante": 3
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#806f4b",
+      "generacion": "17dc456a-ea30-416f-b151-240a2204a810"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-21734978-1",
+      "serie": "archivo",
+      "orden": 554,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "21734978-3411-4927-b504-546e4d7081bd",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1e1f17",
+      "generacion": "21734978-3411-4927-b504-546e4d7081bd"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-2481fcaa-2",
+      "serie": "archivo",
+      "orden": 555,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "2481fcaa-1f09-4fa3-b4c8-b20e24625878",
+        "variante": 2
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#52452e",
+      "generacion": "2481fcaa-1f09-4fa3-b4c8-b20e24625878"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-2ec1e10e-2",
+      "serie": "archivo",
+      "orden": 556,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "2ec1e10e-7a7d-427f-9091-43a29eb672f1",
+        "variante": 2
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#665d49",
+      "generacion": "2ec1e10e-7a7d-427f-9091-43a29eb672f1"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-3b16cf33-1",
+      "serie": "archivo",
+      "orden": 557,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "3b16cf33-2706-4492-a4c1-e2b8befe783e",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4f4c3d",
+      "generacion": "3b16cf33-2706-4492-a4c1-e2b8befe783e"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-434962ca-3",
+      "serie": "archivo",
+      "orden": 558,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "434962ca-7c67-460e-826e-fbcd7f04289c",
+        "variante": 3
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#aa9372",
+      "generacion": "434962ca-7c67-460e-826e-fbcd7f04289c"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-4fe3520b-2",
+      "serie": "archivo",
+      "orden": 559,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "4fe3520b-287c-4e07-87e4-f6a0fcf09410",
+        "variante": 2
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#887d64",
+      "generacion": "4fe3520b-287c-4e07-87e4-f6a0fcf09410"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-940edc4d-3",
+      "serie": "archivo",
+      "orden": 560,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "940edc4d-1bad-429a-bde7-605a2f8c21c3",
+        "variante": 3
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#68664f",
+      "generacion": "940edc4d-1bad-429a-bde7-605a2f8c21c3"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-a1db1804-1",
+      "serie": "archivo",
+      "orden": 561,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "a1db1804-9775-4ce9-af7a-f4db25d22861",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4a4532",
+      "generacion": "a1db1804-9775-4ce9-af7a-f4db25d22861"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-ab31399b-1",
+      "serie": "archivo",
+      "orden": 562,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "ab31399b-9e56-437d-a433-12425ab213ba",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#a28c6e",
+      "generacion": "ab31399b-9e56-437d-a433-12425ab213ba"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b47420a9-1",
+      "serie": "archivo",
+      "orden": 563,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "b47420a9-4b99-42ef-ba8c-df4646a55d05",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#584d37",
+      "generacion": "b47420a9-4b99-42ef-ba8c-df4646a55d05"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b8e33fb5-1",
+      "serie": "archivo",
+      "orden": 564,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#878579",
+      "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b8e33fb5-2",
+      "serie": "archivo",
+      "orden": 565,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920",
+        "variante": 2
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#625c47",
+      "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-bdd5c1a6-1",
+      "serie": "archivo",
+      "orden": 566,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4e3b16",
+      "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-bdd5c1a6-3",
+      "serie": "archivo",
+      "orden": 567,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317",
+        "variante": 3
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#435369",
+      "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317"
+    },
+    {
+      "slug": "organic-flowing-logo-for-curiana-radio-three-mai-e43a51dc-1",
+      "serie": "archivo",
+      "orden": 568,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Organic flowing logo for Curiana Radio three main spiral wave",
+        "generacion": "e43a51dc-8abe-4ec0-b2b3-821d90b83c46",
+        "variante": 1
+      },
+      "titulo": "Organic flowing logo for Curiana Radio three main",
+      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#575850",
+      "generacion": "e43a51dc-8abe-4ec0-b2b3-821d90b83c46"
+    },
+    {
+      "slug": "painting-of-a-demon-having-his-eyes-on-3a24e9ed-0",
+      "serie": "archivo",
+      "orden": 569,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "painting of a demon having his eyes on the floor of a room in",
+        "generacion": "3a24e9ed-2902-4a09-a5a3-6bad7f98d88c",
+        "variante": 0
+      },
+      "titulo": "Painting of a demon having his eyes on",
+      "alt": "painting of a demon having his eyes on the floor of a room in",
+      "w": 800,
+      "h": 1214,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#504038",
+      "generacion": "3a24e9ed-2902-4a09-a5a3-6bad7f98d88c"
+    },
+    {
+      "slug": "painting-of-a-spaceship-going-through-a-spacial-08a32afd-0",
+      "serie": "archivo",
+      "orden": 570,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "painting of a Spaceship going through a Spacial Wormhole --ch",
+        "generacion": "08a32afd-360a-49e0-894e-662cdb8a462e",
+        "variante": 0
+      },
+      "titulo": "Painting of a Spaceship going through a Spacial",
+      "alt": "painting of a Spaceship going through a Spacial Wormhole",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#917069",
+      "generacion": "08a32afd-360a-49e0-894e-662cdb8a462e"
+    },
+    {
+      "slug": "painting-of-a-spaceship-going-through-a-spacial-504ec514-0",
+      "serie": "archivo",
+      "orden": 571,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "painting of a Spaceship going through a Spacial Wormhole --ch",
+        "generacion": "504ec514-1e20-4385-8933-a21959874894",
+        "variante": 0
+      },
+      "titulo": "Painting of a Spaceship going through a Spacial",
+      "alt": "painting of a Spaceship going through a Spacial Wormhole",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5a3c4e",
+      "generacion": "504ec514-1e20-4385-8933-a21959874894"
+    },
+    {
+      "slug": "panorama-of-a-pintoresque-scene-a-young-couple-99e1b4fc-1",
+      "serie": "archivo",
+      "orden": 572,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panorama of a pintoresque scene a young couple riding a donke",
+        "generacion": "99e1b4fc-1f02-4c92-a5f6-aea4d90aac3d",
+        "variante": 1
+      },
+      "titulo": "Panorama of a pintoresque scene a young couple",
+      "alt": "Panorama of a pintoresque scene a young couple riding a donke",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#577378",
+      "generacion": "99e1b4fc-1f02-4c92-a5f6-aea4d90aac3d"
+    },
+    {
+      "slug": "panorama-of-a-pintoresque-scene-a-young-couple-b8489318-2",
+      "serie": "archivo",
+      "orden": 573,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panorama of a pintoresque scene a young couple riding a donke",
+        "generacion": "b8489318-dbe0-4940-973a-5014ba48b155",
+        "variante": 2
+      },
+      "titulo": "Panorama of a pintoresque scene a young couple",
+      "alt": "Panorama of a pintoresque scene a young couple riding a donke",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#535746",
+      "generacion": "b8489318-dbe0-4940-973a-5014ba48b155"
+    },
+    {
+      "slug": "panorama-of-a-pintoresque-scene-of-a-quintet-6debf54a-0",
+      "serie": "archivo",
+      "orden": 574,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panorama of a pintoresque scene of a quintet playling boleros",
+        "generacion": "6debf54a-a74e-44f9-a601-316c10346e19",
+        "variante": 0
+      },
+      "titulo": "Panorama of a pintoresque scene of a quintet",
+      "alt": "Panorama of a pintoresque scene of a quintet playling boleros",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#292726",
+      "generacion": "6debf54a-a74e-44f9-a601-316c10346e19"
+    },
+    {
+      "slug": "panorama-of-a-pintoresque-scene-of-a-quintet-d94dcb7c-2",
+      "serie": "archivo",
+      "orden": 575,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panorama of a pintoresque scene of a quintet playling cumbia",
+        "generacion": "d94dcb7c-b081-44e0-a7a1-a9c57b6eeb33",
+        "variante": 2
+      },
+      "titulo": "Panorama of a pintoresque scene of a quintet",
+      "alt": "Panorama of a pintoresque scene of a quintet playling cumbia",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#433f3d",
+      "generacion": "d94dcb7c-b081-44e0-a7a1-a9c57b6eeb33"
+    },
+    {
+      "slug": "panoramic-and-cinematic-movie-still-depiction-of-a0f3cf50-2",
+      "serie": "archivo",
+      "orden": 576,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "panoramic and cinematic movie still depiction of duel of two",
+        "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377",
+        "variante": 2
+      },
+      "titulo": "Panoramic and cinematic movie still depiction of duel",
+      "alt": "panoramic and cinematic movie still depiction of duel of two",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#2d2320",
+      "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377"
+    },
+    {
+      "slug": "panoramic-and-cinematic-movie-still-depiction-of-a0f3cf50-3",
+      "serie": "archivo",
+      "orden": 577,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "panoramic and cinematic movie still depiction of duel of two",
+        "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377",
+        "variante": 3
+      },
+      "titulo": "Panoramic and cinematic movie still depiction of duel",
+      "alt": "panoramic and cinematic movie still depiction of duel of two",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#362d1f",
+      "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377"
+    },
+    {
+      "slug": "panoramic-view-a-canoe-rests-in-the-shore-391c9cc2-3",
+      "serie": "archivo",
+      "orden": 578,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view A canoe rests in the shore of a beach with nat",
+        "generacion": "391c9cc2-73a5-4e3f-9b38-9959e248e991",
+        "variante": 3
+      },
+      "titulo": "Panoramic view A canoe rests in the shore",
+      "alt": "Panoramic view A canoe rests in the shore of a beach with nat",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#9cafb4",
+      "generacion": "391c9cc2-73a5-4e3f-9b38-9959e248e991"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-25cbccf8-1",
+      "serie": "archivo",
+      "orden": 579,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "25cbccf8-e922-48a8-a224-fa91946316df",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5f4c30",
+      "generacion": "25cbccf8-e922-48a8-a224-fa91946316df"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-25cbccf8-2",
+      "serie": "archivo",
+      "orden": 580,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "25cbccf8-e922-48a8-a224-fa91946316df",
+        "variante": 2
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#604d30",
+      "generacion": "25cbccf8-e922-48a8-a224-fa91946316df"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-44fff746-1",
+      "serie": "archivo",
+      "orden": 581,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#56515f",
+      "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-44fff746-3",
+      "serie": "archivo",
+      "orden": 582,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6e7774",
+      "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-46b16266-1",
+      "serie": "archivo",
+      "orden": 583,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2f4d4f",
+      "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-46b16266-2",
+      "serie": "archivo",
+      "orden": 584,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b",
+        "variante": 2
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#254f69",
+      "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-4771b1a7-0",
+      "serie": "archivo",
+      "orden": 585,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "4771b1a7-b872-4dae-9b14-78bd6bf859ef",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7d7d5e",
+      "generacion": "4771b1a7-b872-4dae-9b14-78bd6bf859ef"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-6ab28b3f-3",
+      "serie": "archivo",
+      "orden": 586,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "6ab28b3f-797e-459f-bdf6-b07bccc9eb71",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#527766",
+      "generacion": "6ab28b3f-797e-459f-bdf6-b07bccc9eb71"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-7df7f9c2-0",
+      "serie": "archivo",
+      "orden": 587,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "7df7f9c2-2362-4d1a-a2c8-69898996e758",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#ab9560",
+      "generacion": "7df7f9c2-2362-4d1a-a2c8-69898996e758"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-9454aa5a-1",
+      "serie": "archivo",
+      "orden": 588,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "9454aa5a-5235-480b-bfca-7274252d5567",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4e6670",
+      "generacion": "9454aa5a-5235-480b-bfca-7274252d5567"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-955996eb-3",
+      "serie": "archivo",
+      "orden": 589,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "955996eb-bdc7-4d54-a5fe-2be7c2a59c23",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3d515e",
+      "generacion": "955996eb-bdc7-4d54-a5fe-2be7c2a59c23"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-9702d5d6-3",
+      "serie": "archivo",
+      "orden": 590,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "9702d5d6-796a-4eaf-af12-a2c85e5eaedd",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#335755",
+      "generacion": "9702d5d6-796a-4eaf-af12-a2c85e5eaedd"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-9c382ad4-0",
+      "serie": "archivo",
+      "orden": 591,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "9c382ad4-4c72-4040-8c9f-66708d6e89b6",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#335c6e",
+      "generacion": "9c382ad4-4c72-4040-8c9f-66708d6e89b6"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-b417955e-0",
+      "serie": "archivo",
+      "orden": 592,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "b417955e-ad15-4c8b-86c3-b5aef6658f66",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#25747d",
+      "generacion": "b417955e-ad15-4c8b-86c3-b5aef6658f66"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-b4d0daa4-0",
+      "serie": "archivo",
+      "orden": 593,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#25484e",
+      "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-b4d0daa4-3",
+      "serie": "archivo",
+      "orden": 594,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#255355",
+      "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-debc367b-1",
+      "serie": "archivo",
+      "orden": 595,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#586368",
+      "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc"
+    },
+    {
+      "slug": "panoramic-view-of-a-city-of-stilt-houses-debc367b-3",
+      "serie": "archivo",
+      "orden": 596,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of a city of stilt houses submerged in crystal",
+        "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of a city of stilt houses",
+      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#363748",
+      "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc"
+    },
+    {
+      "slug": "panoramic-view-of-hundreds-of-space-74295479-1",
+      "serie": "archivo",
+      "orden": 597,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of Hundreds of Space",
+        "generacion": "74295479-05b4-42c1-b396-e8c42c0574c1",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of Hundreds of Space",
+      "alt": "Panoramic view of Hundreds of Space",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4e3029",
+      "generacion": "74295479-05b4-42c1-b396-e8c42c0574c1"
+    },
+    {
+      "slug": "panoramic-view-of-the-battle-of-cara-8c72e9f0-0",
+      "serie": "archivo",
+      "orden": 598,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of The Battle of Cara",
+        "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of The Battle of Cara",
+      "alt": "Panoramic view of The Battle of Cara",
+      "w": 1904,
+      "h": 640,
+      "anchos": [
+        400,
+        800,
+        1400,
+        1904
+      ],
+      "color": "#524839",
+      "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8"
+    },
+    {
+      "slug": "panoramic-view-of-the-battle-of-cara-8c72e9f0-2",
+      "serie": "archivo",
+      "orden": 599,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of The Battle of Cara",
+        "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8",
+        "variante": 2
+      },
+      "titulo": "Panoramic view of The Battle of Cara",
+      "alt": "Panoramic view of The Battle of Cara",
+      "w": 1904,
+      "h": 640,
+      "anchos": [
+        400,
+        800,
+        1400,
+        1904
+      ],
+      "color": "#4c4b3d",
+      "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8"
+    },
+    {
+      "slug": "panoramic-view-of-the-battle-of-cara-959f30d9-0",
+      "serie": "archivo",
+      "orden": 600,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of The Battle of Cara",
+        "generacion": "959f30d9-b760-4821-9d64-174c99113312",
+        "variante": 0
+      },
+      "titulo": "Panoramic view of The Battle of Cara",
+      "alt": "Panoramic view of The Battle of Cara",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#464337",
+      "generacion": "959f30d9-b760-4821-9d64-174c99113312"
+    },
+    {
+      "slug": "panoramic-view-of-the-battle-of-carabobo-the-8606b895-1",
+      "serie": "archivo",
+      "orden": 601,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+        "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01",
+        "variante": 1
+      },
+      "titulo": "Panoramic view of The Battle of Carabobo the",
+      "alt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#413e37",
+      "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01"
+    },
+    {
+      "slug": "panoramic-view-of-the-battle-of-carabobo-the-8606b895-3",
+      "serie": "archivo",
+      "orden": 602,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+        "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01",
+        "variante": 3
+      },
+      "titulo": "Panoramic view of The Battle of Carabobo the",
+      "alt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3f382d",
+      "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01"
+    },
+    {
+      "slug": "photo-of-pink-clouds-depicting-the-form-of-85614378-1",
+      "serie": "archivo",
+      "orden": 603,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photo of pink clouds depicting the form of geishas smiling ab",
+        "generacion": "85614378-8aea-43e1-829d-e5bcb3f76317",
+        "variante": 1
+      },
+      "titulo": "Photo of pink clouds depicting the form of",
+      "alt": "photo of pink clouds depicting the form of geishas smiling ab",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#ab6c68",
+      "generacion": "85614378-8aea-43e1-829d-e5bcb3f76317"
+    },
+    {
+      "slug": "photograph-of-a-panoramic-view-in-outer-space-6a25e6b6-2",
+      "serie": "archivo",
+      "orden": 604,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a Panoramic view in outer space of Hundreds of",
+        "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24",
+        "variante": 2
+      },
+      "titulo": "Photograph of a Panoramic view in outer space",
+      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4e3422",
+      "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24"
+    },
+    {
+      "slug": "photograph-of-a-panoramic-view-in-outer-space-6a25e6b6-3",
+      "serie": "archivo",
+      "orden": 605,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a Panoramic view in outer space of Hundreds of",
+        "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24",
+        "variante": 3
+      },
+      "titulo": "Photograph of a Panoramic view in outer space",
+      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#443022",
+      "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24"
+    },
+    {
+      "slug": "photograph-of-a-panoramic-view-in-outer-space-c1c49a7f-1",
+      "serie": "archivo",
+      "orden": 606,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a Panoramic view in outer space of Hundreds of",
+        "generacion": "c1c49a7f-85de-4995-be55-84193eb900b3",
+        "variante": 1
+      },
+      "titulo": "Photograph of a Panoramic view in outer space",
+      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2d130e",
+      "generacion": "c1c49a7f-85de-4995-be55-84193eb900b3"
+    },
+    {
+      "slug": "photograph-of-a-scene-of-the-sillouette-of-a7889354-1",
+      "serie": "archivo",
+      "orden": 607,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a scene of the sillouette of a man been abduced",
+        "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69",
+        "variante": 1
+      },
+      "titulo": "Photograph of a scene of the sillouette of",
+      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#514f4c",
+      "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69"
+    },
+    {
+      "slug": "photograph-of-a-scene-of-the-sillouette-of-a7889354-3",
+      "serie": "archivo",
+      "orden": 608,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a scene of the sillouette of a man been abduced",
+        "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69",
+        "variante": 3
+      },
+      "titulo": "Photograph of a scene of the sillouette of",
+      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3a4244",
+      "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69"
+    },
+    {
+      "slug": "photograph-of-a-scene-of-the-sillouette-of-c224da8e-1",
+      "serie": "archivo",
+      "orden": 609,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Photograph of a scene of the sillouette of a man been abduced",
+        "generacion": "c224da8e-fe12-4b04-9bfe-3e96746ca8fd",
+        "variante": 1
+      },
+      "titulo": "Photograph of a scene of the sillouette of",
+      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2c2825",
+      "generacion": "c224da8e-fe12-4b04-9bfe-3e96746ca8fd"
+    },
+    {
+      "slug": "photorealistic-b9cd4ac8-3",
+      "serie": "archivo",
+      "orden": 610,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic --ar 32 --stylize 0 --v 6.1",
+        "generacion": "b9cd4ac8-413a-4444-a9b4-56d040841ebd",
+        "variante": 3
+      },
+      "titulo": "Photorealistic",
+      "alt": "photorealistic",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#73818d",
+      "generacion": "b9cd4ac8-413a-4444-a9b4-56d040841ebd"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-0455d116-2",
+      "serie": "archivo",
+      "orden": 611,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "0455d116-d82d-40a2-b7c8-d86247919b3a",
+        "variante": 2
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2b301a",
+      "generacion": "0455d116-d82d-40a2-b7c8-d86247919b3a"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-a7d49a8b-3",
+      "serie": "archivo",
+      "orden": 612,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "a7d49a8b-7509-403f-8e0a-6fb6bd921658",
+        "variante": 3
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4b4f3e",
+      "generacion": "a7d49a8b-7509-403f-8e0a-6fb6bd921658"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-0",
+      "serie": "archivo",
+      "orden": 613,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
+        "variante": 0
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2b2d1b",
+      "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-1",
+      "serie": "archivo",
+      "orden": 614,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
+        "variante": 1
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#242716",
+      "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-2",
+      "serie": "archivo",
+      "orden": 615,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
+        "variante": 2
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#1d1d22",
+      "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-eebb890b-2",
+      "serie": "archivo",
+      "orden": 616,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous ceramic artesan creati",
+        "generacion": "eebb890b-3881-4525-bb95-b6532e6052af",
+        "variante": 2
+      },
+      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
+      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#39291c",
+      "generacion": "eebb890b-3881-4525-bb95-b6532e6052af"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-palafitte-6bee269a-3",
+      "serie": "archivo",
+      "orden": 617,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous palafittes dwellings o",
+        "generacion": "6bee269a-6e7e-4d9d-ada4-ae41d88201ea",
+        "variante": 3
+      },
+      "titulo": "Photorealistic portrayal of indigenous palafittes dwellings o",
+      "alt": "photorealistic portrayal of indigenous palafittes dwellings o",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#666257",
+      "generacion": "6bee269a-6e7e-4d9d-ada4-ae41d88201ea"
+    },
+    {
+      "slug": "photorealistic-portrayal-of-indigenous-palafitte-93c41bf1-3",
+      "serie": "archivo",
+      "orden": 618,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "photorealistic portrayal of indigenous palafittes dwellings o",
+        "generacion": "93c41bf1-513b-4977-9ce2-1659e3e096d4",
+        "variante": 3
+      },
+      "titulo": "Photorealistic portrayal of indigenous palafittes dwellings o",
+      "alt": "photorealistic portrayal of indigenous palafittes dwellings o",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3c405b",
+      "generacion": "93c41bf1-513b-4977-9ce2-1659e3e096d4"
+    },
+    {
+      "slug": "pixel-art-lanscape-photograph-of-rio-de-janeiro-42afcc3d-2",
+      "serie": "archivo",
+      "orden": 619,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Pixel art lanscape photograph of Rio de Janeiro with the cris",
+        "generacion": "42afcc3d-f1f9-4a7c-a267-0f8cf6744fe6",
+        "variante": 2
+      },
+      "titulo": "Pixel art lanscape photograph of Rio de Janeiro",
+      "alt": "Pixel art lanscape photograph of Rio de Janeiro with the cris",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#335071",
+      "generacion": "42afcc3d-f1f9-4a7c-a267-0f8cf6744fe6"
+    },
+    {
+      "slug": "pixelart-of-scene-with-a-caqueto-boy-in-aaf09862-0",
+      "serie": "archivo",
+      "orden": 620,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "pixelart of scene with a caqueto boy in indigenous attire sit",
+        "generacion": "aaf09862-762a-4778-b787-92a5d86448b5",
+        "variante": 0
+      },
+      "titulo": "Pixelart of scene with a caqueto boy in",
+      "alt": "pixelart of scene with a caqueto boy in indigenous attire sit",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#75606c",
+      "generacion": "aaf09862-762a-4778-b787-92a5d86448b5"
+    },
+    {
+      "slug": "police-man-incuring-in-a-trafficc-stop-in-35486a22-0",
+      "serie": "archivo",
+      "orden": 621,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+        "generacion": "35486a22-1c40-431f-b03d-d3c40e5526cc",
+        "variante": 0
+      },
+      "titulo": "Police man incuring in a trafficc stop in",
+      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#804c70",
+      "generacion": "35486a22-1c40-431f-b03d-d3c40e5526cc"
+    },
+    {
+      "slug": "police-man-incuring-in-a-trafficc-stop-in-6c60b2b4-0",
+      "serie": "archivo",
+      "orden": 622,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+        "generacion": "6c60b2b4-058c-4f46-a819-4df535a22c4d",
+        "variante": 0
+      },
+      "titulo": "Police man incuring in a trafficc stop in",
+      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#86587b",
+      "generacion": "6c60b2b4-058c-4f46-a819-4df535a22c4d"
+    },
+    {
+      "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-0",
+      "serie": "archivo",
+      "orden": 623,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+        "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
+        "variante": 0
+      },
+      "titulo": "Police man incuring in a trafficc stop in",
+      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7b246e",
+      "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156"
+    },
+    {
+      "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-2",
+      "serie": "archivo",
+      "orden": 624,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+        "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
+        "variante": 2
+      },
+      "titulo": "Police man incuring in a trafficc stop in",
+      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#733837",
+      "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156"
+    },
+    {
+      "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-3",
+      "serie": "archivo",
+      "orden": 625,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+        "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
+        "variante": 3
+      },
+      "titulo": "Police man incuring in a trafficc stop in",
+      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5b5344",
+      "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156"
+    },
+    {
+      "slug": "portrait-a-young-latinoamerican-goths-vampire-in-bcf7c3d6-0",
+      "serie": "archivo",
+      "orden": 626,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "portrait A young latinoamerican goths vampire in a discotek t",
+        "generacion": "bcf7c3d6-2688-4d8a-9ac2-c624024efa41",
+        "variante": 0
+      },
+      "titulo": "Portrait A young latinoamerican goths vampire in a",
+      "alt": "portrait A young latinoamerican goths vampire in a discotek t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#696065",
+      "generacion": "bcf7c3d6-2688-4d8a-9ac2-c624024efa41"
+    },
+    {
+      "slug": "product-shot-of-a-tin-foil-paper-origami-d2226670-0",
+      "serie": "archivo",
+      "orden": 627,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Product Shot of a tin foil paper Origami unicorn with an opaq",
+        "generacion": "d2226670-b121-4a31-92bd-fa95124acac1",
+        "variante": 0
+      },
+      "titulo": "Product Shot of a tin foil paper Origami",
+      "alt": "Product Shot of a tin foil paper Origami unicorn with an opaq",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#445174",
+      "generacion": "d2226670-b121-4a31-92bd-fa95124acac1"
+    },
+    {
+      "slug": "prompt-early-11th-century-medieval-spain-a-figur-a083fe8f-0",
+      "serie": "archivo",
+      "orden": 628,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Prompt Early 11th century medieval Spain a figure hides in a",
+        "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20",
+        "variante": 0
+      },
+      "titulo": "Prompt Early 11th century medieval Spain a figure",
+      "alt": "Prompt Early 11th century medieval Spain a figure hides in a",
+      "w": 800,
+      "h": 1062,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#3a3a3a",
+      "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20"
+    },
+    {
+      "slug": "prompt-early-11th-century-medieval-spain-a-figur-a083fe8f-3",
+      "serie": "archivo",
+      "orden": 629,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Prompt Early 11th century medieval Spain a figure hides in a",
+        "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20",
+        "variante": 3
+      },
+      "titulo": "Prompt Early 11th century medieval Spain a figure",
+      "alt": "Prompt Early 11th century medieval Spain a figure hides in a",
+      "w": 800,
+      "h": 1062,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#555553",
+      "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20"
+    },
+    {
+      "slug": "psycodelic-cover-art-of-a-internal-dialog-titled-4b5ac5f3-2",
+      "serie": "archivo",
+      "orden": 630,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic cover art of a internal dialog titled Dialogo Inte",
+        "generacion": "4b5ac5f3-860b-46d4-9779-3a46eafd44dc",
+        "variante": 2
+      },
+      "titulo": "Psycodelic cover art of a internal dialog titled",
+      "alt": "Psycodelic cover art of a internal dialog titled Dialogo Inte",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#8f614f",
+      "generacion": "4b5ac5f3-860b-46d4-9779-3a46eafd44dc"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-0",
+      "serie": "archivo",
+      "orden": 631,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
+        "variante": 0
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5b4a4d",
+      "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-1",
+      "serie": "archivo",
+      "orden": 632,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
+        "variante": 1
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#555c54",
+      "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-2",
+      "serie": "archivo",
+      "orden": 633,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
+        "variante": 2
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6f4b72",
+      "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-3",
+      "serie": "archivo",
+      "orden": 634,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
+        "variante": 3
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5a4650",
+      "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-6c4c92b9-0",
+      "serie": "archivo",
+      "orden": 635,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896",
+        "variante": 0
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#744936",
+      "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-6c4c92b9-2",
+      "serie": "archivo",
+      "orden": 636,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896",
+        "variante": 2
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5e4a73",
+      "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-98e50575-1",
+      "serie": "archivo",
+      "orden": 637,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "98e50575-8558-4d38-b23a-aa31132cbc66",
+        "variante": 1
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#6d6357",
+      "generacion": "98e50575-8558-4d38-b23a-aa31132cbc66"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-c1a4acd8-0",
+      "serie": "archivo",
+      "orden": 638,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40",
+        "variante": 0
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#404348",
+      "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-c1a4acd8-3",
+      "serie": "archivo",
+      "orden": 639,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40",
+        "variante": 3
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#46404a",
+      "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-d70059ab-3",
+      "serie": "archivo",
+      "orden": 640,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "d70059ab-c392-4d5e-860b-f9f03679a1c8",
+        "variante": 3
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#805055",
+      "generacion": "d70059ab-c392-4d5e-860b-f9f03679a1c8"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-e6626d20-1",
+      "serie": "archivo",
+      "orden": 641,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb",
+        "variante": 1
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#46403f",
+      "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb"
+    },
+    {
+      "slug": "psycodelic-scene-of-a-man-in-deep-internal-e6626d20-3",
+      "serie": "archivo",
+      "orden": 642,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+        "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb",
+        "variante": 3
+      },
+      "titulo": "Psycodelic scene of a man in deep internal",
+      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#58463b",
+      "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb"
+    },
+    {
+      "slug": "pulp-image-of-high-tech-room-with-a-20753a3a-1",
+      "serie": "archivo",
+      "orden": 643,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Pulp image of High tech Room with A patient dressed in white",
+        "generacion": "20753a3a-e028-4c9d-a33a-dfeba895bb3f",
+        "variante": 1
+      },
+      "titulo": "Pulp image of High tech Room with A",
+      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#728c9c",
+      "generacion": "20753a3a-e028-4c9d-a33a-dfeba895bb3f"
+    },
+    {
+      "slug": "pulp-image-of-high-tech-room-with-a-f22e2dee-0",
+      "serie": "archivo",
+      "orden": 644,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Pulp image of High tech Room with A patient dressed in white",
+        "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e",
+        "variante": 0
+      },
+      "titulo": "Pulp image of High tech Room with A",
+      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#525a63",
+      "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e"
+    },
+    {
+      "slug": "pulp-image-of-high-tech-room-with-a-f22e2dee-3",
+      "serie": "archivo",
+      "orden": 645,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Pulp image of High tech Room with A patient dressed in white",
+        "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e",
+        "variante": 3
+      },
+      "titulo": "Pulp image of High tech Room with A",
+      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#34426a",
+      "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e"
+    },
+    {
+      "slug": "real-life-portrayal-of-indigenous-palafittes-tow-0f4debfd-1",
+      "serie": "archivo",
+      "orden": 646,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "real life portrayal of indigenous palafittes town over caribb",
+        "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852",
+        "variante": 1
+      },
+      "titulo": "Real life portrayal of indigenous palafittes town over",
+      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3f5158",
+      "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852"
+    },
+    {
+      "slug": "real-life-portrayal-of-indigenous-palafittes-tow-0f4debfd-2",
+      "serie": "archivo",
+      "orden": 647,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "real life portrayal of indigenous palafittes town over caribb",
+        "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852",
+        "variante": 2
+      },
+      "titulo": "Real life portrayal of indigenous palafittes town over",
+      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#41556c",
+      "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852"
+    },
+    {
+      "slug": "real-life-portrayal-of-indigenous-palafittes-tow-87cb74eb-2",
+      "serie": "archivo",
+      "orden": 648,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "real life portrayal of indigenous palafittes town over caribb",
+        "generacion": "87cb74eb-39b5-4438-8dac-e870b91019c1",
+        "variante": 2
+      },
+      "titulo": "Real life portrayal of indigenous palafittes town over",
+      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#7f7870",
+      "generacion": "87cb74eb-39b5-4438-8dac-e870b91019c1"
+    },
+    {
+      "slug": "real-life-portrayal-of-indigenous-palafittes-tow-e2262b4a-0",
+      "serie": "archivo",
+      "orden": 649,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "real life portrayal of indigenous palafittes town over caribb",
+        "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45",
+        "variante": 0
+      },
+      "titulo": "Real life portrayal of indigenous palafittes town over",
+      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#79695d",
+      "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45"
+    },
+    {
+      "slug": "real-life-portrayal-of-indigenous-palafittes-tow-e2262b4a-2",
+      "serie": "archivo",
+      "orden": 650,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "real life portrayal of indigenous palafittes town over caribb",
+        "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45",
+        "variante": 2
+      },
+      "titulo": "Real life portrayal of indigenous palafittes town over",
+      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2d304c",
+      "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45"
+    },
+    {
+      "slug": "realistic-and-cinematic-panoramic-view-of-an-ind-a5019004-3",
+      "serie": "archivo",
+      "orden": 651,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Realistic and cinematic panoramic view of an indigenous city",
+        "generacion": "a5019004-e72d-4858-8b48-17400fbb3857",
+        "variante": 3
+      },
+      "titulo": "Realistic and cinematic panoramic view of an indigenous",
+      "alt": "Realistic and cinematic panoramic view of an indigenous city",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4b5565",
+      "generacion": "a5019004-e72d-4858-8b48-17400fbb3857"
+    },
+    {
+      "slug": "realistic-photography-of-a-boat-in-the-shore-2efae6ee-2",
+      "serie": "archivo",
+      "orden": 652,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Realistic photography of a Boat in the shore of a Venezuelan",
+        "generacion": "2efae6ee-e3ee-4936-9605-cb2e677c59a9",
+        "variante": 2
+      },
+      "titulo": "Realistic photography of a Boat in the shore",
+      "alt": "Realistic photography of a Boat in the shore of a Venezuelan",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#7a9d99",
+      "generacion": "2efae6ee-e3ee-4936-9605-cb2e677c59a9"
+    },
+    {
+      "slug": "red-alien-over-the-city-in-the-style-62939855-1",
+      "serie": "archivo",
+      "orden": 653,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "red alien over the city in the style of soviet realism charle",
+        "generacion": "62939855-b8b2-4dba-8245-c63fd4b39353",
+        "variante": 1
+      },
+      "titulo": "Red alien over the city in the style",
+      "alt": "red alien over the city in the style of soviet realism charle",
+      "w": 800,
+      "h": 1289,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#882616",
+      "generacion": "62939855-b8b2-4dba-8245-c63fd4b39353"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-018b351d-0",
+      "serie": "archivo",
+      "orden": 654,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717",
+        "variante": 0
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#847956",
+      "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-018b351d-2",
+      "serie": "archivo",
+      "orden": 655,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717",
+        "variante": 2
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#766349",
+      "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-5ec1d003-1",
+      "serie": "archivo",
+      "orden": 656,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "5ec1d003-c19a-48f7-8c7f-a506c44486cb",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#49371c",
+      "generacion": "5ec1d003-c19a-48f7-8c7f-a506c44486cb"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-7fa94afc-2",
+      "serie": "archivo",
+      "orden": 657,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "7fa94afc-329a-4585-836a-b712a7d90caa",
+        "variante": 2
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#302315",
+      "generacion": "7fa94afc-329a-4585-836a-b712a7d90caa"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-9ce7c866-0",
+      "serie": "archivo",
+      "orden": 658,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa",
+        "variante": 0
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#591e22",
+      "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-9ce7c866-3",
+      "serie": "archivo",
+      "orden": 659,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa",
+        "variante": 3
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#624738",
+      "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-a16ea7ce-1",
+      "serie": "archivo",
+      "orden": 660,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "a16ea7ce-6349-4cee-ba1b-a7ff46c03a51",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6f391c",
+      "generacion": "a16ea7ce-6349-4cee-ba1b-a7ff46c03a51"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-b940115a-1",
+      "serie": "archivo",
+      "orden": 661,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6d563c",
+      "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-b940115a-3",
+      "serie": "archivo",
+      "orden": 662,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9",
+        "variante": 3
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#66694e",
+      "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-bed97181-1",
+      "serie": "archivo",
+      "orden": 663,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+        "generacion": "bed97181-246d-4dd0-b9da-4a916c78058a",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de un indgena nativo",
+      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#292a1b",
+      "generacion": "bed97181-246d-4dd0-b9da-4a916c78058a"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-una-indgena-nativo-0555f135-1",
+      "serie": "archivo",
+      "orden": 664,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de una indgena nativo americano del",
+        "generacion": "0555f135-5b4a-41a7-8707-6f91933d258e",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de una indgena nativo",
+      "alt": "Retrato de cuerpo entero de una indgena nativo americano del",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#365052",
+      "generacion": "0555f135-5b4a-41a7-8707-6f91933d258e"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-una-indgena-nativo-7f86effa-1",
+      "serie": "archivo",
+      "orden": 665,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de una indgena nativo americano del",
+        "generacion": "7f86effa-f1a1-4796-a175-4b67322d087a",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de una indgena nativo",
+      "alt": "Retrato de cuerpo entero de una indgena nativo americano del",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6b5730",
+      "generacion": "7f86effa-f1a1-4796-a175-4b67322d087a"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-una-mujer-indgena-adb9a6f4-0",
+      "serie": "archivo",
+      "orden": 666,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+        "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de",
+        "variante": 0
+      },
+      "titulo": "Retrato de cuerpo entero de una mujer indgena",
+      "alt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6a542a",
+      "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de"
+    },
+    {
+      "slug": "retrato-de-cuerpo-entero-de-una-mujer-indgena-adb9a6f4-1",
+      "serie": "archivo",
+      "orden": 667,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+        "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de",
+        "variante": 1
+      },
+      "titulo": "Retrato de cuerpo entero de una mujer indgena",
+      "alt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#483e1c",
+      "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de"
+    },
+    {
+      "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-47cd527b-2",
+      "serie": "archivo",
+      "orden": 668,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+        "generacion": "47cd527b-e2aa-49e4-9b77-6184145eea1d",
+        "variante": 2
+      },
+      "titulo": "Retrato de indgena nativo americano del Caribe de",
+      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#6e350f",
+      "generacion": "47cd527b-e2aa-49e4-9b77-6184145eea1d"
+    },
+    {
+      "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-aef3d91a-1",
+      "serie": "archivo",
+      "orden": 669,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+        "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c",
+        "variante": 1
+      },
+      "titulo": "Retrato de indgena nativo americano del Caribe de",
+      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#63350b",
+      "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c"
+    },
+    {
+      "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-aef3d91a-3",
+      "serie": "archivo",
+      "orden": 670,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+        "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c",
+        "variante": 3
+      },
+      "titulo": "Retrato de indgena nativo americano del Caribe de",
+      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "w": 800,
+      "h": 1200,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#633a0c",
+      "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c"
+    },
+    {
+      "slug": "retro-add-for-a-consulting-firm-chucao-consultor-dd4cc2ae-0",
+      "serie": "archivo",
+      "orden": 671,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retro Add for a consulting firm Chucao Consultores --ar 34 --",
+        "generacion": "dd4cc2ae-5f4c-401e-b83b-83dbfaab815a",
+        "variante": 0
+      },
+      "titulo": "Retro Add for a consulting firm Chucao Consultores",
+      "alt": "Retro Add for a consulting firm Chucao Consultores",
+      "w": 800,
+      "h": 1062,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#31321e",
+      "generacion": "dd4cc2ae-5f4c-401e-b83b-83dbfaab815a"
+    },
+    {
+      "slug": "retro-animation-of-an-spacestation-orbitating-on-12287928-2",
+      "serie": "archivo",
+      "orden": 672,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Retro Animation of an spacestation orbitating on Saturns ring",
+        "generacion": "12287928-6f83-4f8a-9959-63cafec14b72",
+        "variante": 2
+      },
+      "titulo": "Retro Animation of an spacestation orbitating on Saturns",
+      "alt": "Retro Animation of an spacestation orbitating on Saturns ring",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#32474f",
+      "generacion": "12287928-6f83-4f8a-9959-63cafec14b72"
+    },
+    {
+      "slug": "roberto-gomez-sci-fi-cover-art-in-the-2fb1301e-2",
+      "serie": "archivo",
+      "orden": 673,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "roberto gomez sci fi cover art in the style of octavio ocampo",
+        "generacion": "2fb1301e-399e-4f4b-a1b7-2dd2c93d8082",
+        "variante": 2
+      },
+      "titulo": "Roberto gomez sci fi cover art in the",
+      "alt": "roberto gomez sci fi cover art in the style of octavio ocampo",
+      "w": 1024,
+      "h": 1120,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#959f9b",
+      "generacion": "2fb1301e-399e-4f4b-a1b7-2dd2c93d8082"
+    },
+    {
+      "slug": "scene-of-a-spaceship-going-through-a-spacial-4c807b3d-2",
+      "serie": "archivo",
+      "orden": 674,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of a Spaceship going through a Spacial Wormhole --ar 32",
+        "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd",
+        "variante": 2
+      },
+      "titulo": "Scene of a Spaceship going through a Spacial",
+      "alt": "scene of a Spaceship going through a Spacial Wormhole",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3f3c79",
+      "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd"
+    },
+    {
+      "slug": "scene-of-a-spaceship-going-through-a-spacial-4c807b3d-3",
+      "serie": "archivo",
+      "orden": 675,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of a Spaceship going through a Spacial Wormhole --ar 32",
+        "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd",
+        "variante": 3
+      },
+      "titulo": "Scene of a Spaceship going through a Spacial",
+      "alt": "scene of a Spaceship going through a Spacial Wormhole",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#67442f",
+      "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd"
+    },
+    {
+      "slug": "scene-of-argentinian-public-transport-bus-ride-a-2d4247cc-0",
+      "serie": "archivo",
+      "orden": 676,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of argentinian public transport bus ride a hungover Man",
+        "generacion": "2d4247cc-cd67-4dad-b1f3-6c36789edc1d",
+        "variante": 0
+      },
+      "titulo": "Scene of argentinian public transport bus ride a",
+      "alt": "Scene of argentinian public transport bus ride a hungover Man",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#816c62",
+      "generacion": "2d4247cc-cd67-4dad-b1f3-6c36789edc1d"
+    },
+    {
+      "slug": "scene-of-homer-singing-about-the-illyad-and-6ad819e7-0",
+      "serie": "archivo",
+      "orden": 677,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Homer singing about the Illyad and Odessy in a taber",
+        "generacion": "6ad819e7-3e24-4460-8518-3c8b39bb5306",
+        "variante": 0
+      },
+      "titulo": "Scene of Homer singing about the Illyad and",
+      "alt": "Scene of Homer singing about the Illyad and Odessy in a taber",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5c4934",
+      "generacion": "6ad819e7-3e24-4460-8518-3c8b39bb5306"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-0a7391d9-0",
+      "serie": "archivo",
+      "orden": 678,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+        "generacion": "0a7391d9-5052-44f8-b57a-d17757848082",
+        "variante": 0
+      },
+      "titulo": "Scene of Simn Bolvar in his deathbed seen",
+      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3d3636",
+      "generacion": "0a7391d9-5052-44f8-b57a-d17757848082"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-75e515dc-0",
+      "serie": "archivo",
+      "orden": 679,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+        "generacion": "75e515dc-1fe8-48a2-bbaa-95770413a122",
+        "variante": 0
+      },
+      "titulo": "Scene of Simn Bolvar in his deathbed seen",
+      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#403629",
+      "generacion": "75e515dc-1fe8-48a2-bbaa-95770413a122"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-8e64f248-0",
+      "serie": "archivo",
+      "orden": 680,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+        "generacion": "8e64f248-d0d5-4f2a-9321-56bda8666c62",
+        "variante": 0
+      },
+      "titulo": "Scene of Simn Bolvar in his deathbed seen",
+      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2f2115",
+      "generacion": "8e64f248-d0d5-4f2a-9321-56bda8666c62"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-a4542761-3",
+      "serie": "archivo",
+      "orden": 681,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+        "generacion": "a4542761-8cf0-4689-927e-78e98a94ae8a",
+        "variante": 3
+      },
+      "titulo": "Scene of Simn Bolvar in his deathbed seen",
+      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#695840",
+      "generacion": "a4542761-8cf0-4689-927e-78e98a94ae8a"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-d80aca38-3",
+      "serie": "archivo",
+      "orden": 682,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+        "generacion": "d80aca38-fb5b-4016-95eb-914dbd40e58e",
+        "variante": 3
+      },
+      "titulo": "Scene of Simn Bolvar in his deathbed seen",
+      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#20140b",
+      "generacion": "d80aca38-fb5b-4016-95eb-914dbd40e58e"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-on-the-deck-of-304e3660-0",
+      "serie": "archivo",
+      "orden": 683,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+        "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8",
+        "variante": 0
+      },
+      "titulo": "Scene of Simn Bolvar on the deck of",
+      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3e4459",
+      "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-on-the-deck-of-304e3660-3",
+      "serie": "archivo",
+      "orden": 684,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+        "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8",
+        "variante": 3
+      },
+      "titulo": "Scene of Simn Bolvar on the deck of",
+      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#363b3f",
+      "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-on-the-deck-of-e2ea718d-0",
+      "serie": "archivo",
+      "orden": 685,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+        "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252",
+        "variante": 0
+      },
+      "titulo": "Scene of Simn Bolvar on the deck of",
+      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#263746",
+      "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252"
+    },
+    {
+      "slug": "scene-of-simn-bolvar-on-the-deck-of-e2ea718d-1",
+      "serie": "archivo",
+      "orden": 686,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+        "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252",
+        "variante": 1
+      },
+      "titulo": "Scene of Simn Bolvar on the deck of",
+      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4c5b5b",
+      "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252"
+    },
+    {
+      "slug": "scene-of-the-young-man-from-argentina-is-f905279b-3",
+      "serie": "archivo",
+      "orden": 687,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young man from Argentina is on a public transpor",
+        "generacion": "f905279b-05cf-4f9d-b8f5-6af920e91b5d",
+        "variante": 3
+      },
+      "titulo": "Scene of the young man from Argentina is",
+      "alt": "scene of the young man from Argentina is on a public transpor",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5a613e",
+      "generacion": "f905279b-05cf-4f9d-b8f5-6af920e91b5d"
+    },
+    {
+      "slug": "scene-of-the-young-man-is-on-a-34082082-0",
+      "serie": "archivo",
+      "orden": 688,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young man is on a public transport in the style",
+        "generacion": "34082082-9a1a-4d85-bd97-a5fab48f118b",
+        "variante": 0
+      },
+      "titulo": "Scene of the young man is on a",
+      "alt": "scene of the young man is on a public transport in the style",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#706a55",
+      "generacion": "34082082-9a1a-4d85-bd97-a5fab48f118b"
+    },
+    {
+      "slug": "scene-of-the-young-man-is-on-a-681333a3-0",
+      "serie": "archivo",
+      "orden": 689,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young man is on a public transport in the style",
+        "generacion": "681333a3-0395-4204-9dc7-22bf09dd2a16",
+        "variante": 0
+      },
+      "titulo": "Scene of the young man is on a",
+      "alt": "scene of the young man is on a public transport in the style",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#473523",
+      "generacion": "681333a3-0395-4204-9dc7-22bf09dd2a16"
+    },
+    {
+      "slug": "scene-of-the-young-woman-from-chile-is-63444059-0",
+      "serie": "archivo",
+      "orden": 690,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young woman from Chile is on a public transport",
+        "generacion": "63444059-a463-4ac5-bef9-74e04607b531",
+        "variante": 0
+      },
+      "titulo": "Scene of the young woman from Chile is",
+      "alt": "scene of the young woman from Chile is on a public transport",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#5f5c46",
+      "generacion": "63444059-a463-4ac5-bef9-74e04607b531"
+    },
+    {
+      "slug": "scene-of-the-young-woman-from-chile-is-d6a0a1b7-0",
+      "serie": "archivo",
+      "orden": 691,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young woman from Chile is on a public transport",
+        "generacion": "d6a0a1b7-db61-4fe8-9171-d12f4246d785",
+        "variante": 0
+      },
+      "titulo": "Scene of the young woman from Chile is",
+      "alt": "scene of the young woman from Chile is on a public transport",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#76674b",
+      "generacion": "d6a0a1b7-db61-4fe8-9171-d12f4246d785"
+    },
+    {
+      "slug": "scene-of-the-young-woman-is-on-a-8abe0443-1",
+      "serie": "archivo",
+      "orden": 692,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young woman is on a public transport in the styl",
+        "generacion": "8abe0443-a148-4cbe-b520-30e9624eb34c",
+        "variante": 1
+      },
+      "titulo": "Scene of the young woman is on a",
+      "alt": "scene of the young woman is on a public transport in the styl",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#625a53",
+      "generacion": "8abe0443-a148-4cbe-b520-30e9624eb34c"
+    },
+    {
+      "slug": "scene-of-the-young-woman-is-on-a-dc2ff759-0",
+      "serie": "archivo",
+      "orden": 693,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young woman is on a public transport in the styl",
+        "generacion": "dc2ff759-7ad6-478e-9dab-6b5393a45412",
+        "variante": 0
+      },
+      "titulo": "Scene of the young woman is on a",
+      "alt": "scene of the young woman is on a public transport in the styl",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#586767",
+      "generacion": "dc2ff759-7ad6-478e-9dab-6b5393a45412"
+    },
+    {
+      "slug": "scene-of-the-young-woman-is-on-a-ee5965eb-0",
+      "serie": "archivo",
+      "orden": 694,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "scene of the young woman is on a public transport in the styl",
+        "generacion": "ee5965eb-07ae-45f3-a4a0-c988b2722a78",
+        "variante": 0
+      },
+      "titulo": "Scene of the young woman is on a",
+      "alt": "scene of the young woman is on a public transport in the styl",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#585f6e",
+      "generacion": "ee5965eb-07ae-45f3-a4a0-c988b2722a78"
+    },
+    {
+      "slug": "simn-bolvar-enters-the-purgatory-and-finds-dante-a8d88371-0",
+      "serie": "archivo",
+      "orden": 695,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+        "generacion": "a8d88371-5c6f-4ddc-91d3-2f1ec0d72868",
+        "variante": 0
+      },
+      "titulo": "Simn Bolvar enters the Purgatory and finds Dante",
+      "alt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#291f18",
+      "generacion": "a8d88371-5c6f-4ddc-91d3-2f1ec0d72868"
+    },
+    {
+      "slug": "simn-bolvar-enters-the-purgatory-and-finds-dante-a936a203-2",
+      "serie": "archivo",
+      "orden": 696,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+        "generacion": "a936a203-e1ab-4d0e-8ae4-41d35a108811",
+        "variante": 2
+      },
+      "titulo": "Simn Bolvar enters the Purgatory and finds Dante",
+      "alt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#2e0e0c",
+      "generacion": "a936a203-e1ab-4d0e-8ae4-41d35a108811"
+    },
+    {
+      "slug": "simn-bolvar-enters-the-purgatory-and-meets-dante-85d12035-0",
+      "serie": "archivo",
+      "orden": 697,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+        "generacion": "85d12035-36a3-40ab-a678-e708ff55a100",
+        "variante": 0
+      },
+      "titulo": "Simn Bolvar enters the Purgatory and meets Dante",
+      "alt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#442f24",
+      "generacion": "85d12035-36a3-40ab-a678-e708ff55a100"
+    },
+    {
+      "slug": "simn-bolvar-enters-the-purgatory-and-meets-dante-85d12035-2",
+      "serie": "archivo",
+      "orden": 698,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+        "generacion": "85d12035-36a3-40ab-a678-e708ff55a100",
+        "variante": 2
+      },
+      "titulo": "Simn Bolvar enters the Purgatory and meets Dante",
+      "alt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#423125",
+      "generacion": "85d12035-36a3-40ab-a678-e708ff55a100"
+    },
+    {
+      "slug": "simn-diaz-with-a-llanero-hat-playing-the-3ec2e540-0",
+      "serie": "archivo",
+      "orden": 699,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+        "generacion": "3ec2e540-a240-4f18-b44d-ad17a455ce45",
+        "variante": 0
+      },
+      "titulo": "Simn Diaz with a Llanero Hat playing the",
+      "alt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#262627",
+      "generacion": "3ec2e540-a240-4f18-b44d-ad17a455ce45"
+    },
+    {
+      "slug": "simn-diaz-with-a-llanero-hat-playing-the-e9b31c68-0",
+      "serie": "archivo",
+      "orden": 700,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+        "generacion": "e9b31c68-8e56-4d39-9e30-64e3501c8825",
+        "variante": 0
+      },
+      "titulo": "Simn Diaz with a Llanero Hat playing the",
+      "alt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#241e26",
+      "generacion": "e9b31c68-8e56-4d39-9e30-64e3501c8825"
+    },
+    {
+      "slug": "slice-of-life-a-blue-jaiba-in-the-5768b748-3",
+      "serie": "archivo",
+      "orden": 701,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life a blue jaiba in the caribbean in Venezuela --ch",
+        "generacion": "5768b748-4766-436f-8721-2171acc25c90",
+        "variante": 3
+      },
+      "titulo": "Slice of life a blue jaiba in the",
+      "alt": "Slice of life a blue jaiba in the caribbean in Venezuela",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#455e67",
+      "generacion": "5768b748-4766-436f-8721-2171acc25c90"
+    },
+    {
+      "slug": "slice-of-life-an-arepera-in-caracas-e45e87c0-0",
+      "serie": "archivo",
+      "orden": 702,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life an arepera in Caracas --chaos 22 --ar 32 --exp",
+        "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993",
+        "variante": 0
+      },
+      "titulo": "Slice of life an arepera in Caracas",
+      "alt": "Slice of life an arepera in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2d2723",
+      "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993"
+    },
+    {
+      "slug": "slice-of-life-an-arepera-in-caracas-e45e87c0-1",
+      "serie": "archivo",
+      "orden": 703,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life an arepera in Caracas --chaos 22 --ar 32 --exp",
+        "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993",
+        "variante": 1
+      },
+      "titulo": "Slice of life an arepera in Caracas",
+      "alt": "Slice of life an arepera in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#426072",
+      "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993"
+    },
+    {
+      "slug": "slice-of-life-human-interaction-in-a-3bbd9168-0",
+      "serie": "archivo",
+      "orden": 704,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life human interaction in a",
+        "generacion": "3bbd9168-384a-4a91-ab86-32bf1b2438bd",
+        "variante": 0
+      },
+      "titulo": "Slice of life human interaction in a",
+      "alt": "slice of life human interaction in a",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#2d4651",
+      "generacion": "3bbd9168-384a-4a91-ab86-32bf1b2438bd"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-17d60dea-1",
+      "serie": "archivo",
+      "orden": 705,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 70 --ar 32 --exp 10 --raw --",
+        "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
+        "variante": 1
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#426b8b",
+      "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-17d60dea-2",
+      "serie": "archivo",
+      "orden": 706,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 70 --ar 32 --exp 10 --raw --",
+        "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
+        "variante": 2
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#536458",
+      "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-17d60dea-3",
+      "serie": "archivo",
+      "orden": 707,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 70 --ar 32 --exp 10 --raw --",
+        "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
+        "variante": 3
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2e566c",
+      "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-4667fe02-1",
+      "serie": "archivo",
+      "orden": 708,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 50",
+        "generacion": "4667fe02-a4b6-4a94-837c-d688980c8861",
+        "variante": 1
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#495a5f",
+      "generacion": "4667fe02-a4b6-4a94-837c-d688980c8861"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-d0acdc97-2",
+      "serie": "archivo",
+      "orden": 709,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 70 --ar 32 --exp 10 --raw --",
+        "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6",
+        "variante": 2
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#2e434a",
+      "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-d0acdc97-3",
+      "serie": "archivo",
+      "orden": 710,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 70 --ar 32 --exp 10 --raw --",
+        "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6",
+        "variante": 3
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#505359",
+      "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-dbe6719d-2",
+      "serie": "archivo",
+      "orden": 711,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 22 --ar 32 --exp 10 --raw --",
+        "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837",
+        "variante": 2
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#46585b",
+      "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-dbe6719d-3",
+      "serie": "archivo",
+      "orden": 712,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 22 --ar 32 --exp 10 --raw --",
+        "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837",
+        "variante": 3
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#697270",
+      "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837"
+    },
+    {
+      "slug": "slice-of-life-in-caracas-df4c31f8-3",
+      "serie": "archivo",
+      "orden": 713,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Caracas --chaos 22 --ar 32 --exp 10 --raw --",
+        "generacion": "df4c31f8-92be-4307-a94e-2a8cf1110b9b",
+        "variante": 3
+      },
+      "titulo": "Slice of life in Caracas",
+      "alt": "Slice of life in Caracas",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#38463d",
+      "generacion": "df4c31f8-92be-4307-a94e-2a8cf1110b9b"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-5bfefad7-2",
+      "serie": "archivo",
+      "orden": 714,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "5bfefad7-2aaf-42d3-95f4-d04bfb358b0e",
+        "variante": 2
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "Slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#425658",
+      "generacion": "5bfefad7-2aaf-42d3-95f4-d04bfb358b0e"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-8382763d-0",
+      "serie": "archivo",
+      "orden": 715,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
+        "variante": 0
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4d4d4f",
+      "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-8382763d-1",
+      "serie": "archivo",
+      "orden": 716,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
+        "variante": 1
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5d6a61",
+      "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-8382763d-2",
+      "serie": "archivo",
+      "orden": 717,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
+        "variante": 2
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3a3636",
+      "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-b196dcb9-1",
+      "serie": "archivo",
+      "orden": 718,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "b196dcb9-3009-46c4-b1d0-9ee246b4e450",
+        "variante": 1
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4f4c3e",
+      "generacion": "b196dcb9-3009-46c4-b1d0-9ee246b4e450"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-b5876fbf-1",
+      "serie": "archivo",
+      "orden": 719,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "b5876fbf-db3a-406c-9202-6b1bc5df2995",
+        "variante": 1
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#61624b",
+      "generacion": "b5876fbf-db3a-406c-9202-6b1bc5df2995"
+    },
+    {
+      "slug": "slice-of-life-in-paraguan-d18ea9ff-3",
+      "serie": "archivo",
+      "orden": 720,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Slice of life in Paraguan --chaos 70 --ar 32 --exp 10 --raw -",
+        "generacion": "d18ea9ff-19be-43d8-91c9-21e83b93e33e",
+        "variante": 3
+      },
+      "titulo": "Slice of life in Paraguan",
+      "alt": "Slice of life in Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4b4f4e",
+      "generacion": "d18ea9ff-19be-43d8-91c9-21e83b93e33e"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-32506529-2",
+      "serie": "archivo",
+      "orden": 721,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 100 --ar 32",
+        "generacion": "32506529-5437-4b2e-b247-b941381b0542",
+        "variante": 2
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#33362f",
+      "generacion": "32506529-5437-4b2e-b247-b941381b0542"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-5760ecff-0",
+      "serie": "archivo",
+      "orden": 722,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 90 --ar 32",
+        "generacion": "5760ecff-f143-4d8b-862a-a9214bf584a9",
+        "variante": 0
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#536156",
+      "generacion": "5760ecff-f143-4d8b-862a-a9214bf584a9"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-6b1ec78b-0",
+      "serie": "archivo",
+      "orden": 723,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 77 --ar 32",
+        "generacion": "6b1ec78b-13d5-4ece-88c8-380e7f249c5f",
+        "variante": 0
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4d4f5c",
+      "generacion": "6b1ec78b-13d5-4ece-88c8-380e7f249c5f"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-6f0ba75b-2",
+      "serie": "archivo",
+      "orden": 724,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 100 --ar 32",
+        "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1",
+        "variante": 2
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#322e34",
+      "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-6f0ba75b-3",
+      "serie": "archivo",
+      "orden": 725,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 100 --ar 32",
+        "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1",
+        "variante": 3
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6e7272",
+      "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-96c65f44-1",
+      "serie": "archivo",
+      "orden": 726,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 90 --ar 32",
+        "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d",
+        "variante": 1
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#44413b",
+      "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-96c65f44-3",
+      "serie": "archivo",
+      "orden": 727,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 90 --ar 32",
+        "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d",
+        "variante": 3
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#636a65",
+      "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-a25f9e10-0",
+      "serie": "archivo",
+      "orden": 728,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 77 --ar 32",
+        "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571",
+        "variante": 0
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#514a43",
+      "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-a25f9e10-1",
+      "serie": "archivo",
+      "orden": 729,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 77 --ar 32",
+        "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571",
+        "variante": 1
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#444545",
+      "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571"
+    },
+    {
+      "slug": "slice-of-life-in-the-pennsula-of-paraguan-a53629f5-0",
+      "serie": "archivo",
+      "orden": 730,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of life in the Pennsula of Paraguan --chaos 77 --ar 32",
+        "generacion": "a53629f5-d506-493e-b9aa-1475137902e0",
+        "variante": 0
+      },
+      "titulo": "Slice of life in the Pennsula of Paraguan",
+      "alt": "slice of life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#414b39",
+      "generacion": "a53629f5-d506-493e-b9aa-1475137902e0"
+    },
+    {
+      "slug": "slice-of-utopic-life-in-the-pennsula-of-983eae4b-0",
+      "serie": "archivo",
+      "orden": 731,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life in the Pennsula of Paraguan --chaos 77 -",
+        "generacion": "983eae4b-1bd6-4aa9-88cf-a4916de63690",
+        "variante": 0
+      },
+      "titulo": "Slice of utopic life in the Pennsula of",
+      "alt": "slice of utopic life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#695d69",
+      "generacion": "983eae4b-1bd6-4aa9-88cf-a4916de63690"
+    },
+    {
+      "slug": "slice-of-utopic-life-in-the-pennsula-of-a19e389c-3",
+      "serie": "archivo",
+      "orden": 732,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life in the Pennsula of Paraguan --chaos 77 -",
+        "generacion": "a19e389c-d909-4af7-8277-f044004011f2",
+        "variante": 3
+      },
+      "titulo": "Slice of utopic life in the Pennsula of",
+      "alt": "slice of utopic life in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#534a43",
+      "generacion": "a19e389c-d909-4af7-8277-f044004011f2"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-p-ddab3fca-3",
+      "serie": "archivo",
+      "orden": 733,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the P",
+        "generacion": "ddab3fca-e628-4dfa-a8e6-ce96779dd668",
+        "variante": 3
+      },
+      "titulo": "Slice of utopic life vistas in the P",
+      "alt": "slice of utopic life vistas in the P",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4c4138",
+      "generacion": "ddab3fca-e628-4dfa-a8e6-ce96779dd668"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-18ff04f9-1",
+      "serie": "archivo",
+      "orden": 734,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan --cha",
+        "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b",
+        "variante": 1
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#44453e",
+      "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-18ff04f9-3",
+      "serie": "archivo",
+      "orden": 735,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan --cha",
+        "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b",
+        "variante": 3
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#374441",
+      "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-3a1f54a6-2",
+      "serie": "archivo",
+      "orden": 736,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "3a1f54a6-0a19-4e92-baec-042d0f08bcbc",
+        "variante": 2
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#412b2f",
+      "generacion": "3a1f54a6-0a19-4e92-baec-042d0f08bcbc"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-0",
+      "serie": "archivo",
+      "orden": 737,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
+        "variante": 0
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#39372f",
+      "generacion": "49db312b-a679-432f-b51a-e329893fe8d3"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-1",
+      "serie": "archivo",
+      "orden": 738,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
+        "variante": 1
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#393a41",
+      "generacion": "49db312b-a679-432f-b51a-e329893fe8d3"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-2",
+      "serie": "archivo",
+      "orden": 739,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
+        "variante": 2
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#504f47",
+      "generacion": "49db312b-a679-432f-b51a-e329893fe8d3"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-3",
+      "serie": "archivo",
+      "orden": 740,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
+        "variante": 3
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#444d50",
+      "generacion": "49db312b-a679-432f-b51a-e329893fe8d3"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-55f95e2d-1",
+      "serie": "archivo",
+      "orden": 741,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "55f95e2d-a94f-46df-9a94-dee1c0a53717",
+        "variante": 1
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3b464a",
+      "generacion": "55f95e2d-a94f-46df-9a94-dee1c0a53717"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-62deeb3e-0",
+      "serie": "archivo",
+      "orden": 742,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+        "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e",
+        "variante": 0
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#495b5e",
+      "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-62deeb3e-1",
+      "serie": "archivo",
+      "orden": 743,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+        "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e",
+        "variante": 1
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3b3e38",
+      "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-9940fd95-0",
+      "serie": "archivo",
+      "orden": 744,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a cai",
+        "generacion": "9940fd95-f6f8-45aa-b2b1-8a6d767697c1",
+        "variante": 0
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a cai",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#362a28",
+      "generacion": "9940fd95-f6f8-45aa-b2b1-8a6d767697c1"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-ee146ea9-0",
+      "serie": "archivo",
+      "orden": 745,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+        "generacion": "ee146ea9-2ea7-42d5-9d3a-3d2d7a028090",
+        "variante": 0
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3f444b",
+      "generacion": "ee146ea9-2ea7-42d5-9d3a-3d2d7a028090"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-fb70df30-2",
+      "serie": "archivo",
+      "orden": 746,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d",
+        "variante": 2
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#404a50",
+      "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d"
+    },
+    {
+      "slug": "slice-of-utopic-life-vistas-in-the-pennsula-fb70df30-3",
+      "serie": "archivo",
+      "orden": 747,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+        "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d",
+        "variante": 3
+      },
+      "titulo": "Slice of utopic life vistas in the Pennsula",
+      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#40403e",
+      "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d"
+    },
+    {
+      "slug": "soldier-poses-in-his-home-in-venezuela-in-7aeb5fef-1",
+      "serie": "archivo",
+      "orden": 748,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "soldier poses in his home in venezuela in the style of laurel",
+        "generacion": "7aeb5fef-dda2-4e9d-ae9e-69b75ed60fed",
+        "variante": 1
+      },
+      "titulo": "Soldier poses in his home in venezuela in",
+      "alt": "soldier poses in his home in venezuela in the style of laurel",
+      "w": 800,
+      "h": 1131,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#302d26",
+      "generacion": "7aeb5fef-dda2-4e9d-ae9e-69b75ed60fed"
+    },
+    {
+      "slug": "space-control-room-with-people-at-desks-and-76f50de1-1",
+      "serie": "archivo",
+      "orden": 749,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "space control room with people at desks and a space view at t",
+        "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e",
+        "variante": 1
+      },
+      "titulo": "Space control room with people at desks and",
+      "alt": "space control room with people at desks and a space view at t",
+      "w": 1376,
+      "h": 864,
+      "anchos": [
+        400,
+        800,
+        1376
+      ],
+      "color": "#232028",
+      "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e"
+    },
+    {
+      "slug": "space-control-room-with-people-at-desks-and-76f50de1-2",
+      "serie": "archivo",
+      "orden": 750,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "space control room with people at desks and a space view at t",
+        "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e",
+        "variante": 2
+      },
+      "titulo": "Space control room with people at desks and",
+      "alt": "space control room with people at desks and a space view at t",
+      "w": 1376,
+      "h": 864,
+      "anchos": [
+        400,
+        800,
+        1376
+      ],
+      "color": "#272529",
+      "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e"
+    },
+    {
+      "slug": "stencil-magazine-font-title-for-cmo-ser-buena-9389a5ae-0",
+      "serie": "archivo",
+      "orden": 751,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+        "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2",
+        "variante": 0
+      },
+      "titulo": "Stencil Magazine font title for Cmo ser buena",
+      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#282727",
+      "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2"
+    },
+    {
+      "slug": "stencil-magazine-font-title-for-cmo-ser-buena-9389a5ae-3",
+      "serie": "archivo",
+      "orden": 752,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+        "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2",
+        "variante": 3
+      },
+      "titulo": "Stencil Magazine font title for Cmo ser buena",
+      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#201f1b",
+      "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2"
+    },
+    {
+      "slug": "stencil-magazine-font-title-for-cmo-ser-buena-dbc0346f-0",
+      "serie": "archivo",
+      "orden": 753,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+        "generacion": "dbc0346f-3c35-43ed-9c12-3f6498151ec4",
+        "variante": 0
+      },
+      "titulo": "Stencil Magazine font title for Cmo ser buena",
+      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#0e0e0d",
+      "generacion": "dbc0346f-3c35-43ed-9c12-3f6498151ec4"
+    },
+    {
+      "slug": "stock-image-corporativa-03c30dbc-0",
+      "serie": "archivo",
+      "orden": 754,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk --stylize 150",
+        "generacion": "03c30dbc-0304-46ef-b08a-c5952e984c0c",
+        "variante": 0
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#173f4e",
+      "generacion": "03c30dbc-0304-46ef-b08a-c5952e984c0c"
+    },
+    {
+      "slug": "stock-image-corporativa-91c23937-0",
+      "serie": "archivo",
+      "orden": 755,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk y6bvj6a --sty",
+        "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
+        "variante": 0
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#725435",
+      "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9"
+    },
+    {
+      "slug": "stock-image-corporativa-91c23937-1",
+      "serie": "archivo",
+      "orden": 756,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk y6bvj6a --sty",
+        "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
+        "variante": 1
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#414a41",
+      "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9"
+    },
+    {
+      "slug": "stock-image-corporativa-91c23937-3",
+      "serie": "archivo",
+      "orden": 757,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk y6bvj6a --sty",
+        "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
+        "variante": 3
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#33383b",
+      "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9"
+    },
+    {
+      "slug": "stock-image-corporativa-da752d00-2",
+      "serie": "archivo",
+      "orden": 758,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk --stylize 150",
+        "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d",
+        "variante": 2
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#1e4552",
+      "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d"
+    },
+    {
+      "slug": "stock-image-corporativa-da752d00-3",
+      "serie": "archivo",
+      "orden": 759,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "stock image corporativa --raw --profile 1d4pjwk --stylize 150",
+        "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d",
+        "variante": 3
+      },
+      "titulo": "Stock image corporativa",
+      "alt": "stock image corporativa",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#2f2f2b",
+      "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d"
+    },
+    {
+      "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-0",
+      "serie": "archivo",
+      "orden": 760,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Teenage wasteland pop art a character on a caribbean beach fi",
+        "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
+        "variante": 0
+      },
+      "titulo": "Teenage wasteland pop art a character on a",
+      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#282a29",
+      "generacion": "547c4f2a-e646-406c-882e-25c69d87c304"
+    },
+    {
+      "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-1",
+      "serie": "archivo",
+      "orden": 761,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Teenage wasteland pop art a character on a caribbean beach fi",
+        "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
+        "variante": 1
+      },
+      "titulo": "Teenage wasteland pop art a character on a",
+      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#464a37",
+      "generacion": "547c4f2a-e646-406c-882e-25c69d87c304"
+    },
+    {
+      "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-2",
+      "serie": "archivo",
+      "orden": 762,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Teenage wasteland pop art a character on a caribbean beach fi",
+        "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
+        "variante": 2
+      },
+      "titulo": "Teenage wasteland pop art a character on a",
+      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3e4448",
+      "generacion": "547c4f2a-e646-406c-882e-25c69d87c304"
+    },
+    {
+      "slug": "the-cover-art-of-the-apocalypse-zine-in-eca0b207-0",
+      "serie": "archivo",
+      "orden": 763,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the cover art of the apocalypse zine in the style of hajime s",
+        "generacion": "eca0b207-58a2-4123-be6a-5cdae5d5b1e1",
+        "variante": 0
+      },
+      "titulo": "The cover art of the apocalypse zine in",
+      "alt": "the cover art of the apocalypse zine in the style of hajime s",
+      "w": 1024,
+      "h": 1120,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#487994",
+      "generacion": "eca0b207-58a2-4123-be6a-5cdae5d5b1e1"
+    },
+    {
+      "slug": "the-earth-monolith-found-in-centralstan-c1890-wi-d5ac46d9-3",
+      "serie": "archivo",
+      "orden": 764,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the earth monolith found in centralstan c1890 with the spiral",
+        "generacion": "d5ac46d9-91a0-4269-92cb-812a719144a8",
+        "variante": 3
+      },
+      "titulo": "The earth monolith found in centralstan c1890 with",
+      "alt": "the earth monolith found in centralstan c1890 with the spiral",
+      "w": 800,
+      "h": 1103,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#948e81",
+      "generacion": "d5ac46d9-91a0-4269-92cb-812a719144a8"
+    },
+    {
+      "slug": "the-man-in-white-is-surrounded-by-many-3faad93b-1",
+      "serie": "archivo",
+      "orden": 765,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the man in white is surrounded by many people in the style of",
+        "generacion": "3faad93b-0967-42c5-a878-74f0a267a801",
+        "variante": 1
+      },
+      "titulo": "The man in white is surrounded by many",
+      "alt": "the man in white is surrounded by many people in the style of",
+      "w": 1328,
+      "h": 912,
+      "anchos": [
+        400,
+        800,
+        1328
+      ],
+      "color": "#585858",
+      "generacion": "3faad93b-0967-42c5-a878-74f0a267a801"
+    },
+    {
+      "slug": "the-sennheiser-space-station-control-549baf68-0",
+      "serie": "archivo",
+      "orden": 766,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the sennheiser space station control",
+        "generacion": "549baf68-936d-4e81-92a0-3d6eff76f78a",
+        "variante": 0
+      },
+      "titulo": "The sennheiser space station control",
+      "alt": "the sennheiser space station control",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#26212e",
+      "generacion": "549baf68-936d-4e81-92a0-3d6eff76f78a"
+    },
+    {
+      "slug": "the-sennheiser-space-station-control-72a31474-1",
+      "serie": "archivo",
+      "orden": 767,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the sennheiser space station control",
+        "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e",
+        "variante": 1
+      },
+      "titulo": "The sennheiser space station control",
+      "alt": "the sennheiser space station control",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#585c4e",
+      "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e"
+    },
+    {
+      "slug": "the-sennheiser-space-station-control-72a31474-3",
+      "serie": "archivo",
+      "orden": 768,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the sennheiser space station control",
+        "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e",
+        "variante": 3
+      },
+      "titulo": "The sennheiser space station control",
+      "alt": "the sennheiser space station control",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#5b6760",
+      "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e"
+    },
+    {
+      "slug": "the-water-has-a-subtle-blue-and-orange-20be483f-0",
+      "serie": "archivo",
+      "orden": 769,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the water has a subtle blue and orange pattern in the style o",
+        "generacion": "20be483f-2718-49f4-8303-c94b8f7e1835",
+        "variante": 0
+      },
+      "titulo": "The water has a subtle blue and orange",
+      "alt": "the water has a subtle blue and orange pattern in the style o",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#90687f",
+      "generacion": "20be483f-2718-49f4-8303-c94b8f7e1835"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-151727f6-0",
+      "serie": "archivo",
+      "orden": 770,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a",
+        "variante": 0
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#635e5b",
+      "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-151727f6-1",
+      "serie": "archivo",
+      "orden": 771,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a",
+        "variante": 1
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#624b53",
+      "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-0",
+      "serie": "archivo",
+      "orden": 772,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
+        "variante": 0
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#857359",
+      "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-2",
+      "serie": "archivo",
+      "orden": 773,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
+        "variante": 2
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#3c3b3b",
+      "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-3",
+      "serie": "archivo",
+      "orden": 774,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
+        "variante": 3
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#695f5e",
+      "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-d91839fc-0",
+      "serie": "archivo",
+      "orden": 775,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "d91839fc-f300-4342-8338-602239605fd0",
+        "variante": 0
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#65423a",
+      "generacion": "d91839fc-f300-4342-8338-602239605fd0"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-d91839fc-1",
+      "serie": "archivo",
+      "orden": 776,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "d91839fc-f300-4342-8338-602239605fd0",
+        "variante": 1
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#715e5a",
+      "generacion": "d91839fc-f300-4342-8338-602239605fd0"
+    },
+    {
+      "slug": "the-young-man-is-on-a-public-transport-d91839fc-3",
+      "serie": "archivo",
+      "orden": 777,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "the young man is on a public transport in the style of psyche",
+        "generacion": "d91839fc-f300-4342-8338-602239605fd0",
+        "variante": 3
+      },
+      "titulo": "The young man is on a public transport",
+      "alt": "the young man is on a public transport in the style of psyche",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#6b6461",
+      "generacion": "d91839fc-f300-4342-8338-602239605fd0"
+    },
+    {
+      "slug": "top-view-of-cinematographic-scene-of-83762f01-0",
+      "serie": "archivo",
+      "orden": 778,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "top view of cinematographic scene of",
+        "generacion": "83762f01-2077-441d-8526-6acbda2ca361",
+        "variante": 0
+      },
+      "titulo": "Top view of cinematographic scene of",
+      "alt": "top view of cinematographic scene of",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#324239",
+      "generacion": "83762f01-2077-441d-8526-6acbda2ca361"
+    },
+    {
+      "slug": "two-aliens-and-an-astronaut-are-resting-side-4fc9e319-0",
+      "serie": "archivo",
+      "orden": 779,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "two aliens and an Astronaut are resting side by side on the g",
+        "generacion": "4fc9e319-81fc-4044-a848-94d1360beb6d",
+        "variante": 0
+      },
+      "titulo": "Two aliens and an Astronaut are resting side",
+      "alt": "two aliens and an Astronaut are resting side by side on the g",
+      "w": 960,
+      "h": 1200,
+      "anchos": [
+        400,
+        800,
+        960
+      ],
+      "color": "#4f4d43",
+      "generacion": "4fc9e319-81fc-4044-a848-94d1360beb6d"
+    },
+    {
+      "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-0",
+      "serie": "archivo",
+      "orden": 780,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Two people looking at each other with tenderness with love sp",
+        "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
+        "variante": 0
+      },
+      "titulo": "Two people looking at each other with tenderness",
+      "alt": "Two people looking at each other with tenderness with love sp",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4d5144",
+      "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7"
+    },
+    {
+      "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-1",
+      "serie": "archivo",
+      "orden": 781,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Two people looking at each other with tenderness with love sp",
+        "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
+        "variante": 1
+      },
+      "titulo": "Two people looking at each other with tenderness",
+      "alt": "Two people looking at each other with tenderness with love sp",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#303a2c",
+      "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7"
+    },
+    {
+      "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-3",
+      "serie": "archivo",
+      "orden": 782,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Two people looking at each other with tenderness with love sp",
+        "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
+        "variante": 3
+      },
+      "titulo": "Two people looking at each other with tenderness",
+      "alt": "Two people looking at each other with tenderness with love sp",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4f2d22",
+      "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7"
+    },
+    {
+      "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-3ccb80ec-3",
+      "serie": "archivo",
+      "orden": 783,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ultra realistic photo of Retro magazine cover of an Martian C",
+        "generacion": "3ccb80ec-34d7-48ab-a8a0-7af1ee115a70",
+        "variante": 3
+      },
+      "titulo": "Ultra realistic photo of Retro magazine cover of",
+      "alt": "Ultra realistic photo of Retro magazine cover of an Martian C",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#806456",
+      "generacion": "3ccb80ec-34d7-48ab-a8a0-7af1ee115a70"
+    },
+    {
+      "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-796b7719-0",
+      "serie": "archivo",
+      "orden": 784,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ultra realistic photo of Retro magazine cover of a the comman",
+        "generacion": "796b7719-e7ba-4c5f-989c-84bf8c10a1f9",
+        "variante": 0
+      },
+      "titulo": "Ultra realistic photo of Retro magazine cover of",
+      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#4a362e",
+      "generacion": "796b7719-e7ba-4c5f-989c-84bf8c10a1f9"
+    },
+    {
+      "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-87f22837-2",
+      "serie": "archivo",
+      "orden": 785,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ultra realistic photo of Retro magazine cover of a the comman",
+        "generacion": "87f22837-9932-4bad-81f9-f4f8fda87ed1",
+        "variante": 2
+      },
+      "titulo": "Ultra realistic photo of Retro magazine cover of",
+      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#444b4b",
+      "generacion": "87f22837-9932-4bad-81f9-f4f8fda87ed1"
+    },
+    {
+      "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-ca102c98-0",
+      "serie": "archivo",
+      "orden": 786,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Ultra realistic photo of Retro magazine cover of a the comman",
+        "generacion": "ca102c98-1f1f-4bd9-979d-c51e932cce3f",
+        "variante": 0
+      },
+      "titulo": "Ultra realistic photo of Retro magazine cover of",
+      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#473a2f",
+      "generacion": "ca102c98-1f1f-4bd9-979d-c51e932cce3f"
+    },
+    {
+      "slug": "un-cuadro-al-leo-de-un-mundo-surreal-905eb375-0",
+      "serie": "archivo",
+      "orden": 787,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Un cuadro al leo de un mundo surreal con un Conejo Blanco con",
+        "generacion": "905eb375-ad33-4e10-b69c-b28adcf1164e",
+        "variante": 0
+      },
+      "titulo": "Un cuadro al leo de un mundo surreal",
+      "alt": "Un cuadro al leo de un mundo surreal con un Conejo Blanco con",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4d4338",
+      "generacion": "905eb375-ad33-4e10-b69c-b28adcf1164e"
+    },
+    {
+      "slug": "un-oso-sale-de-su-cueva-despus-de-55d34b6e-1",
+      "serie": "archivo",
+      "orden": 788,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Un oso sale de su cueva despus de hibernar mirando un sol res",
+        "generacion": "55d34b6e-6eb7-4332-a8f9-8707a36cfe6b",
+        "variante": 1
+      },
+      "titulo": "Un oso sale de su cueva despus de",
+      "alt": "Un oso sale de su cueva despus de hibernar mirando un sol res",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#36322e",
+      "generacion": "55d34b6e-6eb7-4332-a8f9-8707a36cfe6b"
+    },
+    {
+      "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-0b915070-2",
+      "serie": "archivo",
+      "orden": 789,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "underwater high shot photo of lifeless bodies of men women an",
+        "generacion": "0b915070-ee8f-4638-88f9-ee280b69e795",
+        "variante": 2
+      },
+      "titulo": "Underwater high shot photo of lifeless bodies of",
+      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#5d5c71",
+      "generacion": "0b915070-ee8f-4638-88f9-ee280b69e795"
+    },
+    {
+      "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-1db93e4f-1",
+      "serie": "archivo",
+      "orden": 790,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "underwater high shot photo of lifeless bodies of men women an",
+        "generacion": "1db93e4f-e71c-4525-92ad-b6105f09128f",
+        "variante": 1
+      },
+      "titulo": "Underwater high shot photo of lifeless bodies of",
+      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#232526",
+      "generacion": "1db93e4f-e71c-4525-92ad-b6105f09128f"
+    },
+    {
+      "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-871edb1c-1",
+      "serie": "archivo",
+      "orden": 791,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "underwater high shot photo of lifeless bodies of men women an",
+        "generacion": "871edb1c-78fa-406a-b389-44f435efa699",
+        "variante": 1
+      },
+      "titulo": "Underwater high shot photo of lifeless bodies of",
+      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#707484",
+      "generacion": "871edb1c-78fa-406a-b389-44f435efa699"
+    },
+    {
+      "slug": "very-detailed-colonial-oil-painting-group-of-mus-5646f29f-2",
+      "serie": "archivo",
+      "orden": 792,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+        "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551",
+        "variante": 2
+      },
+      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
+      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#38405e",
+      "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551"
+    },
+    {
+      "slug": "very-detailed-colonial-oil-painting-group-of-mus-5646f29f-3",
+      "serie": "archivo",
+      "orden": 793,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+        "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551",
+        "variante": 3
+      },
+      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
+      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#523e41",
+      "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551"
+    },
+    {
+      "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-0",
+      "serie": "archivo",
+      "orden": 794,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+        "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
+        "variante": 0
+      },
+      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
+      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#353c2f",
+      "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f"
+    },
+    {
+      "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-1",
+      "serie": "archivo",
+      "orden": 795,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+        "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
+        "variante": 1
+      },
+      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
+      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#29211d",
+      "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f"
+    },
+    {
+      "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-2",
+      "serie": "archivo",
+      "orden": 796,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+        "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
+        "variante": 2
+      },
+      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
+      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#374641",
+      "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-373931ab-3",
+      "serie": "archivo",
+      "orden": 797,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "373931ab-4b8b-4439-beaa-b32d8e451eaa",
+        "variante": 3
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#554a39",
+      "generacion": "373931ab-4b8b-4439-beaa-b32d8e451eaa"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-4eeb5758-0",
+      "serie": "archivo",
+      "orden": 798,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9",
+        "variante": 0
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#363c4a",
+      "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-4eeb5758-3",
+      "serie": "archivo",
+      "orden": 799,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9",
+        "variante": 3
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#565a58",
+      "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-6fa93c15-3",
+      "serie": "archivo",
+      "orden": 800,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "6fa93c15-1068-4735-95af-177467cf30a8",
+        "variante": 3
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 800,
+      "h": 1427,
+      "anchos": [
+        400,
+        800
+      ],
+      "color": "#483d58",
+      "generacion": "6fa93c15-1068-4735-95af-177467cf30a8"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-be244a62-0",
+      "serie": "archivo",
+      "orden": 801,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "be244a62-95ba-48a9-ab57-9736a97e53c1",
+        "variante": 0
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#524431",
+      "generacion": "be244a62-95ba-48a9-ab57-9736a97e53c1"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-c41029fa-0",
+      "serie": "archivo",
+      "orden": 802,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b",
+        "variante": 0
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#4a5167",
+      "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b"
+    },
+    {
+      "slug": "very-detailed-moody-colonial-oil-painting-of-a-c41029fa-3",
+      "serie": "archivo",
+      "orden": 803,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+        "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b",
+        "variante": 3
+      },
+      "titulo": "Very Detailed moody Colonial oil Painting Of a",
+      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#575365",
+      "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b"
+    },
+    {
+      "slug": "very-detailed-photo-of-a-cinematogra-dfcb3380-1",
+      "serie": "archivo",
+      "orden": 804,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "very detailed photo of a cinematogra",
+        "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b",
+        "variante": 1
+      },
+      "titulo": "Very detailed photo of a cinematogra",
+      "alt": "very detailed photo of a cinematogra",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#1a2721",
+      "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b"
+    },
+    {
+      "slug": "very-detailed-photo-of-a-cinematogra-dfcb3380-3",
+      "serie": "archivo",
+      "orden": 805,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "very detailed photo of a cinematogra",
+        "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b",
+        "variante": 3
+      },
+      "titulo": "Very detailed photo of a cinematogra",
+      "alt": "very detailed photo of a cinematogra",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#21302f",
+      "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b"
+    },
+    {
+      "slug": "very-detailed-photo-of-a-cinematographic-full-vi-8726b12d-2",
+      "serie": "archivo",
+      "orden": 806,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "very detailed photo of a cinematographic full view of Simn B",
+        "generacion": "8726b12d-6328-4bb4-a1c6-f2ff2a288372",
+        "variante": 2
+      },
+      "titulo": "Very detailed photo of a cinematographic full view",
+      "alt": "very detailed photo of a cinematographic full view of Simn B",
+      "w": 672,
+      "h": 512,
+      "anchos": [
+        400,
+        672
+      ],
+      "color": "#344443",
+      "generacion": "8726b12d-6328-4bb4-a1c6-f2ff2a288372"
+    },
+    {
+      "slug": "very-detailed-photo-of-an-indigenous-merchant-se-5107821a-3",
+      "serie": "archivo",
+      "orden": 807,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very detailed photo of an indigenous merchant selling shell c",
+        "generacion": "5107821a-3c59-4294-a881-545e8fd7dcbe",
+        "variante": 3
+      },
+      "titulo": "Very detailed photo of an indigenous merchant selling",
+      "alt": "Very detailed photo of an indigenous merchant selling shell c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#424d4d",
+      "generacion": "5107821a-3c59-4294-a881-545e8fd7dcbe"
+    },
+    {
+      "slug": "very-detailed-photo-of-an-indigenous-merchant-se-e021cc65-0",
+      "serie": "archivo",
+      "orden": 808,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Very detailed photo of an indigenous merchant selling shell c",
+        "generacion": "e021cc65-a587-4401-a7b7-d683bf6dce42",
+        "variante": 0
+      },
+      "titulo": "Very detailed photo of an indigenous merchant selling",
+      "alt": "Very detailed photo of an indigenous merchant selling shell c",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#3a503f",
+      "generacion": "e021cc65-a587-4401-a7b7-d683bf6dce42"
+    },
+    {
+      "slug": "vintage-picture-of-a-horizon-of-a-field-0c1cdd97-2",
+      "serie": "archivo",
+      "orden": 809,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Vintage picture of a horizon of a field with Garden with alie",
+        "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef",
+        "variante": 2
+      },
+      "titulo": "Vintage picture of a horizon of a field",
+      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#4c4336",
+      "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef"
+    },
+    {
+      "slug": "vintage-picture-of-a-horizon-of-a-field-0c1cdd97-3",
+      "serie": "archivo",
+      "orden": 810,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Vintage picture of a horizon of a field with Garden with alie",
+        "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef",
+        "variante": 3
+      },
+      "titulo": "Vintage picture of a horizon of a field",
+      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3c3527",
+      "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef"
+    },
+    {
+      "slug": "vintage-picture-of-a-horizon-of-a-field-3bd72e58-2",
+      "serie": "archivo",
+      "orden": 811,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Vintage picture of a horizon of a field with Garden with alie",
+        "generacion": "3bd72e58-8329-4896-b7ef-83e5a2b0eeff",
+        "variante": 2
+      },
+      "titulo": "Vintage picture of a horizon of a field",
+      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3a2c19",
+      "generacion": "3bd72e58-8329-4896-b7ef-83e5a2b0eeff"
+    },
+    {
+      "slug": "vintage-picture-of-a-road-to-the-horizonwith-5394b061-1",
+      "serie": "archivo",
+      "orden": 812,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "Vintage picture of a Road to the horizonwith alien buildings",
+        "generacion": "5394b061-dffb-41a4-a7da-2555db51628f",
+        "variante": 1
+      },
+      "titulo": "Vintage picture of a Road to the horizonwith",
+      "alt": "Vintage picture of a Road to the horizonwith alien buildings",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#3f3227",
+      "generacion": "5394b061-dffb-41a4-a7da-2555db51628f"
+    },
+    {
+      "slug": "w78je-scene-of-simn-bolvar-in-his-deathbed-2f1f07e7-3",
+      "serie": "archivo",
+      "orden": 813,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "W78JE Scene of Simn Bolvar in his deathbed",
+        "generacion": "2f1f07e7-8281-4e21-b9ec-3c80b8c58025",
+        "variante": 3
+      },
+      "titulo": "W78JE Scene of Simn Bolvar in his deathbed",
+      "alt": "W78JE Scene of Simn Bolvar in his deathbed",
+      "w": 1344,
+      "h": 896,
+      "anchos": [
+        400,
+        800,
+        1344
+      ],
+      "color": "#20221f",
+      "generacion": "2f1f07e7-8281-4e21-b9ec-3c80b8c58025"
+    },
+    {
+      "slug": "w78je-scene-of-simn-bolvar-in-his-deathbed-314cec35-2",
+      "serie": "archivo",
+      "orden": 814,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "W78JE Scene of Simn Bolvar in his deathbed",
+        "generacion": "314cec35-d869-411a-b93f-845d291a2eea",
+        "variante": 2
+      },
+      "titulo": "W78JE Scene of Simn Bolvar in his deathbed",
+      "alt": "W78JE Scene of Simn Bolvar in his deathbed",
+      "w": 1232,
+      "h": 928,
+      "anchos": [
+        400,
+        800,
+        1232
+      ],
+      "color": "#131213",
+      "generacion": "314cec35-d869-411a-b93f-845d291a2eea"
+    },
+    {
+      "slug": "walking-perspective-down-a-santiago-chile-neighb-c3687654-3",
+      "serie": "archivo",
+      "orden": 815,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "walking perspective down a Santiago Chile neighborhood street",
+        "generacion": "c3687654-5bc2-497f-9d8a-17c395097f4a",
+        "variante": 3
+      },
+      "titulo": "Walking perspective down a Santiago Chile neighborhood street",
+      "alt": "walking perspective down a Santiago Chile neighborhood street",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#776f66",
+      "generacion": "c3687654-5bc2-497f-9d8a-17c395097f4a"
+    },
+    {
+      "slug": "west-african-coast-1462-a-merchant-captain-and-6b59c446-2",
+      "serie": "archivo",
+      "orden": 816,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "West African coast 1462 a merchant captain and his first mate",
+        "generacion": "6b59c446-5766-4674-921a-f4912a6fc775",
+        "variante": 2
+      },
+      "titulo": "West African coast 1462 a merchant captain and",
+      "alt": "West African coast 1462 a merchant captain and his first mate",
+      "w": 1400,
+      "h": 785,
+      "anchos": [
+        400,
+        800,
+        1400
+      ],
+      "color": "#99948a",
+      "generacion": "6b59c446-5766-4674-921a-f4912a6fc775"
+    },
+    {
+      "slug": "wide-shot-of-a-gothic-vampire-castle-8b1a9ea7-2",
+      "serie": "archivo",
+      "orden": 817,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a gothic vampire castle --raw --sref 58261644 --",
+        "generacion": "8b1a9ea7-7443-4752-8b25-82304c205dca",
+        "variante": 2
+      },
+      "titulo": "Wide shot of a gothic vampire castle",
+      "alt": "wide shot of a gothic vampire castle",
+      "w": 1024,
+      "h": 1024,
+      "anchos": [
+        400,
+        800,
+        1024
+      ],
+      "color": "#464f47",
+      "generacion": "8b1a9ea7-7443-4752-8b25-82304c205dca"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-1c765ecb-1",
+      "serie": "archivo",
+      "orden": 818,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07",
+        "variante": 1
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#474e55",
+      "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-1c765ecb-3",
+      "serie": "archivo",
+      "orden": 819,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07",
+        "variante": 3
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#545d64",
+      "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-862ac6f5-0",
+      "serie": "archivo",
+      "orden": 820,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91",
+        "variante": 0
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#56554e",
+      "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-862ac6f5-2",
+      "serie": "archivo",
+      "orden": 821,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91",
+        "variante": 2
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#7b745b",
+      "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-0",
+      "serie": "archivo",
+      "orden": 822,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
+        "variante": 0
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#1d2056",
+      "generacion": "c053388a-28fb-46c8-895c-16e2922e046b"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-1",
+      "serie": "archivo",
+      "orden": 823,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
+        "variante": 1
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#494b4e",
+      "generacion": "c053388a-28fb-46c8-895c-16e2922e046b"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-2",
+      "serie": "archivo",
+      "orden": 824,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
+        "variante": 2
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#17292f",
+      "generacion": "c053388a-28fb-46c8-895c-16e2922e046b"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-3",
+      "serie": "archivo",
+      "orden": 825,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
+        "variante": 3
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#3a4761",
+      "generacion": "c053388a-28fb-46c8-895c-16e2922e046b"
+    },
+    {
+      "slug": "wide-shot-of-a-medieval-plaza-in-the-cb19cb80-0",
+      "serie": "archivo",
+      "orden": 826,
+      "estado": "pendiente",
+      "concepto": "",
+      "anio": 2025,
+      "tags": [],
+      "licencia": "reservado",
+      "licenciaDetalle": {
+        "tipo": "reservado",
+        "print": false
+      },
+      "procedencia": {
+        "herramienta": "Midjourney",
+        "prompt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+        "generacion": "cb19cb80-4fd0-4109-b175-4225184ea319",
+        "variante": 0
+      },
+      "titulo": "Wide shot of a Medieval Plaza in the",
+      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "w": 1392,
+      "h": 848,
+      "anchos": [
+        400,
+        800,
+        1392
+      ],
+      "color": "#4f5860",
+      "generacion": "cb19cb80-4fd0-4109-b175-4225184ea319"
+    }
+  ]
+}

--- a/lib/galeria.ts
+++ b/lib/galeria.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+import path from "path";
+import type {
+  GaleriaManifest,
+  Obra,
+  ObraGrid,
+  Serie,
+} from "@/types/galeria";
+
+const MANIFEST_PATH = path.join(
+  process.cwd(),
+  "content",
+  "galeria",
+  "obras.json"
+);
+
+const VACIO: GaleriaManifest = { blobBase: null, series: [], obras: [] };
+
+/**
+ * El manifest se lee una vez por proceso. Con ~800 obras, releer y reparsear
+ * el JSON en cada una de las ~800 llamadas a generateStaticParams/página
+ * convertiría el build en minutos de E/S inútil.
+ */
+let cache: GaleriaManifest | null = null;
+
+function readManifest(): GaleriaManifest {
+  if (cache) return cache;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(MANIFEST_PATH, "utf-8");
+  } catch (err) {
+    // Manifest ausente = galería vacía, estado legítimo (clon nuevo, rama sin
+    // contenido). Mismo criterio que lib/lexicon.ts.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      cache = VACIO;
+      return cache;
+    }
+    throw err;
+  }
+  // JSON roto SÍ debe romper el build: es contenido curado, no dato opcional.
+  const parsed = JSON.parse(raw) as Partial<GaleriaManifest>;
+  cache = {
+    blobBase: parsed.blobBase ?? null,
+    series: parsed.series ?? [],
+    obras: parsed.obras ?? [],
+  };
+  return cache;
+}
+
+/** Orden curatorial: el de `series` en el manifest, y dentro, `orden`. */
+function ordenar(obras: Obra[], series: Serie[]): Obra[] {
+  const pesoSerie = new Map(series.map((s, i) => [s.id, i]));
+  return [...obras].sort((a, b) => {
+    const sa = pesoSerie.get(a.serie) ?? Number.MAX_SAFE_INTEGER;
+    const sb = pesoSerie.get(b.serie) ?? Number.MAX_SAFE_INTEGER;
+    return sa !== sb ? sa - sb : a.orden - b.orden;
+  });
+}
+
+/**
+ * Proyecta el registro completo a lo que necesita el mosaico. Es la frontera
+ * servidor/cliente: todo lo que no esté aquí no cruza. Que `ObraGrid` sea un
+ * tipo aparte —y no un `Omit` del completo— hace que añadir un campo sensible
+ * al manifest no lo filtre por descuido.
+ */
+function aGrid(obra: Obra): ObraGrid {
+  return {
+    slug: obra.slug,
+    titulo: obra.titulo,
+    alt: obra.alt,
+    serie: obra.serie,
+    orden: obra.orden,
+    estado: obra.estado,
+    tags: obra.tags,
+    licencia: obra.licencia,
+    w: obra.w,
+    h: obra.h,
+    anchos: obra.anchos,
+    color: obra.color,
+    generacion: obra.generacion,
+  };
+}
+
+export function getBlobBase(): string | null {
+  return readManifest().blobBase;
+}
+
+export function getSeries(): Serie[] {
+  return readManifest().series;
+}
+
+/** Payload del mosaico. Es lo único que se serializa al cliente. */
+export function getObrasGrid(): ObraGrid[] {
+  const { obras, series } = readManifest();
+  return ordenar(obras, series).map(aGrid);
+}
+
+/** Registro completo. Solo servidor — lo usa la ficha. */
+export function getObra(slug: string): Obra | null {
+  return readManifest().obras.find((o) => o.slug === slug) ?? null;
+}
+
+/** Slugs para generateStaticParams, sin cargar el resto del registro. */
+export function getSlugs(): string[] {
+  const { obras, series } = readManifest();
+  return ordenar(obras, series).map((o) => o.slug);
+}
+
+/** Vecinas en el orden curatorial, para navegar de obra en obra. */
+export function getVecinas(slug: string): {
+  anterior: { slug: string; titulo: string } | null;
+  siguiente: { slug: string; titulo: string } | null;
+} {
+  const { obras, series } = readManifest();
+  const ordenadas = ordenar(obras, series);
+  const i = ordenadas.findIndex((o) => o.slug === slug);
+  if (i === -1) return { anterior: null, siguiente: null };
+  const resumir = (o: Obra | undefined) =>
+    o ? { slug: o.slug, titulo: o.titulo } : null;
+  return {
+    anterior: resumir(ordenadas[i - 1]),
+    siguiente: resumir(ordenadas[i + 1]),
+  };
+}
+
+/**
+ * Tags para los filtros, ordenados por frecuencia. Se recortan a `limite`
+ * porque con ~800 obras la cola larga son cientos de motivos con una sola
+ * obra cada uno: una pared de píldoras que nadie usa.
+ */
+export function getTags(limite = 24): { tag: string; total: number }[] {
+  const cuenta = new Map<string, number>();
+  for (const obra of readManifest().obras) {
+    for (const tag of obra.tags) {
+      cuenta.set(tag, (cuenta.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...cuenta.entries()]
+    .map(([tag, total]) => ({ tag, total }))
+    .sort((a, b) => b.total - a.total || a.tag.localeCompare(b.tag, "es"))
+    .slice(0, limite);
+}
+
+/**
+ * Ruta del original en el bucket privado. Solo servidor: es la pieza que un
+ * futuro checkout usará para firmar una descarga tras verificar el pago.
+ * Nunca pasar el resultado a un componente cliente.
+ */
+export function getOriginalKey(slug: string): string | null {
+  return readManifest().obras.find((o) => o.slug === slug)?.originalKey ?? null;
+}

--- a/lib/mosaico.ts
+++ b/lib/mosaico.ts
@@ -1,0 +1,196 @@
+/**
+ * Motor del mosaico de la galería.
+ *
+ * Reparte las obras en filas justificadas: cada fila ocupa el ancho exacto del
+ * contenedor y su altura sale de las proporciones reales de las imágenes que
+ * le tocaron. Es lo que hace que la grilla se lea como un tejido y no como una
+ * cuadrícula — el tamaño de cada pieza lo decide su forma, no una celda fija.
+ *
+ * Módulo puro: sin DOM, sin `fs`. Lo importan tanto el servidor como el
+ * cliente, y se puede probar llamándolo con números.
+ */
+
+import type { ObraGrid } from "@/types/galeria";
+
+// ── Aleatoriedad reproducible ─────────────────────────────────────────
+
+/** djb2. Determinista y estable entre servidor y cliente. */
+export function hashTexto(texto: string): number {
+  let h = 5381;
+  for (let i = 0; i < texto.length; i++) {
+    h = (h * 33) ^ texto.charCodeAt(i);
+  }
+  return Math.abs(h);
+}
+
+/** mulberry32: PRNG de 32 bits, suficiente para barajar y sembrable. */
+function generador(semilla: number): () => number {
+  let a = semilla >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Fisher-Yates sembrado. Con semilla explícita porque el orden tiene que ser
+ * el mismo dentro de una visita (filtrar no debe rebarajar la galería) y
+ * distinto entre visitas.
+ */
+export function mezclar<T>(items: readonly T[], semilla: number): T[] {
+  const azar = generador(semilla);
+  const copia = [...items];
+  for (let i = copia.length - 1; i > 0; i--) {
+    const j = Math.floor(azar() * (i + 1));
+    [copia[i], copia[j]] = [copia[j], copia[i]];
+  }
+  return copia;
+}
+
+// ── Proporciones ──────────────────────────────────────────────────────
+
+/**
+ * Proporciones plausibles para obras que todavía no tienen render. El mosaico
+ * necesita un aspecto para colocar la pieza; usar 4:5 en todas dejaría una
+ * franja de huecos idénticos que delata el estado pendiente como un bug.
+ * Se elige por hash del slug: la misma obra ocupa siempre la misma forma.
+ */
+const ASPECTOS_PENDIENTE = [16 / 9, 4 / 5, 1, 3 / 2, 21 / 9, 4 / 3];
+
+export function aspectoDeObra(obra: ObraGrid): number {
+  if (obra.w && obra.h) return obra.w / obra.h;
+  return ASPECTOS_PENDIENTE[hashTexto(obra.slug) % ASPECTOS_PENDIENTE.length];
+}
+
+/**
+ * Aparta las variantes hermanas de una misma generación.
+ *
+ * Midjourney devuelve cuatro imágenes casi idénticas por prompt. Publicadas
+ * las cuatro, un barajado normal las deja caer contiguas cada tanto y el
+ * mosaico parece un error de repetición. Esto recorre el orden ya barajado y,
+ * cuando una pieza choca con una hermana dentro de las `distancia` anteriores,
+ * la intercambia por la primera de más adelante que no choque.
+ *
+ * Es una reparación, no una reordenación: el azar del barajado se conserva
+ * salvo en los pocos puntos donde hacía falta. Si no hay candidato limpio, se
+ * deja como está — mejor una repetición que un orden retorcido.
+ */
+export function separarHermanas<T>(
+  items: readonly T[],
+  claveDe: (item: T) => string | undefined,
+  distancia = 6
+): T[] {
+  const salida = [...items];
+  const chocaConVentana = (clave: string | undefined, hasta: number) => {
+    if (!clave) return false;
+    for (let k = Math.max(0, hasta - distancia); k < hasta; k++) {
+      if (claveDe(salida[k]) === clave) return true;
+    }
+    return false;
+  };
+
+  for (let i = 0; i < salida.length; i++) {
+    if (!chocaConVentana(claveDe(salida[i]), i)) continue;
+    for (let j = i + 1; j < salida.length; j++) {
+      if (!chocaConVentana(claveDe(salida[j]), i)) {
+        [salida[i], salida[j]] = [salida[j], salida[i]];
+        break;
+      }
+    }
+  }
+  return salida;
+}
+
+// ── Composición en filas justificadas ─────────────────────────────────
+
+export interface Celda<T> {
+  item: T;
+  ancho: number;
+  alto: number;
+}
+
+export interface Fila<T> {
+  celdas: Celda<T>[];
+  alto: number;
+  /** La última fila puede quedar corta: no se estira para no inflar piezas. */
+  completa: boolean;
+}
+
+export interface OpcionesMosaico {
+  /** Altura a la que tienden las filas. El motor se desvía para justificar. */
+  alturaObjetivo: number;
+  /** Separación entre piezas. Pequeña a propósito: el tejido es el punto. */
+  gap: number;
+}
+
+/**
+ * Reparte `items` en filas que ocupan `ancho` exacto.
+ *
+ * Greedy: se van sumando piezas a la fila hasta que estirarla al ancho del
+ * contenedor la dejaría más baja que `alturaObjetivo`; ahí se cierra. Es el
+ * mismo criterio de las galerías justificadas clásicas, y basta: el óptimo
+ * global (partición lineal) no se nota a simple vista y cuesta O(n²).
+ */
+export function componerFilas<T>(
+  items: readonly T[],
+  ancho: number,
+  aspectoDe: (item: T) => number,
+  { alturaObjetivo, gap }: OpcionesMosaico
+): Fila<T>[] {
+  if (ancho <= 0 || items.length === 0) return [];
+
+  const filas: Fila<T>[] = [];
+  let actual: T[] = [];
+  let sumaAspectos = 0;
+
+  const cerrar = (completa: boolean) => {
+    if (actual.length === 0) return;
+    const anchoUtil = ancho - gap * (actual.length - 1);
+    // Altura que justifica la fila. Si la fila quedó corta (la última), no se
+    // estira: se respeta alturaObjetivo y se deja el borde derecho irregular.
+    const alto = completa
+      ? anchoUtil / sumaAspectos
+      : Math.min(alturaObjetivo, anchoUtil / sumaAspectos);
+
+    let acumulado = 0;
+    const celdas = actual.map((item, i) => {
+      const esUltima = i === actual.length - 1;
+      // El redondeo se salda en la última pieza para que la suma dé el ancho
+      // exacto; si no, quedan hilos de fondo de 1px entre columnas.
+      const anchoCelda =
+        completa && esUltima
+          ? anchoUtil - acumulado
+          : Math.round(alto * aspectoDe(item));
+      acumulado += anchoCelda;
+      return { item, ancho: anchoCelda, alto };
+    });
+
+    filas.push({ celdas, alto, completa });
+    actual = [];
+    sumaAspectos = 0;
+  };
+
+  for (const item of items) {
+    actual.push(item);
+    sumaAspectos += aspectoDe(item);
+    const anchoUtil = ancho - gap * (actual.length - 1);
+    if (anchoUtil / sumaAspectos <= alturaObjetivo) cerrar(true);
+  }
+  cerrar(false);
+
+  return filas;
+}
+
+/**
+ * Altura objetivo por ancho de viewport. En móvil una fila justificada de
+ * varias piezas las dejaría diminutas, así que las filas se hacen altas: el
+ * motor acaba poniendo una o dos por fila sin necesidad de un caso especial.
+ */
+export function alturaObjetivoPara(ancho: number): number {
+  if (ancho < 480) return 260;
+  if (ancho < 768) return 240;
+  if (ancho < 1280) return 300;
+  return 340;
+}

--- a/lib/semilla-orden.ts
+++ b/lib/semilla-orden.ts
@@ -1,0 +1,48 @@
+/**
+ * Semilla del orden del mosaico.
+ *
+ * La galería se baraja en cada visita, pero la página es estática: si el
+ * servidor barajara, el orden quedaría congelado en el build. Y barajar
+ * durante el render del cliente rompería la hidratación, porque el HTML que
+ * llega y el que React calcula dirían cosas distintas.
+ *
+ * Así que la semilla se modela como lo que es: un dato externo a React que
+ * vale `null` en el servidor y un número en el navegador. Ese es justo el caso
+ * de `useSyncExternalStore` — React renderiza el orden canónico para hidratar
+ * y acto seguido conmuta al barajado, sin efectos que escriban estado.
+ */
+
+let semilla: number | null = null;
+const suscriptores = new Set<() => void>();
+
+function nuevaSemilla(): number {
+  return (Math.random() * 0x7fffffff) | 0;
+}
+
+export function suscribirse(alCambiar: () => void): () => void {
+  suscriptores.add(alCambiar);
+  return () => {
+    suscriptores.delete(alCambiar);
+  };
+}
+
+/**
+ * Snapshot en cliente. Se siembra en la primera lectura y luego es estable:
+ * `useSyncExternalStore` exige que devolver dos veces seguidas dé lo mismo o
+ * entra en bucle de renders.
+ */
+export function leerSemilla(): number {
+  if (semilla === null) semilla = nuevaSemilla();
+  return semilla;
+}
+
+/** Snapshot en servidor: sin semilla, orden curatorial del manifest. */
+export function leerSemillaServidor(): null {
+  return null;
+}
+
+/** Vuelve a barajar a petición del visitante. */
+export function rebarajar(): void {
+  semilla = nuevaSemilla();
+  for (const alCambiar of suscriptores) alCambiar();
+}

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,16 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     formats: ['image/webp', 'image/avif'],
+    // La galería NO usa este optimizador: sus imágenes ya se sirven como
+    // WebP pre-generado desde Blob con un <img srcset>, justo para no gastar
+    // transformaciones facturables (ver GALERIA.md). Este patrón queda
+    // habilitado para cualquier otro uso de next/image sobre Blob.
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.public.blob.vercel-storage.com',
+      },
+    ],
   },
   // We'll add MDX support after installing next-mdx-remote
   async redirects() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,12 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@vercel/blob": "^2.6.1",
         "autoprefixer": "^10.4.22",
         "eslint": "^9.39.1",
         "eslint-config-next": "^16.0.6",
         "postcss": "^8.5.6",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3"
       }
@@ -323,9 +325,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -540,66 +542,89 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -610,12 +635,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -626,12 +652,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -642,12 +669,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -658,12 +686,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -674,12 +703,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -690,12 +720,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -706,12 +737,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -722,12 +754,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -738,12 +771,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -754,252 +788,281 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2454,6 +2517,73 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.2.tgz",
+      "integrity": "sha512-kAy35eymNzRBfmcqEViVQge0KJ59FYEKsPqGNCSJQ7M9HTuFGWd3qPcZos1A5cZpAWRBdiYe82Bcz9P7pIZvUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz",
+      "integrity": "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.2.tgz",
+      "integrity": "sha512-nmVSeQ7tewCkqYBNB/MNL8aPB9sTvtjvqIE6+U17U4IuTyehuWVERDlWrSn0DVfiFAstRlRkGLHBlKHB2FyzbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.2",
+        "@vercel/cli-exec": "1.0.1",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2709,6 +2839,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -4251,6 +4391,30 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4531,6 +4695,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4850,6 +5027,16 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -5019,6 +5206,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-bun-module": {
@@ -5209,6 +5420,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5294,6 +5512,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -5433,6 +5664,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6094,6 +6335,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6714,6 +6962,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6859,6 +7117,462 @@
         "react": ">=16"
       }
     },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6887,6 +7601,51 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -6902,6 +7661,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -7026,6 +7798,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7042,6 +7830,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -7597,6 +8395,16 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7707,9 +8515,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -7769,48 +8577,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -7911,6 +8724,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -8113,6 +8933,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8212,6 +9042,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -8492,6 +9335,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -8869,6 +9722,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "galeria:preparar": "node scripts/galeria-ingesta.mjs preparar",
+    "galeria:subir": "node scripts/galeria-ingesta.mjs subir"
   },
   "repository": {
     "type": "git",
@@ -25,18 +27,20 @@
     "next": "^16.0.6",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.2.0",
-    "recharts": "^2.15.4",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "recharts": "^2.15.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@vercel/blob": "^2.6.1",
     "autoprefixer": "^10.4.22",
     "eslint": "^9.39.1",
     "eslint-config-next": "^16.0.6",
     "postcss": "^8.5.6",
+    "sharp": "^0.35.3",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3"
   }

--- a/scripts/galeria-ingesta.mjs
+++ b/scripts/galeria-ingesta.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+/**
+ * Ingesta de la galería: de un volcado de PNG de Midjourney al manifest.
+ *
+ *   node scripts/galeria-ingesta.mjs preparar <carpeta...> [opciones]
+ *   node scripts/galeria-ingesta.mjs subir [--overwrite]
+ *
+ * Dos fases a propósito. `preparar` no necesita credenciales: extrae los
+ * metadatos, genera la escalera de WebP en una carpeta de trabajo fuera del
+ * repo y escribe el manifest con las obras ya descritas. Se puede correr,
+ * revisar y repetir sin tocar nada remoto. `subir` es la única que habla con
+ * Vercel Blob.
+ *
+ * Ambas son reanudables: `preparar` salta lo que ya generó y `subir` lleva un
+ * registro de lo ya subido. Con ~800 imágenes eso no es un lujo.
+ *
+ * El token NO se lee de ningún archivo del proyecto: este repo sincroniza a
+ * OneDrive. Pásalo como variable de entorno solo para la corrida.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import sharp from "sharp";
+
+// ── Constantes de ingesta ─────────────────────────────────────────────
+
+const EXTENSIONES = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+
+/**
+ * Escalera de anchos. Se recorta a la resolución real de cada fuente: las
+ * exportaciones de Midjourney rondan los 1200-1456px, así que generar una
+ * variante de 2000px produciría un archivo idéntico al de 1400 ocupando el
+ * doble. Nunca se amplía.
+ */
+const ESCALERA = [400, 800, 1400];
+
+/** Calidad WebP. 80 es el punto donde dejar de ver diferencia en pantalla. */
+const CALIDAD = 80;
+
+/** Cuántas imágenes se procesan a la vez. Sube CPU sin reventar memoria. */
+const CONCURRENCIA = 4;
+
+const RAIZ = process.cwd();
+const MANIFEST = path.join(RAIZ, "content", "galeria", "obras.json");
+/** Fuera del repo versionado: son cientos de MB de derivados regenerables. */
+const TRABAJO = path.join(RAIZ, ".galeria-trabajo");
+const REGISTRO_SUBIDA = path.join(TRABAJO, "subidas.json");
+
+// ── Utilidades ────────────────────────────────────────────────────────
+
+function salir(mensaje) {
+  console.error(`\n✗ ${mensaje}\n`);
+  process.exit(1);
+}
+
+const UUID = "[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}";
+const RE_NOMBRE = new RegExp(`^(.*)_(${UUID})_(\\d+)$`, "i");
+
+/**
+ * Midjourney codifica el prompt en el nombre del archivo:
+ *   `<prompt_con_guiones_bajos>_<uuid-de-generacion>_<variante>.png`
+ * Ese uuid agrupa las cuatro imágenes de una misma parrilla, y el número final
+ * dice cuál de las cuatro es. Aprovecharlo evita transcribir 800 prompts.
+ */
+function analizarNombre(base) {
+  const m = base.match(RE_NOMBRE);
+  if (!m) return { prompt: limpiarPrompt(base), generacion: null, variante: 0 };
+  return {
+    prompt: limpiarPrompt(m[1]),
+    generacion: m[2].toLowerCase(),
+    variante: Number(m[3]),
+  };
+}
+
+function limpiarPrompt(crudo) {
+  return crudo
+    .replace(/_/g, " ")
+    // Las referencias de imagen (`httpss.mj.run<hash>`) no son texto legible.
+    .replace(/https?s?\.?mj\.run\S*/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** El título es el prompt sin sus parámetros y recortado a algo pronunciable. */
+function tituloDesdePrompt(prompt) {
+  const sinParametros = prompt.split(/\s--/)[0].trim();
+  const palabras = sinParametros.split(" ").filter(Boolean).slice(0, 8);
+  if (palabras.length === 0) return "Sin título";
+  const texto = palabras.join(" ");
+  return texto.charAt(0).toUpperCase() + texto.slice(1);
+}
+
+function aSlug(texto) {
+  return texto
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+    .replace(/-+$/g, "");
+}
+
+/**
+ * Anchos a generar para una fuente de `anchoFuente` píxeles. Añade el ancho
+ * nativo solo si la escalera se queda muy corta respecto a él; si no, la
+ * variante extra sería casi idéntica a la mayor y solo ocuparía sitio.
+ */
+function anchosPara(anchoFuente) {
+  const anchos = ESCALERA.filter((a) => a <= anchoFuente);
+  if (anchos.length === 0) return [anchoFuente];
+  const mayor = anchos[anchos.length - 1];
+  if (mayor < anchoFuente * 0.85) anchos.push(anchoFuente);
+  return anchos;
+}
+
+/** Color dominante aproximado: la imagen reducida a un solo píxel. */
+async function colorDominante(imagen) {
+  const { data } = await imagen
+    .clone()
+    .resize(1, 1, { fit: "fill" })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const hex = (n) => n.toString(16).padStart(2, "0");
+  return `#${hex(data[0])}${hex(data[1])}${hex(data[2])}`;
+}
+
+/** Ejecuta `tarea` sobre `items` con como mucho `limite` en vuelo. */
+async function enParalelo(items, limite, tarea) {
+  let siguiente = 0;
+  const trabajadores = Array.from(
+    { length: Math.min(limite, items.length) },
+    async () => {
+      while (siguiente < items.length) {
+        const i = siguiente++;
+        await tarea(items[i], i);
+      }
+    }
+  );
+  await Promise.all(trabajadores);
+}
+
+async function leerManifest() {
+  try {
+    return JSON.parse(await fs.readFile(MANIFEST, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") return { blobBase: null, series: [], obras: [] };
+    throw err;
+  }
+}
+
+async function escribirManifest(manifest) {
+  await fs.mkdir(path.dirname(MANIFEST), { recursive: true });
+  await fs.writeFile(MANIFEST, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+}
+
+async function existe(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Fase 1: preparar ──────────────────────────────────────────────────
+
+async function preparar(carpetas, opciones) {
+  if (carpetas.length === 0) {
+    salir(
+      "Falta al menos una carpeta con imágenes.\n" +
+        "  Si vienes de un ZIP, extráelo primero fuera del repo:\n" +
+        '  Expand-Archive "$env:USERPROFILE\\Downloads\\midjourney_session_1.zip" -DestinationPath "$env:USERPROFILE\\galeria-fuente"'
+    );
+  }
+
+  const manifest = await leerManifest();
+  const serie = opciones.serie ?? manifest.series[0]?.id ?? "archivo";
+  if (!manifest.series.some((s) => s.id === serie)) {
+    manifest.series.push({
+      id: serie,
+      titulo: serie,
+      descripcion: "TODO: describir la serie.",
+    });
+  }
+
+  // Reunir archivos de todas las carpetas.
+  const archivos = [];
+  for (const carpeta of carpetas) {
+    let entradas;
+    try {
+      entradas = await fs.readdir(carpeta);
+    } catch {
+      salir(`No pude leer la carpeta: ${carpeta}`);
+    }
+    for (const nombre of entradas.sort()) {
+      if (EXTENSIONES.has(path.extname(nombre).toLowerCase())) {
+        archivos.push(path.join(carpeta, nombre));
+      }
+    }
+  }
+  if (archivos.length === 0) salir("No encontré imágenes en esas carpetas.");
+
+  const aProcesar = opciones.limite ? archivos.slice(0, opciones.limite) : archivos;
+  await fs.mkdir(TRABAJO, { recursive: true });
+
+  console.log(`\n${aProcesar.length} imagen(es) a preparar → ${TRABAJO}\n`);
+
+  const porSlug = new Map(manifest.obras.map((o) => [o.slug, o]));
+  const usados = new Set(porSlug.keys());
+  const nuevas = [];
+  let hechas = 0;
+  let saltadas = 0;
+  const errores = [];
+
+  await enParalelo(aProcesar, CONCURRENCIA, async (origen) => {
+    try {
+      const base = path.basename(origen, path.extname(origen));
+      const { prompt, generacion, variante } = analizarNombre(base);
+      const titulo = tituloDesdePrompt(prompt);
+
+      // El slug lleva un sufijo de la generación porque cuatro variantes del
+      // mismo prompt producen el mismo título.
+      const sufijo = generacion
+        ? `${generacion.slice(0, 8)}-${variante}`
+        : String(hechas);
+      let slug = `${aSlug(titulo)}-${sufijo}`;
+      while (usados.has(slug) && !porSlug.has(slug)) slug = `${slug}-x`;
+      usados.add(slug);
+
+      const imagen = sharp(origen).rotate();
+      const meta = await imagen.metadata();
+      const anchos = anchosPara(meta.width);
+
+      // Reanudable: si ya están todas las variantes de este slug, no se
+      // recomprime. Con 800 imágenes, repetir el trabajo cuesta media hora.
+      const destinos = anchos.map((a) => path.join(TRABAJO, `${slug}-${a}.webp`));
+      const yaEstan = (await Promise.all(destinos.map(existe))).every(Boolean);
+
+      let mayorW = null;
+      let mayorH = null;
+      if (yaEstan) {
+        saltadas++;
+        const m = await sharp(destinos[destinos.length - 1]).metadata();
+        mayorW = m.width;
+        mayorH = m.height;
+      } else {
+        for (let i = 0; i < anchos.length; i++) {
+          const salida = await imagen
+            .clone()
+            .resize({ width: anchos[i], withoutEnlargement: true })
+            .webp({ quality: CALIDAD })
+            .toFile(destinos[i]);
+          if (i === anchos.length - 1) {
+            mayorW = salida.width;
+            mayorH = salida.height;
+          }
+        }
+      }
+
+      const color = await colorDominante(imagen);
+
+      const existente = porSlug.get(slug);
+      const obra = existente ?? {
+        slug,
+        serie,
+        orden: 0,
+        estado: "pendiente",
+        // Sin texto curatorial: nadie escribe 800 statements. La ficha muestra
+        // el prompt, que es el contenido real de una imagen generada.
+        concepto: "",
+        anio: 2025,
+        tags: [],
+        licencia: "reservado",
+        licenciaDetalle: { tipo: "reservado", print: false },
+        procedencia: { herramienta: "Midjourney" },
+      };
+
+      obra.titulo = existente?.titulo ?? titulo;
+      // El alt sale del prompt: describe lo que se pidió que hubiera en la
+      // imagen. No es una descripción escrita a mano, pero es honesto y muy
+      // superior a dejarlo vacío.
+      obra.alt = existente?.alt ?? (prompt.split(/\s--/)[0].trim() || titulo);
+      obra.w = mayorW;
+      obra.h = mayorH;
+      obra.anchos = anchos;
+      obra.color = color;
+      if (generacion) obra.generacion = generacion;
+      obra.procedencia = {
+        ...obra.procedencia,
+        herramienta: obra.procedencia?.herramienta ?? "Midjourney",
+        prompt,
+        generacion: generacion ?? undefined,
+        variante,
+      };
+
+      if (!existente) nuevas.push(obra);
+      hechas++;
+      if (hechas % 50 === 0) {
+        console.log(`  ${hechas}/${aProcesar.length}…`);
+      }
+    } catch (err) {
+      errores.push(`${path.basename(origen)}: ${err.message}`);
+    }
+  });
+
+  // Orden estable por título para que el manifest no baile entre corridas.
+  manifest.obras.push(...nuevas);
+  manifest.obras.sort((a, b) => a.slug.localeCompare(b.slug, "es"));
+  manifest.obras.forEach((o, i) => {
+    o.orden = i + 1;
+  });
+
+  await escribirManifest(manifest);
+
+  console.log(`\n✓ ${hechas} preparadas (${saltadas} ya estaban)`);
+  console.log(`  ${nuevas.length} obras nuevas en el manifest`);
+  console.log(`  total en catálogo: ${manifest.obras.length}`);
+  if (errores.length > 0) {
+    console.log(`\n⚠ ${errores.length} fallo(s):`);
+    for (const e of errores.slice(0, 10)) console.log(`   ${e}`);
+  }
+  console.log(`\nSiguiente: node scripts/galeria-ingesta.mjs subir\n`);
+}
+
+// ── Fase 2: subir ─────────────────────────────────────────────────────
+
+/**
+ * Carga un archivo de variables (el que produce `vercel env pull`) en
+ * process.env. Se acepta una ruta explícita para poder tenerlo FUERA del
+ * repo: `.env.local` en la carpeta del proyecto lo sincronizaría OneDrive
+ * aunque esté en .gitignore.
+ */
+async function cargarEnv(ruta) {
+  let texto;
+  try {
+    texto = await fs.readFile(ruta, "utf-8");
+  } catch {
+    salir(`No pude leer el archivo de entorno: ${ruta}`);
+  }
+  for (const linea of texto.split(/\r?\n/)) {
+    const limpia = linea.trim();
+    if (!limpia || limpia.startsWith("#")) continue;
+    const i = limpia.indexOf("=");
+    if (i === -1) continue;
+    const clave = limpia.slice(0, i).trim();
+    const valor = limpia
+      .slice(i + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (!process.env[clave]) process.env[clave] = valor;
+  }
+}
+
+async function subir(opciones) {
+  if (opciones.env) await cargarEnv(opciones.env);
+
+  // Dos credenciales posibles. Vercel conecta los stores con OIDC por defecto
+  // (token corto que rota solo) y solo crea BLOB_READ_WRITE_TOKEN si se pidió
+  // al crear el store. El SDK resuelve solo: si están VERCEL_OIDC_TOKEN y
+  // BLOB_STORE_ID en el entorno, usa OIDC; si no, cae al token estático.
+  const tieneRW = Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+  const tieneOidc = Boolean(
+    process.env.VERCEL_OIDC_TOKEN && process.env.BLOB_STORE_ID
+  );
+  if (!tieneRW && !tieneOidc) {
+    salir(
+      "No hay credenciales de Blob en el entorno. Dos opciones:\n\n" +
+        "  a) OIDC (lo que Vercel crea por defecto):\n" +
+        "     conecta el store al proyecto incluyendo el entorno Development, y luego\n" +
+        "       vercel env pull \"$env:TEMP\\curiana-blob.env\"\n" +
+        "       npm run galeria:subir -- --env \"$env:TEMP\\curiana-blob.env\"\n\n" +
+        "  b) Token estático, si tu store creó BLOB_READ_WRITE_TOKEN:\n" +
+        "       $env:BLOB_READ_WRITE_TOKEN = Read-Host \"Token\"\n\n" +
+        "  En ambos casos, fuera del repo: esta carpeta sincroniza a OneDrive."
+    );
+  }
+  console.log(
+    `\nCredencial: ${tieneRW ? "BLOB_READ_WRITE_TOKEN" : "OIDC (VERCEL_OIDC_TOKEN + BLOB_STORE_ID)"}`
+  );
+
+  const { put } = await import("@vercel/blob");
+
+  const manifest = await leerManifest();
+  const publicables = manifest.obras.filter((o) => o.anchos?.length > 0);
+  if (publicables.length === 0) salir("No hay nada preparado. Corre `preparar` primero.");
+
+  let registro = {};
+  if (await existe(REGISTRO_SUBIDA)) {
+    registro = JSON.parse(await fs.readFile(REGISTRO_SUBIDA, "utf-8"));
+  }
+
+  // Aplanar a la lista de archivos concretos que faltan por subir.
+  const pendientes = [];
+  for (const obra of publicables) {
+    for (const ancho of obra.anchos) {
+      const clave = `${obra.slug}-${ancho}.webp`;
+      if (registro[clave] && !opciones.overwrite) continue;
+      pendientes.push({ clave, local: path.join(TRABAJO, clave) });
+    }
+  }
+
+  if (pendientes.length === 0) {
+    console.log("\n✓ Todo estaba subido ya.\n");
+  } else {
+    console.log(`\n${pendientes.length} archivo(s) por subir…\n`);
+    let subidos = 0;
+    const errores = [];
+    // Concurrencia moderada: `put()` cuenta como operación avanzada y los
+    // planes tienen tope por minuto (900/min en Hobby).
+    await enParalelo(pendientes, 6, async ({ clave, local }) => {
+      try {
+        const cuerpo = await fs.readFile(local);
+        const blob = await put(`galeria/${clave}`, cuerpo, {
+          access: "public",
+          contentType: "image/webp",
+          addRandomSuffix: false,
+          allowOverwrite: true,
+          // Un año: el nombre incluye el slug y el ancho, así que un cambio de
+          // imagen implica un nombre nuevo. Nunca hay que invalidar.
+          cacheControlMaxAge: 31536000,
+        });
+        registro[clave] = blob.url;
+        subidos++;
+        if (subidos % 50 === 0) {
+          console.log(`  ${subidos}/${pendientes.length}…`);
+          await fs.writeFile(REGISTRO_SUBIDA, JSON.stringify(registro), "utf-8");
+        }
+      } catch (err) {
+        errores.push(`${clave}: ${err.message}`);
+      }
+    });
+    await fs.writeFile(REGISTRO_SUBIDA, JSON.stringify(registro), "utf-8");
+    console.log(`\n✓ ${subidos} subidos`);
+    if (errores.length > 0) {
+      console.log(`⚠ ${errores.length} fallo(s) — vuelve a correr para reintentar:`);
+      for (const e of errores.slice(0, 10)) console.log(`   ${e}`);
+    }
+  }
+
+  // El manifest guarda el origen del store una sola vez, no una URL por
+  // variante: con 800 obras x 3 anchos eso serían ~200 KB de JSON repetido.
+  const cualquiera = Object.values(registro)[0];
+  if (cualquiera) {
+    const u = new URL(cualquiera);
+    manifest.blobBase = `${u.origin}/galeria`;
+  }
+  for (const obra of manifest.obras) {
+    if (obra.anchos?.every((a) => registro[`${obra.slug}-${a}.webp`])) {
+      obra.estado = "publicada";
+    }
+  }
+  await escribirManifest(manifest);
+  console.log(`\n✓ Manifest actualizado. blobBase = ${manifest.blobBase}\n`);
+}
+
+// ── Entrada ───────────────────────────────────────────────────────────
+
+async function main() {
+  const [comando, ...resto] = process.argv.slice(2);
+  const opciones = { serie: null, limite: null, overwrite: false, env: null };
+  const posicionales = [];
+  for (let i = 0; i < resto.length; i++) {
+    const a = resto[i];
+    if (a === "--serie") opciones.serie = resto[++i];
+    else if (a === "--limite") opciones.limite = Number(resto[++i]);
+    else if (a === "--env") opciones.env = resto[++i];
+    else if (a === "--overwrite") opciones.overwrite = true;
+    else if (!a.startsWith("--")) posicionales.push(a);
+  }
+
+  if (comando === "preparar") await preparar(posicionales, opciones);
+  else if (comando === "subir") await subir(opciones);
+  else
+    salir(
+      "Uso:\n" +
+        "  node scripts/galeria-ingesta.mjs preparar <carpeta...> [--serie <id>] [--limite N]\n" +
+        "  node scripts/galeria-ingesta.mjs subir [--env <archivo>] [--overwrite]"
+    );
+}
+
+main().catch((err) => salir(err.stack ?? String(err)));

--- a/types/galeria.ts
+++ b/types/galeria.ts
@@ -1,0 +1,166 @@
+/**
+ * Galería visual — experimentos de imagen generados con IA.
+ *
+ * El manifest (`content/galeria/obras.json`) es la fuente de verdad y vive
+ * versionado; los archivos de imagen NO viven en el repo. Cada obra publicada
+ * tiene una escalera de variantes WebP ya redimensionadas en Vercel Blob, que
+ * el navegador pide directamente al CDN.
+ *
+ * Ese pre-redimensionado es deliberado: pasar por la optimización de imágenes
+ * de Vercel factura una transformación por cada fallo de caché y hace esperar
+ * al primer visitante de cada variante. Generándolas al ingerir, la galería no
+ * consume transformaciones y las imágenes salen del CDN como archivos planos.
+ *
+ * El esquema contempla la licencia porque el modelo de datos es lo caro de
+ * cambiar después: hoy nadie cobra nada, pero cuando exista checkout no habrá
+ * que re-etiquetar el catálogo entero.
+ */
+
+/** Publicada = tiene escalera en Blob. Pendiente = concepto sin render todavía. */
+export type EstadoObra = "publicada" | "pendiente";
+
+/**
+ * Qué puede hacer un visitante con la imagen. Deliberadamente pocas opciones:
+ * cada una es una promesa legal, no una etiqueta decorativa.
+ */
+export type TipoLicencia =
+  /** Uso libre no comercial con atribución a Curiana Radio. */
+  | "cc-by-nc"
+  /** Prensa, docencia, divulgación. Sin reventa ni merchandising. */
+  | "editorial"
+  /** Disponible para uso comercial / impresión bajo acuerdo. */
+  | "comercial"
+  /** No se licencia (pieza de identidad de la radio, encargo, etc.). */
+  | "reservado";
+
+export interface LicenciaObra {
+  tipo: TipoLicencia;
+  /** Si la obra puede terminar en un producto físico (print, textil). */
+  print: boolean;
+  /** Matices que la etiqueta no captura (exclusividades, créditos exigidos). */
+  notas?: string;
+}
+
+/** Proveniencia: de dónde salió la imagen. Se muestra en la ficha. */
+export interface ProcedenciaObra {
+  /** "Midjourney", "Nano Banana", … */
+  herramienta: string;
+  /** El prompt real. Parte del contenido, no un detalle técnico oculto. */
+  prompt?: string;
+  /** Retoque, upscaling, collage posterior. */
+  posproceso?: string;
+  /**
+   * Id de la generación de origen. Midjourney devuelve una parrilla de cuatro
+   * variantes por prompt: comparten `generacion` y se distinguen por
+   * `variante`. El barajado lo usa para no dejarlas contiguas en el mosaico.
+   */
+  generacion?: string;
+  variante?: number;
+}
+
+/**
+ * Lo mínimo para pintar una pieza del mosaico. Se separa del registro completo
+ * porque con ~800 obras el manifest entero serializado al cliente pesa más que
+ * las propias imágenes de la primera pantalla.
+ */
+export interface ObraGrid {
+  slug: string;
+  titulo: string;
+  /** Texto alternativo real. Obligatorio, no opcional. */
+  alt: string;
+  serie: string;
+  orden: number;
+  estado: EstadoObra;
+  tags: string[];
+  /** Solo el tipo: el resto de la licencia se lee en la ficha. */
+  licencia: TipoLicencia;
+
+  /** Dimensiones de la variante mayor. Dan la proporción al motor del mosaico. */
+  w: number | null;
+  h: number | null;
+  /**
+   * Anchos disponibles en Blob, de menor a mayor. La URL se compone con
+   * `blobBase` del manifest: `${blobBase}/${slug}-${ancho}.webp`. Guardar los
+   * anchos y no las URLs completas ahorra ~200 KB de JSON en el cliente.
+   */
+  anchos: number[];
+  /**
+   * Color dominante (`#rrggbb`) para reservar el hueco mientras carga. Siete
+   * bytes en vez de los ~400 de una miniatura borrosa en base64: a esta escala
+   * la diferencia son 330 KB de JSON antes de ver la primera imagen.
+   */
+  color: string;
+  /** Agrupa las variantes hermanas de una misma parrilla de Midjourney. */
+  generacion?: string;
+}
+
+/** El registro completo. Solo se lee en servidor, para la ficha. */
+export interface Obra extends ObraGrid {
+  /** Statement curatorial: qué es y por qué existe. */
+  concepto: string;
+  anio: number;
+  licenciaDetalle: LicenciaObra;
+  procedencia: ProcedenciaObra;
+  /** Edición del fanzine con la que dialoga, si aplica (slug de la edición). */
+  edicion?: string;
+  /**
+   * Ruta (pathname, NO url firmada) del original en el bucket privado.
+   * Se guarda solo la clave a propósito: el manifest está versionado y
+   * sincroniza a OneDrive, así que nunca debe contener nada firmado ni secreto.
+   * Resolver siempre en servidor. Ver lib/galeria.ts → getOriginalKey().
+   */
+  originalKey?: string;
+}
+
+export interface Serie {
+  id: string;
+  titulo: string;
+  descripcion: string;
+}
+
+export interface GaleriaManifest {
+  /**
+   * Origen público del store de Blob, sin barra final. Se guarda una vez y no
+   * por obra. `null` mientras no se haya subido nada.
+   */
+  blobBase: string | null;
+  series: Serie[];
+  obras: Obra[];
+}
+
+export const ETIQUETA_LICENCIA: Record<TipoLicencia, string> = {
+  "cc-by-nc": "CC BY-NC",
+  editorial: "Uso editorial",
+  comercial: "Licencia comercial",
+  reservado: "Derechos reservados",
+};
+
+export const DESCRIPCION_LICENCIA: Record<TipoLicencia, string> = {
+  "cc-by-nc":
+    "Puedes usarla y adaptarla sin fines comerciales, citando a Curiana Radio.",
+  editorial:
+    "Uso en prensa, docencia y divulgación. No cubre reventa ni merchandising.",
+  comercial: "Disponible para uso comercial e impresión bajo acuerdo previo.",
+  reservado: "Pieza de identidad de la radio. No se licencia para uso externo.",
+};
+
+/** Compone la URL de una variante concreta en Blob. */
+export function urlVariante(
+  blobBase: string | null,
+  slug: string,
+  ancho: number
+): string | null {
+  return blobBase ? `${blobBase}/${slug}-${ancho}.webp` : null;
+}
+
+/**
+ * `srcset` completo de una obra. El navegador elige el archivo según el ancho
+ * real de la pieza y la densidad de pantalla — sin intermediarios ni cómputo
+ * en servidor.
+ */
+export function srcSetDe(blobBase: string | null, obra: ObraGrid): string {
+  if (!blobBase || obra.anchos.length === 0) return "";
+  return obra.anchos
+    .map((a) => `${urlVariante(blobBase, obra.slug, a)} ${a}w`)
+    .join(", ");
+}


### PR DESCRIPTION
Cuarta arista del proyecto, junto a Archivo, Simulador y JAI Sounds: una galería de los experimentos visuales hechos con IA, con el prompt y la procedencia a la vista.

## El mosaico

`lib/mosaico.ts` reparte las obras en **filas justificadas**: cada fila ocupa el ancho exacto del contenedor y su altura la deciden las proporciones reales de las imágenes que le tocaron. Solo la última queda corta, sin estirar, para no inflar dos imágenes sueltas hasta ocupar la pantalla. Módulo puro, sin DOM.

El orden **se baraja en cada visita** sin renunciar al prerenderizado: la semilla se modela como dato externo a React y se lee con `useSyncExternalStore`, así que el HTML sale en orden curatorial —estable para los rastreadores— y el cliente conmuta al barajado al hidratar. Después, `separarHermanas()` aparta las variantes de una misma generación de Midjourney, que el azar deja contiguas unas 4 veces por barajado.

## Por qué no se usa la optimización de imágenes de Vercel

La escalera de anchos ya se genera en la ingesta, así que optimizar al vuelo solo añadiría coste por transformación y la espera del primer visitante de cada variante. Las imágenes salen del CDN como archivos planos vía `<img srcset>`. Hay un `eslint-disable` razonado en `ImagenObra.tsx` para que no se revierta por costumbre.

Medido sobre el volcado real, no estimado:

| | Por imagen | Total (821) |
|---|---|---|
| PNG original | ~2.048 KB | 1,72 GB |
| Escalera WebP servida | ~167 KB | 179 MB |

Transformaciones facturables: **0**.

## Peso del payload

Con ~800 obras el manifest completo pesaría más que las imágenes de la primera pantalla. `ObraGrid` es un tipo aparte del registro completo (sin `concepto`, `procedencia` ni `originalKey`), el manifest guarda `blobBase` una sola vez, el hueco se reserva con el color dominante en vez de una miniatura en base64, y el mosaico pinta una ventana de 60 piezas que crece al bajar. Resultado: **294 KB → 40 KB comprimidos**.

## Ingesta

Pipeline en dos fases: `preparar` (local, sin credenciales) y `subir`. Reanudables ambas. El nombre de archivo que exporta Midjourney lleva dentro el prompt, el uuid de generación y el índice de variante, así que el prompt, el título, el alt y el agrupamiento salen de ahí sin transcribir nada.

Acepta credencial estática u OIDC, que es lo que Vercel configura por defecto al conectar un store.

## Verificación

- Motor probado en aislamiento: 40/7/1/0 piezas, móvil y escritorio, gap 0 y 4. No pierde piezas, conserva el orden, las filas completas suman el ancho exacto.
- Con 14 imágenes reales de proporciones variadas: filas justificadas al píxel a 1280, 1100 y 375. Alturas 220–300px.
- `srcset` eligiendo bien: pieza de 518px → variante de 800; de 290px → variante de 400.
- Lightbox: teclado, trampa de foco, devuelve el foco a la pieza de origen. Índice correcto sobre 826.
- Separación de hermanas: 0 choques, contra 4,3 de media sin reparar.
- Build de 826 páginas estáticas en 22 s. `tsc`, `eslint` y `next build` limpios.

## Estado y lo que falta

Las 821 obras entran con `licencia: "reservado"` y `concepto` vacío — valores conservadores a propósito: nadie escribe 800 statements, y es preferible no prometer nada a prometer de más.

`blobBase` va en `null`: **las imágenes todavía no están subidas**. Hasta que se corra `galeria:subir`, la galería renderiza los huecos con su color y no rompe nada.

## Nota sobre `Navigation.tsx`

Sumar Galería dejaba la barra en 440px sobre un viewport de 375. Se descartó ocultar alguna sección en móvil, que dejaría fuera del menú una arista entera y no es decisión que corresponda tomar desde este PR: en su lugar la fila se aprieta y puede desplazarse por debajo de `sm`. De `sm` en adelante nada cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)