### PR TITLE
feat(galeria): describir las 821 obras mirándolas

### DIFF
--- a/app/galeria/[slug]/page.tsx
+++ b/app/galeria/[slug]/page.tsx
@@ -91,18 +91,10 @@ export default async function ObraPage({ params }: ObraPageProps) {
             </p>
           )}
 
-          {obra.procedencia.prompt && (
-            <section className="mt-8">
-              <h2 className="mb-3 font-sans text-xs tracking-[0.2em] uppercase text-earth-600">
-                El prompt
-              </h2>
-              <blockquote className="border-l-2 border-frequency bg-earth-50 py-4 pl-5 pr-4">
-                <p className="max-w-reading font-mono text-sm leading-relaxed text-deep-800">
-                  {obra.procedencia.prompt}
-                </p>
-              </blockquote>
-            </section>
-          )}
+          {/* El prompt ya no se publica. 72 de las 821 obras nombran a un
+              artista en el suyo ("in the style of…"), y apoyar la ficha en el
+              nombre de otro no es describir la obra. El texto de arriba sale
+              de mirar la imagen — ver scripts/galeria-describir.mjs. */}
 
           {obra.procedencia.posproceso && (
             <section className="mt-8">

--- a/content/galeria/obras.json
+++ b/content/galeria/obras.json
@@ -2,11 +2,6 @@
   "blobBase": "https://hzq4kdtnujnzvrvg.public.blob.vercel-storage.com/galeria",
   "series": [
     {
-      "id": "umbral",
-      "titulo": "El Umbral",
-      "descripcion": "Los cinco planos que abren la Edición #01. Médanos de Coro leídos como circuito: el desierto no es vacío, es una superficie que guarda señal."
-    },
-    {
       "id": "archivo",
       "titulo": "archivo",
       "descripcion": "TODO: describir la serie."
@@ -5150,37 +5145,9 @@
       "generacion": "32b747d9-25c4-4b65-a621-8f7a2d575d15"
     },
     {
-      "slug": "cimatica-tambor",
-      "titulo": "Cimática del tambor",
-      "alt": "Primer plano de arena vibrando sobre la piel de un tambor, formando figuras geométricas concéntricas bajo luz tenue.",
-      "serie": "umbral",
-      "orden": 167,
-      "estado": "pendiente",
-      "tags": [
-        "abstracto",
-        "sonido",
-        "textura"
-      ],
-      "licencia": "cc-by-nc",
-      "w": null,
-      "h": null,
-      "anchos": [],
-      "color": "#4f3e35",
-      "concepto": "Textura abstracta. Arena vibrando sobre una membrana de tambor hasta formar patrones geométricos exactos. Iluminación tenue e íntima: bioluminiscencia o vela.",
-      "anio": 2025,
-      "licenciaDetalle": {
-        "tipo": "cc-by-nc",
-        "print": true
-      },
-      "procedencia": {
-        "herramienta": "Midjourney"
-      },
-      "edicion": "01"
-    },
-    {
       "slug": "cinematic-m-2e8f16ba-3",
       "serie": "archivo",
-      "orden": 168,
+      "orden": 167,
       "estado": "publicada",
       "concepto": "A la punta más larga del caracol solo le faltan tres centímetros y noventa atardeceres para ensartar el sol rojo que tiene enfrente.",
       "anio": 2025,
@@ -5211,7 +5178,7 @@
     {
       "slug": "cinematic-m-3f6aebe8-0",
       "serie": "archivo",
-      "orden": 169,
+      "orden": 168,
       "estado": "publicada",
       "concepto": "Los surcos de este caracol atesoran mar azul entero, y el sol tuvo que teñirse de naranja para no perder el concurso de brillo contra la concha.",
       "anio": 2025,
@@ -5242,7 +5209,7 @@
     {
       "slug": "cinematic-m-8d56dec9-0",
       "serie": "archivo",
-      "orden": 170,
+      "orden": 169,
       "estado": "publicada",
       "concepto": "Le cruzan el caparazón vetas tan rojas que parecen la marca de la última ola, aunque la espuma blanca todavía se frena a dos pasos de distancia.",
       "anio": 2025,
@@ -5273,7 +5240,7 @@
     {
       "slug": "cinematic-m-8d56dec9-3",
       "serie": "archivo",
-      "orden": 171,
+      "orden": 170,
       "estado": "publicada",
       "concepto": "El cielo ya le robó casi todo el color a la concha, y solo el sol, reducido a una moneda roja, se niega a dejarla del todo a oscuras.",
       "anio": 2025,
@@ -5304,7 +5271,7 @@
     {
       "slug": "close-up-po-ee43ad82-0",
       "serie": "archivo",
-      "orden": 172,
+      "orden": 171,
       "estado": "publicada",
       "concepto": "Diez mil puntos dorados y turquesas le cubren la piel entera, y cada uno se enciende un instante antes de que el aire le llegue a los labios entreabiertos.",
       "anio": 2025,
@@ -5335,7 +5302,7 @@
     {
       "slug": "close-up-portrait-cinematic-lighting-of-an-andro-184d0463-3",
       "serie": "archivo",
-      "orden": 173,
+      "orden": 172,
       "estado": "publicada",
       "concepto": "La mitad derecha de esta cara arde en cobre y la izquierda se le queda fría en turquesa, sin que ninguna logre cruzar la nariz para ganarle terreno a la otra.",
       "anio": 2025,
@@ -5366,7 +5333,7 @@
     {
       "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-0",
       "serie": "archivo",
-      "orden": 174,
+      "orden": 173,
       "estado": "publicada",
       "concepto": "Una red verde le cubre toda la cara menos los ojos azules, que la atraviesan sin dejarle ni un solo punto de luz a medio camino.",
       "anio": 2025,
@@ -5397,7 +5364,7 @@
     {
       "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-1",
       "serie": "archivo",
-      "orden": 175,
+      "orden": 174,
       "estado": "publicada",
       "concepto": "Unas cortinas de cuentas azules le tapan medio rostro, y aun así consigue mirar derecho a través de cada una sin mover el cuello ni una vez.",
       "anio": 2025,
@@ -5428,7 +5395,7 @@
     {
       "slug": "close-up-portrait-cinematic-lighting-of-an-andro-bbbcefd5-3",
       "serie": "archivo",
-      "orden": 176,
+      "orden": 175,
       "estado": "publicada",
       "concepto": "Medio rostro y un hombro entero ya se los devora una tela azul, pero el ojo que queda del lado de la luz alcanza a contar cada punto dorado de su propio iris.",
       "anio": 2025,
@@ -5459,7 +5426,7 @@
     {
       "slug": "coastal-waters-of-guinea-bissau-late-autumn-of-1-126fa0e0-0",
       "serie": "archivo",
-      "orden": 177,
+      "orden": 176,
       "estado": "publicada",
       "concepto": "El rayo parte el cielo justo detrás de la isla de palmeras, y el hombre del turbante ya perdió la cuenta de los mil relámpagos que no lo han alcanzado.",
       "anio": 2025,
@@ -5490,7 +5457,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-27e6053b-2",
       "serie": "archivo",
-      "orden": 178,
+      "orden": 177,
       "estado": "publicada",
       "concepto": "Cada pincelada es un día; los del lado claro se recuerdan mal y los del azul uno por uno, pero nadie sabe dónde cambió la cuenta.",
       "anio": 2025,
@@ -5521,7 +5488,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-0",
       "serie": "archivo",
-      "orden": 179,
+      "orden": 178,
       "estado": "publicada",
       "concepto": "Justo donde el rojo se convierte en azul cae algo invisible, y las ondas que suelta tardan toda una vida en llegar a las cuatro esquinas del cuadro.",
       "anio": 2025,
@@ -5552,7 +5519,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-1",
       "serie": "archivo",
-      "orden": 180,
+      "orden": 179,
       "estado": "publicada",
       "concepto": "Miles de líneas salen del centro blanco, y a cada una le toca decidir si se pinta de rojo hacia la izquierda o de azul hacia la derecha.",
       "anio": 2025,
@@ -5583,7 +5550,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-2",
       "serie": "archivo",
-      "orden": 181,
+      "orden": 180,
       "estado": "publicada",
       "concepto": "Entre el rojo de la izquierda y el azul de la derecha se abre una franja pálida en diagonal, y ahí se queda, indecisa, sin acercarse del todo a ningún borde.",
       "anio": 2025,
@@ -5614,7 +5581,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-343ba58e-3",
       "serie": "archivo",
-      "orden": 182,
+      "orden": 181,
       "estado": "publicada",
       "concepto": "El naranja llega ondulando desde la izquierda como si viniera ardiendo, y se apaga solo, línea por línea, en la espuma blanca que ocupa todo el borde derecho.",
       "anio": 2025,
@@ -5645,7 +5612,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-464708df-2",
       "serie": "archivo",
-      "orden": 183,
+      "orden": 182,
       "estado": "publicada",
       "concepto": "Sin cambiar ni una sola curva, las líneas onduladas que forman la duna dorada de la izquierda cruzan el cuadro entero y del otro lado ya son mar azul.",
       "anio": 2025,
@@ -5676,7 +5643,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-464708df-3",
       "serie": "archivo",
-      "orden": 184,
+      "orden": 183,
       "estado": "publicada",
       "concepto": "Los brochazos horizontales dividen el lienzo justo donde el cielo rosado decide hacerse agua azul, y ninguno se atreve a cruzar esa línea.",
       "anio": 2025,
@@ -5707,7 +5674,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-0",
       "serie": "archivo",
-      "orden": 185,
+      "orden": 184,
       "estado": "publicada",
       "concepto": "Arriba, la tela azul índigo se deshilacha en diagonal hasta volverse hilo dorado abajo, dejando ver, hebra por hebra, la costura exacta del cambio.",
       "anio": 2025,
@@ -5738,7 +5705,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-1",
       "serie": "archivo",
-      "orden": 186,
+      "orden": 185,
       "estado": "publicada",
       "concepto": "El resplandor durazno del centro se hunde bajo las ondas azules que lo rodean, y en la esquina inferior derecha ya no queda ni rastro de luz.",
       "anio": 2025,
@@ -5769,7 +5736,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-2",
       "serie": "archivo",
-      "orden": 187,
+      "orden": 186,
       "estado": "publicada",
       "concepto": "Por donde el sol roza la cresta oscura de la montaña se sueltan franjas de arcoíris enteras, y el cielo azul de arriba ni se anima a bajar hasta el filo.",
       "anio": 2025,
@@ -5800,7 +5767,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-469b42e7-3",
       "serie": "archivo",
-      "orden": 188,
+      "orden": 187,
       "estado": "publicada",
       "concepto": "Al cruzarse dos franjas naranjas del cuadriculado, la tela deja de fingir que es tela y se enciende en un círculo entero de brasa.",
       "anio": 2025,
@@ -5831,7 +5798,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-0",
       "serie": "archivo",
-      "orden": 189,
+      "orden": 188,
       "estado": "publicada",
       "concepto": "Los anillos azules nacen del centro anaranjado y se agrandan sin parar, y todavía ninguno se ha decidido a tocar el borde del cuadro.",
       "anio": 2025,
@@ -5862,7 +5829,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-2",
       "serie": "archivo",
-      "orden": 190,
+      "orden": 189,
       "estado": "publicada",
       "concepto": "Alternando naranja y azul como un código de barras, las franjas verticales pierden la cuenta justo en el centro y se emborronan todas juntas.",
       "anio": 2025,
@@ -5893,7 +5860,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-86c7ea83-3",
       "serie": "archivo",
-      "orden": 191,
+      "orden": 190,
       "estado": "publicada",
       "concepto": "Sobre una franja verde y naranja se posa, en capas, el cielo azul de arriba, que termina hundiéndose en un fondo tan oscuro que ya no se sabe si es agua o sombra.",
       "anio": 2025,
@@ -5924,7 +5891,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-96e5f65a-0",
       "serie": "archivo",
-      "orden": 192,
+      "orden": 191,
       "estado": "publicada",
       "concepto": "Una nube guarda brasas naranjas en el pecho en medio de la neblina azul, y el frío de alrededor todavía no ha logrado apagarla.",
       "anio": 2025,
@@ -5955,7 +5922,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-1",
       "serie": "archivo",
-      "orden": 193,
+      "orden": 192,
       "estado": "publicada",
       "concepto": "Justo en la frontera entre el cielo azul y el cielo naranja se detiene un círculo pálido, y ninguno de los dos lados logra ponerle encima su color.",
       "anio": 2025,
@@ -5986,7 +5953,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-2",
       "serie": "archivo",
-      "orden": 194,
+      "orden": 193,
       "estado": "publicada",
       "concepto": "El cielo se resiste a quedarse quieto y alguien lo arrastra hacia la derecha sin soltarlo, dejando nueve franjas doradas colgadas del aire como ropa tendida a media tarde.",
       "anio": 2025,
@@ -6017,7 +5984,7 @@
     {
       "slug": "color-field-painting-in-the-style-of-uhd-ffc5595d-3",
       "serie": "archivo",
-      "orden": 195,
+      "orden": 194,
       "estado": "publicada",
       "concepto": "El reflejo del sol no cabe entero en el agua, así que se reparte en miles de puntos redondos que se van enfriando de naranja a violeta antes de llegar a la orilla.",
       "anio": 2025,
@@ -6048,7 +6015,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-0",
       "serie": "archivo",
-      "orden": 196,
+      "orden": 195,
       "estado": "publicada",
       "concepto": "Entre sus pechos crece una planta de hojas anchas: soltó su última hoja hace veintitrés años, el día en que se acercaron el primer milímetro, y desde entonces ninguno se ha movido.",
       "anio": 2025,
@@ -6079,7 +6046,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-1",
       "serie": "archivo",
-      "orden": 197,
+      "orden": 196,
       "estado": "publicada",
       "concepto": "Se pintan la piel del mismo bote de azul desde hace tantos años que ya no queda pintura para diferenciar dónde termina la cara de uno y empieza la del otro.",
       "anio": 2025,
@@ -6110,7 +6077,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-2",
       "serie": "archivo",
-      "orden": 198,
+      "orden": 197,
       "estado": "publicada",
       "concepto": "El corazón que lleva bordado en el pecho ha sido remendado con hilo de oro tantas veces que ya pesa más que la camisa entera.",
       "anio": 2025,
@@ -6141,7 +6108,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-5a2a1012-3",
       "serie": "archivo",
-      "orden": 199,
+      "orden": 198,
       "estado": "publicada",
       "concepto": "El trébol dorado que le cuelga del oído ya perdió medio brillo de tanto rozar la mejilla del hombre que tiene enfrente, con los ojos cerrados los dos.",
       "anio": 2025,
@@ -6172,7 +6139,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-7616fd8f-0",
       "serie": "archivo",
-      "orden": 200,
+      "orden": 199,
       "estado": "publicada",
       "concepto": "Las flores azules les crecieron de la noche a la mañana hasta la altura de la clavícula, y la semana que viene les va a tapar el beso que todavía no se dan.",
       "anio": 2025,
@@ -6203,7 +6170,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-7616fd8f-3",
       "serie": "archivo",
-      "orden": 201,
+      "orden": 200,
       "estado": "publicada",
       "concepto": "Detrás de ellos la selva está hecha de puntos de pintura pura, tantos que hace falta una estación seca entera para contarlos todos sin perder la cuenta.",
       "anio": 2025,
@@ -6234,7 +6201,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-8591efc0-0",
       "serie": "archivo",
-      "orden": 202,
+      "orden": 201,
       "estado": "publicada",
       "concepto": "Llevan bordado en el pecho el mismo árbol dorado, una rama por cada año que llevan parados a esta distancia exacta el uno del otro.",
       "anio": 2025,
@@ -6265,7 +6232,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-8591efc0-1",
       "serie": "archivo",
-      "orden": 203,
+      "orden": 202,
       "estado": "publicada",
       "concepto": "La pintura se agrietó en todas partes menos en los dos corazones dorados que llevan bordados en el pecho, como si el tiempo no se atreviera a tocar esa parte.",
       "anio": 2025,
@@ -6296,7 +6263,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-8591efc0-3",
       "serie": "archivo",
-      "orden": 204,
+      "orden": 203,
       "estado": "publicada",
       "concepto": "No ha parpadeado desde que pintaron la pared de atrás, y en ese tiempo la pintura ya se descascaró dos veces mientras sus ojos siguen igual de blancos y abiertos.",
       "anio": 2025,
@@ -6327,7 +6294,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-ae1161b5-0",
       "serie": "archivo",
-      "orden": 205,
+      "orden": 204,
       "estado": "publicada",
       "concepto": "La rama dorada bordada en el vestido de ella lleva diez años creciendo hacia el cuello de él, y le faltan tres hojas para alcanzar el primer corazón pequeño.",
       "anio": 2025,
@@ -6358,7 +6325,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-ae1161b5-3",
       "serie": "archivo",
-      "orden": 206,
+      "orden": 205,
       "estado": "publicada",
       "concepto": "El vestido de ella tiene sembrados tantos corazones diminutos que ya son más que los latidos que han compartido de pie, sin moverse, en esta misma pose.",
       "anio": 2025,
@@ -6389,7 +6356,7 @@
     {
       "slug": "cover-art-with-two-people-looking-at-each-d56fb0ea-1",
       "serie": "archivo",
-      "orden": 207,
+      "orden": 206,
       "estado": "publicada",
       "concepto": "Los labios se juntan con tanta fuerza que los puntos de color de una cara se mezclan con los de la otra, y ya solo queda una forma con dos narices.",
       "anio": 2025,
@@ -6420,7 +6387,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-sty-302a7fe7-1",
       "serie": "archivo",
-      "orden": 208,
+      "orden": 207,
       "estado": "publicada",
       "concepto": "La calavera flota sobre el tablero de cuadros del cielo con los ojos fijos en la torre del reloj desde hace tanto que ya le quemó dos agujeros azules al fondo.",
       "anio": 2025,
@@ -6451,7 +6418,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-sty-302a7fe7-3",
       "serie": "archivo",
-      "orden": 209,
+      "orden": 208,
       "estado": "publicada",
       "concepto": "A la montaña le tomó mil años terminar de tallarse la cara, y al caminante que se acerca por la arena de colores todavía le faltan tres pasos para verla abrir los ojos.",
       "anio": 2025,
@@ -6482,7 +6449,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-sty-9d149f76-0",
       "serie": "archivo",
-      "orden": 210,
+      "orden": 209,
       "estado": "publicada",
       "concepto": "La escalera tallada en la roca sube hacia la torre del reloj, y el que la sube lleva caminando desde que la luna de allá arriba todavía era redonda y no un remolino.",
       "anio": 2025,
@@ -6513,7 +6480,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-sty-e48ca045-1",
       "serie": "archivo",
-      "orden": 211,
+      "orden": 210,
       "estado": "publicada",
       "concepto": "El reloj cuelga del cielo en vez del sol, y hace tanto ruido al marcar la hora que sus anillos de colores todavía siguen temblando en el aire.",
       "anio": 2025,
@@ -6544,7 +6511,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-style-0e4afe5c-0",
       "serie": "archivo",
-      "orden": 212,
+      "orden": 211,
       "estado": "publicada",
       "concepto": "Detrás de él gira un mecanismo de relojes tan grande que ninguno de sus engranajes coincide en la hora, y él lleva años sin voltear a comprobarlo.",
       "anio": 2025,
@@ -6575,7 +6542,7 @@
     {
       "slug": "cover-of-time-travelers-7-in-the-style-9e7f44fc-1",
       "serie": "archivo",
-      "orden": 213,
+      "orden": 212,
       "estado": "publicada",
       "concepto": "El vestido naranja se le pega al cuerpo con un viento que sube directo de la curva del planeta, y lleva media vida intentando doblarlo hasta darle la forma del horizonte.",
       "anio": 2025,
@@ -6606,7 +6573,7 @@
     {
       "slug": "cryochamber-where-intergalactic-trav-ba42f980-1",
       "serie": "archivo",
-      "orden": 214,
+      "orden": 213,
       "estado": "publicada",
       "concepto": "Camina por un pasillo tallado con símbolos antiguos hacia una sola estrella azul al fondo, y lleva tantos años acercándose que la estrella todavía no crece ni un poco.",
       "anio": 2025,
@@ -6637,7 +6604,7 @@
     {
       "slug": "cryochamber-where-intergalactic-trav-ba42f980-3",
       "serie": "archivo",
-      "orden": 215,
+      "orden": 214,
       "estado": "publicada",
       "concepto": "La luz que entra por la abertura circular del fondo es tan fuerte que todo lo tallado en las paredes solo existe porque a ella se le ocurrió iluminarlo.",
       "anio": 2025,
@@ -6668,7 +6635,7 @@
     {
       "slug": "cryochamber-where-intergalactic-travelers-enter-80bc2cc7-0",
       "serie": "archivo",
-      "orden": 216,
+      "orden": 215,
       "estado": "publicada",
       "concepto": "Cuenta cada panel amarillo encendido a lo largo del pasillo metálico, y pierde la cuenta justo donde el túnel oscuro se traga la última luz.",
       "anio": 2025,
@@ -6699,7 +6666,7 @@
     {
       "slug": "cs65c-8bit-halftone-screen-with-the-word-p-6cfce9ea-0",
       "serie": "archivo",
-      "orden": 217,
+      "orden": 216,
       "estado": "publicada",
       "concepto": "La palabra encendida en la pantalla lleva tanto tiempo repitiéndose que ya se borró de las notas de papel de donde la copiaron a mano.",
       "anio": 2025,
@@ -6730,7 +6697,7 @@
     {
       "slug": "cyberpunk-eye-shape-starship-with-a-45c70d99-0",
       "serie": "archivo",
-      "orden": 218,
+      "orden": 217,
       "estado": "publicada",
       "concepto": "El ojo enorme que flota arriba no ha parpadeado desde que las siluetas de abajo se quedaron paradas, y no lo va a hacer hasta que la última de ellas mire para otro lado.",
       "anio": 2025,
@@ -6761,7 +6728,7 @@
     {
       "slug": "cydney-parker-photo-by-michael-odet-in-the-f2ca84df-3",
       "serie": "archivo",
-      "orden": 219,
+      "orden": 218,
       "estado": "publicada",
       "concepto": "El delineado le nace en el párpado y no para hasta la sien, tres centímetros de más que lleva puestos con la misma calma con que otros llevan puesto un nombre.",
       "anio": 2025,
@@ -6792,7 +6759,7 @@
     {
       "slug": "daily-life-in-a-stilt-houses-submerged-in-62ca7a63-0",
       "serie": "archivo",
-      "orden": 220,
+      "orden": 219,
       "estado": "publicada",
       "concepto": "El agua bajo la canoa es tan transparente que el remero cuenta los peces dos veces: una vez nadando y otra en su sombra sobre la arena.",
       "anio": 2025,
@@ -6823,7 +6790,7 @@
     {
       "slug": "day-in-the-corporate-office-postcard-in-the-5c4f4208-3",
       "serie": "archivo",
-      "orden": 221,
+      "orden": 220,
       "estado": "publicada",
       "concepto": "Los tres llevan tanto tiempo mirando el vidrio verde que ya no distinguen si observan la ciudad o si la ciudad, allá abajo, los observa a ellos.",
       "anio": 2025,
@@ -6854,7 +6821,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-08b14f56-2",
       "serie": "archivo",
-      "orden": 222,
+      "orden": 221,
       "estado": "publicada",
       "concepto": "Las paredes desaparecen bajo tantas hojas pegadas unas sobre otras que ya nadie sabe de qué color se pintaron, y solo la nevera blanca del fondo guarda un rectángulo libre.",
       "anio": 2025,
@@ -6885,7 +6852,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-08b14f56-3",
       "serie": "archivo",
-      "orden": 223,
+      "orden": 222,
       "estado": "publicada",
       "concepto": "La pared de ladrillo sostiene más papeles clavados que ladrillos visibles le quedan, mientras la silla negra gira sola hacia la ventana esperando que alguien entre antes de que se apague la luz.",
       "anio": 2025,
@@ -6916,7 +6883,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-b9dc5818-2",
       "serie": "archivo",
-      "orden": 224,
+      "orden": 223,
       "estado": "publicada",
       "concepto": "Firma papel tras papel sobre el mostrador beige sin levantar la vista, mientras la planta de la esquina crece tan derecha que parece llevar ahí desde la inauguración del edificio.",
       "anio": 2025,
@@ -6947,7 +6914,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-b9dc5818-3",
       "serie": "archivo",
-      "orden": 225,
+      "orden": 224,
       "estado": "publicada",
       "concepto": "Las cuatro sillas moradas rodean el escritorio de caoba sin que nadie las haya movido en años, mientras la ciudad entera se extiende bajo el vidrio esperando una reunión que no llega.",
       "anio": 2025,
@@ -6978,7 +6945,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-e4436906-2",
       "serie": "archivo",
-      "orden": 226,
+      "orden": 225,
       "estado": "publicada",
       "concepto": "Los papeles cubren el piso turquesa como una alfombra que nadie ha barrido en cinco cambios de sistema operativo, mientras las pantallas viejas siguen encendidas mirando hacia la nada.",
       "anio": 2025,
@@ -7009,7 +6976,7 @@
     {
       "slug": "day-in-the-office-room-postcard-in-the-e4436906-3",
       "serie": "archivo",
-      "orden": 227,
+      "orden": 226,
       "estado": "publicada",
       "concepto": "El único mueble del cuarto es esta silla roja, y el sol entra tan oblicuo por la puerta de vidrio que le dibuja una sombra el doble de larga que ella misma.",
       "anio": 2025,
@@ -7040,7 +7007,7 @@
     {
       "slug": "day-inside-the-corporate-office-room-busy-cubicl-1a592b03-0",
       "serie": "archivo",
-      "orden": 228,
+      "orden": 227,
       "estado": "publicada",
       "concepto": "La planta cuelga tan cargada de hojas sobre los cubículos que dos personas trabajan a la sombra de sus ramas sin haber sembrado nada ellas mismas.",
       "anio": 2025,
@@ -7071,7 +7038,7 @@
     {
       "slug": "day-inside-the-corporate-office-room-busy-cubicl-1a592b03-1",
       "serie": "archivo",
-      "orden": 229,
+      "orden": 228,
       "estado": "publicada",
       "concepto": "Trabaja de espaldas a la puerta con dos pantallas encendidas frente a él, y detrás las carpetas se apilan en una torre tan firme que ya hace las veces de pared.",
       "anio": 2025,
@@ -7102,7 +7069,7 @@
     {
       "slug": "day-with-the-fishermen-postcard-in-the-style-277187c6-0",
       "serie": "archivo",
-      "orden": 230,
+      "orden": 229,
       "estado": "publicada",
       "concepto": "Lleva la espalda tan mojada de sudor y salitre que el sol le dibuja encima el mismo brillo del mar que tiene enfrente, y ya no se sabe cuál de los dos moja al otro.",
       "anio": 2025,
@@ -7133,7 +7100,7 @@
     {
       "slug": "day-with-the-fishermen-postcard-in-the-style-2ced6dad-3",
       "serie": "archivo",
-      "orden": 231,
+      "orden": 230,
       "estado": "publicada",
       "concepto": "Reman los cuatro exactamente al mismo compás, y la estela que dejan sobre el agua verde queda tan recta que parece trazada con regla desde la orilla.",
       "anio": 2025,
@@ -7164,7 +7131,7 @@
     {
       "slug": "dcxg-a-fishing-b-10246a99-0",
       "serie": "archivo",
-      "orden": 232,
+      "orden": 231,
       "estado": "publicada",
       "concepto": "Las olas rompen en una línea blanca tan larga que parece un cordón que amarra la isla de palmeras a la orilla, y el bote diminuto cruza justo por el nudo.",
       "anio": 2025,
@@ -7195,7 +7162,7 @@
     {
       "slug": "dcxg-a-fishing-boat-at-the-distance-in-97fb414d-1",
       "serie": "archivo",
-      "orden": 233,
+      "orden": 232,
       "estado": "publicada",
       "concepto": "El sol se rompe en tantos pedazos sobre el agua que la barca navega envuelta en su propio enjambre de chispas, dejando atrás una estela de espuma blanca.",
       "anio": 2025,
@@ -7226,7 +7193,7 @@
     {
       "slug": "dcxg-a-fishing-boat-at-the-distance-in-a69cc905-0",
       "serie": "archivo",
-      "orden": 234,
+      "orden": 233,
       "estado": "publicada",
       "concepto": "La mesa azul del primer plano queda vacía menos por un vaso, mientras el bote de pescadores se recorta diminuto justo en el centro del marco de paja.",
       "anio": 2025,
@@ -7257,7 +7224,7 @@
     {
       "slug": "dcxg-a-fishing-boat-at-the-distance-in-a69cc905-2",
       "serie": "archivo",
-      "orden": 235,
+      "orden": 234,
       "estado": "publicada",
       "concepto": "La costa se difumina tan lejos en la neblina que el bote navega sin saber ya si todavía tiene tierra detrás o si ya la dejó atrás hace rato.",
       "anio": 2025,
@@ -7288,7 +7255,7 @@
     {
       "slug": "dcxg-httpss-mj-r-06e5aaf4-2",
       "serie": "archivo",
-      "orden": 236,
+      "orden": 235,
       "estado": "publicada",
       "concepto": "Corren en fila justo por la orilla donde el agua toca la arena, y el sol de frente los recorta tan negros que ya son puro contorno en movimiento.",
       "anio": 2025,
@@ -7319,7 +7286,7 @@
     {
       "slug": "dcxg-httpss-mj-r-0a30f04e-1",
       "serie": "archivo",
-      "orden": 237,
+      "orden": 236,
       "estado": "publicada",
       "concepto": "Tiene dos puertas azules idénticas una junto a la otra, y ninguna de las dos se usa tanto como la lancha varada en la arena de al lado.",
       "anio": 2025,
@@ -7350,7 +7317,7 @@
     {
       "slug": "dcxg-httpss-mj-r-12647c4e-3",
       "serie": "archivo",
-      "orden": 238,
+      "orden": 237,
       "estado": "publicada",
       "concepto": "Baja por el sendero de tierra entre las piedras blancas, y la ola que rompe al final es tan alta que lo deja del tamaño de una de esas piedras.",
       "anio": 2025,
@@ -7381,7 +7348,7 @@
     {
       "slug": "dcxg-httpss-mj-r-1778e0f7-1",
       "serie": "archivo",
-      "orden": 239,
+      "orden": 238,
       "estado": "publicada",
       "concepto": "La nube blanca ocupa más cielo que las tres casas de paja ocupan tierra, y aun así ninguna de las puertas azules se ha movido para mirarla.",
       "anio": 2025,
@@ -7412,7 +7379,7 @@
     {
       "slug": "dcxg-httpss-mj-r-267dff55-2",
       "serie": "archivo",
-      "orden": 240,
+      "orden": 239,
       "estado": "publicada",
       "concepto": "La lente curva tanto el horizonte que el lago rosado se le enrosca completo detrás de la cabeza, con todo y bote, antes de volver a enderezarse en los bordes.",
       "anio": 2025,
@@ -7443,7 +7410,7 @@
     {
       "slug": "dcxg-httpss-mj-r-3eb12ea5-2",
       "serie": "archivo",
-      "orden": 241,
+      "orden": 240,
       "estado": "publicada",
       "concepto": "El piano suena tan cerca del arco abierto al mar que las notas salen directo hacia el agua sin pasar antes por ninguna de las mesas.",
       "anio": 2025,
@@ -7474,7 +7441,7 @@
     {
       "slug": "dcxg-httpss-mj-r-42234bf1-1",
       "serie": "archivo",
-      "orden": 242,
+      "orden": 241,
       "estado": "publicada",
       "concepto": "Las flores amarillas cubren tanto terreno frente a la casa que los dos que están sentados junto a la puerta parecen esperar en medio de un campo entero.",
       "anio": 2025,
@@ -7505,7 +7472,7 @@
     {
       "slug": "dcxg-httpss-mj-r-4b72baa4-3",
       "serie": "archivo",
-      "orden": 243,
+      "orden": 242,
       "estado": "publicada",
       "concepto": "La pared azul se oscurece tanto con la última luz que el techo de tejas rojas es lo único que todavía se distingue del cielo que se le está poniendo encima.",
       "anio": 2025,
@@ -7536,7 +7503,7 @@
     {
       "slug": "dcxg-httpss-mj-r-a9a6e656-0",
       "serie": "archivo",
-      "orden": 244,
+      "orden": 243,
       "estado": "publicada",
       "concepto": "El bote de madera lleva apoyado en la pared turquesa tanto tiempo que los arbustos le crecieron por dentro, y hace rato dejó de esperar la marea.",
       "anio": 2025,
@@ -7567,7 +7534,7 @@
     {
       "slug": "dcxg-httpss-mj-r-cd08ef79-0",
       "serie": "archivo",
-      "orden": 245,
+      "orden": 244,
       "estado": "publicada",
       "concepto": "Empedrado de nubes iguales, el cielo ocupa las tres cuartas partes de la fotografía y dobla la calle entera dentro de su curva de vidrio.",
       "anio": 2025,
@@ -7598,7 +7565,7 @@
     {
       "slug": "dcxg-httpss-mj-r-cf10e7cb-0",
       "serie": "archivo",
-      "orden": 246,
+      "orden": 245,
       "estado": "publicada",
       "concepto": "El canal se parte en tres brazos de agua que devuelven el sol como espejos rotos, y el pantano verde no deja ver dónde empieza la tierra firme.",
       "anio": 2025,
@@ -7629,7 +7596,7 @@
     {
       "slug": "dcxg-slice-of-li-a404bb2f-3",
       "serie": "archivo",
-      "orden": 247,
+      "orden": 246,
       "estado": "publicada",
       "concepto": "Reparten el pescado en cestas de mimbre los hombres de sombrero blanco, y la noche se traga cada bulto apenas se aparta de la luz.",
       "anio": 2025,
@@ -7660,7 +7627,7 @@
     {
       "slug": "dcxg-slice-of-li-c08c9837-1",
       "serie": "archivo",
-      "orden": 248,
+      "orden": 247,
       "estado": "publicada",
       "concepto": "El árbol se dobla entero hacia la playa, como si llevara cien años señalando el camino al carro blanco que baja solo por la carretera.",
       "anio": 2025,
@@ -7691,7 +7658,7 @@
     {
       "slug": "dcxg-slice-of-li-c08c9837-2",
       "serie": "archivo",
-      "orden": 249,
+      "orden": 248,
       "estado": "publicada",
       "concepto": "Lleva el sombrero de paja calado hasta las cejas y deja la cerveza a medio terminar sobre el muro, mientras el bote se mece detrás de él como si esperara turno.",
       "anio": 2025,
@@ -7722,7 +7689,7 @@
     {
       "slug": "dcxg-slice-of-li-e1ea1286-1",
       "serie": "archivo",
-      "orden": 250,
+      "orden": 249,
       "estado": "publicada",
       "concepto": "La moto atraviesa la orilla a tanta velocidad que la casa de zinc se vuelve un borrón detrás de él y el bote ni alcanza a moverse con la ola de aire.",
       "anio": 2025,
@@ -7753,7 +7720,7 @@
     {
       "slug": "dcxg-slice-of-li-e1ea1286-2",
       "serie": "archivo",
-      "orden": 251,
+      "orden": 250,
       "estado": "publicada",
       "concepto": "Contra el brillo del mar se recorta un grupo de cabezas en silueta, y al fondo las torres de la refinería queman su propia luz compitiendo con el sol de la tarde.",
       "anio": 2025,
@@ -7784,7 +7751,7 @@
     {
       "slug": "de-httpss-mj-r-0952c9b5-1",
       "serie": "archivo",
-      "orden": 252,
+      "orden": 251,
       "estado": "publicada",
       "concepto": "El rojo de la pintura le cubre la cara entera hasta la línea del cuello, donde el collar de piel se cierra con un solo diente blanco que cuelga como firma.",
       "anio": 2025,
@@ -7814,7 +7781,7 @@
     {
       "slug": "de-httpss-mj-r-50375359-1",
       "serie": "archivo",
-      "orden": 253,
+      "orden": 252,
       "estado": "publicada",
       "concepto": "Se apilan las conchas collar sobre collar hasta rozarle la barbilla, y tres rayas negras le bajan por el cuello como si contaran los años que lleva usándolas.",
       "anio": 2025,
@@ -7844,7 +7811,7 @@
     {
       "slug": "de-httpss-mj-r-5b4b01a8-3",
       "serie": "archivo",
-      "orden": 254,
+      "orden": 253,
       "estado": "publicada",
       "concepto": "Dos colmillos de metal le atraviesan el tabique al mismo tiempo, y la luz naranja le quema la piel hasta hacerla parecer brasa encendida.",
       "anio": 2025,
@@ -7874,7 +7841,7 @@
     {
       "slug": "de-httpss-mj-r-7009380c-1",
       "serie": "archivo",
-      "orden": 255,
+      "orden": 254,
       "estado": "publicada",
       "concepto": "Una sola mecha de canas le cruza el pelo negro, y la tela roja bordada le cubre apenas un hombro mientras el otro se queda desnudo bajo la sombra.",
       "anio": 2025,
@@ -7904,7 +7871,7 @@
     {
       "slug": "de-httpss-mj-r-a38d24f9-1",
       "serie": "archivo",
-      "orden": 256,
+      "orden": 255,
       "estado": "publicada",
       "concepto": "Le nace la pluma justo en la coronilla, y el collar de cuentas le cae por el pecho hasta rematar en una franja de conchas que casi le llega al ombligo.",
       "anio": 2025,
@@ -7934,7 +7901,7 @@
     {
       "slug": "de-httpss-mj-r-a38d24f9-2",
       "serie": "archivo",
-      "orden": 257,
+      "orden": 256,
       "estado": "publicada",
       "concepto": "El arete de madera se le curva como un anzuelo entero colgado del lóbulo, y entre los collares le asoman plumas como si un ave se hubiera quedado atrapada ahí.",
       "anio": 2025,
@@ -7964,7 +7931,7 @@
     {
       "slug": "de-httpss-mj-r-c469a44e-2",
       "serie": "archivo",
-      "orden": 258,
+      "orden": 257,
       "estado": "publicada",
       "concepto": "El flequillo le corta la frente en línea perfecta, y dos aros dorados le atraviesan la nariz mientras los collares se apilan uno sobre otro hasta rozarle la barbilla.",
       "anio": 2025,
@@ -7994,7 +7961,7 @@
     {
       "slug": "de-httpss-mj-r-cc75e988-1",
       "serie": "archivo",
-      "orden": 259,
+      "orden": 258,
       "estado": "publicada",
       "concepto": "Apenas le alcanza la luz el filo de la nariz y el pómulo derecho, dejando el resto de la cara suelto en la oscuridad del fondo.",
       "anio": 2025,
@@ -8024,7 +7991,7 @@
     {
       "slug": "de-httpss-mj-r-cebda612-1",
       "serie": "archivo",
-      "orden": 260,
+      "orden": 259,
       "estado": "publicada",
       "concepto": "La manta a rayas rojas y negras le cubre un solo hombro y deja el otro desnudo, como si la tela hubiera decidido a mitad de camino no seguir cubriendo.",
       "anio": 2025,
@@ -8054,7 +8021,7 @@
     {
       "slug": "de-httpss-mj-r-cebda612-2",
       "serie": "archivo",
-      "orden": 261,
+      "orden": 260,
       "estado": "publicada",
       "concepto": "Lleva un brazalete de cuentas idéntico en cada brazo, como un par de pulseras gemelas, mientras la estera tejida del fondo repite el mismo trenzado hasta el borde del retrato.",
       "anio": 2025,
@@ -8084,7 +8051,7 @@
     {
       "slug": "de-httpss-mj-r-e8e9ea51-2",
       "serie": "archivo",
-      "orden": 262,
+      "orden": 261,
       "estado": "publicada",
       "concepto": "Los collares se multiplican capa tras capa hasta que todos convergen en una sola piedra colgante, como si tanta cuenta solo existiera para sostener ese punto final.",
       "anio": 2025,
@@ -8114,7 +8081,7 @@
     {
       "slug": "de-httpss-mj-r-e8e9ea51-3",
       "serie": "archivo",
-      "orden": 263,
+      "orden": 262,
       "estado": "publicada",
       "concepto": "La vincha de cuentas le divide el pelo en una línea recta sobre la frente, y el azul del fondo hace que cada concha blanca del collar brille como si tuviera luz propia.",
       "anio": 2025,
@@ -8144,7 +8111,7 @@
     {
       "slug": "de-httpss-mj-r-eb39163d-2",
       "serie": "archivo",
-      "orden": 264,
+      "orden": 263,
       "estado": "publicada",
       "concepto": "El collar se ensancha hasta volverse un peto entero de cuentas que le cubre el pecho como si fuera una armadura tejida hilo por hilo.",
       "anio": 2025,
@@ -8174,7 +8141,7 @@
     {
       "slug": "de-httpss-mj-r-fc90690d-1",
       "serie": "archivo",
-      "orden": 265,
+      "orden": 264,
       "estado": "publicada",
       "concepto": "El manto tejido le nace en los hombros sembrado de conchas, como si el tejedor hubiera decidido coserle el mar entero encima.",
       "anio": 2025,
@@ -8204,7 +8171,7 @@
     {
       "slug": "de-httpss-mj-r-fc90690d-3",
       "serie": "archivo",
-      "orden": 266,
+      "orden": 265,
       "estado": "publicada",
       "concepto": "El arete de conchas le cuelga tan largo que le roza el hombro, y la vincha a rayas azules le cruza la frente como una segunda ceja pintada de tela.",
       "anio": 2025,
@@ -8234,7 +8201,7 @@
     {
       "slug": "de-retrato-de-02ff3e12-0",
       "serie": "archivo",
-      "orden": 267,
+      "orden": 266,
       "estado": "publicada",
       "concepto": "Las plumas se abren en abanico justo detrás de la sien y encienden de rojo y azul la única parte de la cabeza que la sombra no alcanza a cubrir.",
       "anio": 2025,
@@ -8265,7 +8232,7 @@
     {
       "slug": "did-you-know-that-acuatic-dinosaurs-also-spawn-f1eac6ab-0",
       "serie": "archivo",
-      "orden": 268,
+      "orden": 267,
       "estado": "publicada",
       "concepto": "La cresta de la ola se vuelve un vidrio verde justo antes de romper, y la espuma le dibuja una cortina blanca que dura menos de un segundo bajo la luz naranja del atardecer.",
       "anio": 2025,
@@ -8296,7 +8263,7 @@
     {
       "slug": "did-you-know-that-sharks-also-spawn-eggs-5704380b-3",
       "serie": "archivo",
-      "orden": 269,
+      "orden": 268,
       "estado": "publicada",
       "concepto": "Abre la boca de frente a la cámara y enseña cada diente uno por uno, mientras las burbujas del buzo suben derechas como una cuenta hacia la superficie.",
       "anio": 2025,
@@ -8327,7 +8294,7 @@
     {
       "slug": "did-you-know-that-sharks-also-spawn-eggs-81a5d6ea-1",
       "serie": "archivo",
-      "orden": 270,
+      "orden": 269,
       "estado": "publicada",
       "concepto": "Entre el arrecife anaranjado que arde bajo sus aletas y el mismo incendio repetido en el reflejo de la superficie, nada raso sin chamuscarse ni una escama.",
       "anio": 2025,
@@ -8358,7 +8325,7 @@
     {
       "slug": "did-you-know-that-starfish-and-brittle-stars-9abaf15c-3",
       "serie": "archivo",
-      "orden": 271,
+      "orden": 270,
       "estado": "publicada",
       "concepto": "Flota a un palmo del agua sin mojarse nunca, con los pliegues color brasa tan tersos que el viento del atardecer los dobla como si fueran tela.",
       "anio": 2025,
@@ -8389,7 +8356,7 @@
     {
       "slug": "dqcokgi-cinematic-film-photo-close-up-of-per-8477f66b-1",
       "serie": "archivo",
-      "orden": 272,
+      "orden": 271,
       "estado": "publicada",
       "concepto": "Las manos desnudas golpean el cuero del tambor, y cada golpe suelta una chispa naranja que da la vuelta completa a la playa antes de apagarse.",
       "anio": 2025,
@@ -8420,7 +8387,7 @@
     {
       "slug": "el-regal-este-bolero-lp-remastered-in-the-9793bbf9-0",
       "serie": "archivo",
-      "orden": 273,
+      "orden": 272,
       "estado": "publicada",
       "concepto": "La esfera afelpada y azul del suelo queda a un roce de las faldas de rafia, y ninguno de los cuatro se atreve a tocarla primero.",
       "anio": 2025,
@@ -8451,7 +8418,7 @@
     {
       "slug": "el-regal-este-bolero-lp-remastered-in-the-ec6f5647-3",
       "serie": "archivo",
-      "orden": 274,
+      "orden": 273,
       "estado": "publicada",
       "concepto": "Toca el cuatro sentado en el centro exacto del tablero a cuadros, y el tablero gira tan despacio que los otros dos llevan media vida buscando ese mismo centro.",
       "anio": 2025,
@@ -8482,7 +8449,7 @@
     {
       "slug": "elegant-jap-480ff122-2",
       "serie": "archivo",
-      "orden": 275,
+      "orden": 274,
       "estado": "publicada",
       "concepto": "Bajo los letreros de neón puntea el shamisen, y cada nota que suelta apaga una letra distinta del rótulo rosado antes de volver a encenderse sola.",
       "anio": 2025,
@@ -8513,7 +8480,7 @@
     {
       "slug": "elegant-jap-a3c612f9-2",
       "serie": "archivo",
-      "orden": 276,
+      "orden": 275,
       "estado": "publicada",
       "concepto": "Sostiene el laúd contra el pecho como si fuera a caérsele el letrero rosado de encima, y camina tan despacio que las luces alcanzan a cambiar dos veces antes del siguiente paso.",
       "anio": 2025,
@@ -8544,7 +8511,7 @@
     {
       "slug": "epic-battle-between-aquiles-and-prince-hector-in-df7e0d6d-2",
       "serie": "archivo",
-      "orden": 277,
+      "orden": 276,
       "estado": "publicada",
       "concepto": "El yelmo de plata le queda salpicado de sangre ajena, y grita tan fuerte en medio de la batalla que los que están detrás bajan la lanza sin darse cuenta.",
       "anio": 2025,
@@ -8575,7 +8542,7 @@
     {
       "slug": "eric-clapton-and-claude-jean-in-elvis-presleys-c451691a-2",
       "serie": "archivo",
-      "orden": 278,
+      "orden": 277,
       "estado": "publicada",
       "concepto": "Apoya la lanza en la baranda de piedra y mira hacia la bahía como si llevara dos mil años calculando el momento exacto de bajar hasta el agua.",
       "anio": 2025,
@@ -8606,7 +8573,7 @@
     {
       "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-5f57ec01-1",
       "serie": "archivo",
-      "orden": 279,
+      "orden": 278,
       "estado": "publicada",
       "concepto": "Lleva puestos tantos collares de cuentas doradas que el cuello desaparece bajo ellos, mientras detrás le trenzan el cabello sin que mueva ni un músculo de la cara.",
       "anio": 2025,
@@ -8637,7 +8604,7 @@
     {
       "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-5f57ec01-3",
       "serie": "archivo",
-      "orden": 280,
+      "orden": 279,
       "estado": "publicada",
       "concepto": "La cinta de cuentas le cruza la frente de sien a sien sin ceder un milímetro, aunque a su lado le estén cerrando el último collar con manos apuradas.",
       "anio": 2025,
@@ -8668,7 +8635,7 @@
     {
       "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-63694911-3",
       "serie": "archivo",
-      "orden": 281,
+      "orden": 280,
       "estado": "publicada",
       "concepto": "Le colocan la tela roja sobre la cabeza a cuatro manos, dos por cada lado, y ninguna suelta hasta que queda exactamente recta sobre el peinado.",
       "anio": 2025,
@@ -8699,7 +8666,7 @@
     {
       "slug": "escena-de-una-princesa-caqueta-con-atuendo-tradi-7b2c2125-0",
       "serie": "archivo",
-      "orden": 282,
+      "orden": 281,
       "estado": "publicada",
       "concepto": "Una le trenza el cabello mechón por mechón mientras otra le acomoda el chal a rayas sobre los hombros, y las dos terminan a la vez sin haberse mirado.",
       "anio": 2025,
@@ -8728,38 +8695,9 @@
       "generacion": "7b2c2125-d97f-43b3-953f-790f9ed4e871"
     },
     {
-      "slug": "escucha-profunda",
-      "titulo": "Escucha profunda",
-      "alt": "Retrato de perfil de una persona con los ojos cerrados, usando audífonos hechos de madera, conchas y tejido, unidos por hilos de fibra óptica.",
-      "serie": "umbral",
-      "orden": 283,
-      "estado": "pendiente",
-      "tags": [
-        "retrato",
-        "híbrido",
-        "escucha"
-      ],
-      "licencia": "editorial",
-      "w": null,
-      "h": null,
-      "anchos": [],
-      "color": "#4f3e35",
-      "concepto": "Primer plano de perfil. Una figura caquetía contemporánea escucha con los ojos cerrados. Los audífonos son de madera, conchas y tejido, conectados por fibra óptica.",
-      "anio": 2025,
-      "licenciaDetalle": {
-        "tipo": "editorial",
-        "print": false,
-        "notas": "Retrato: revisar derechos antes de cualquier uso comercial."
-      },
-      "procedencia": {
-        "herramienta": "Midjourney"
-      },
-      "edicion": "01"
-    },
-    {
       "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-26c39d33-0",
       "serie": "archivo",
-      "orden": 284,
+      "orden": 282,
       "estado": "publicada",
       "concepto": "La hamaca cuelga atravesada en el marco de la puerta, y desde ella se ve el mar entero sin levantarse ni mecerla una sola vez.",
       "anio": 2025,
@@ -8790,7 +8728,7 @@
     {
       "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-26c39d33-2",
       "serie": "archivo",
-      "orden": 285,
+      "orden": 283,
       "estado": "publicada",
       "concepto": "Entre las flores amarillas se queda quieto el caballo blanco tanto rato que las enredaderas empiezan a treparle por las patas sin que se aparte.",
       "anio": 2025,
@@ -8821,7 +8759,7 @@
     {
       "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-1",
       "serie": "archivo",
-      "orden": 286,
+      "orden": 284,
       "estado": "publicada",
       "concepto": "Las estrellas se amontonan justo encima del techo de tejas mientras la hamaca vacía se mece sola frente a la puerta, como si alguien acabara de soltarla.",
       "anio": 2025,
@@ -8852,7 +8790,7 @@
     {
       "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-2",
       "serie": "archivo",
-      "orden": 287,
+      "orden": 285,
       "estado": "publicada",
       "concepto": "La cortina se abre justo lo necesario para que la bahía entera quepa entre las flores del balcón y la sombra de quien mira sin moverse del marco.",
       "anio": 2025,
@@ -8883,7 +8821,7 @@
     {
       "slug": "ethereal-vistas-from-paraguan-with-indigenous-re-6bb29086-3",
       "serie": "archivo",
-      "orden": 288,
+      "orden": 286,
       "estado": "publicada",
       "concepto": "Abierta de par en par, la puerta azul deja que la montaña entera quepa detrás del árbol sin que nadie se moleste nunca en cerrarla.",
       "anio": 2025,
@@ -8914,7 +8852,7 @@
     {
       "slug": "extreme-close-up-on-retro-analog-control-panel-07ee67aa-0",
       "serie": "archivo",
-      "orden": 289,
+      "orden": 287,
       "estado": "publicada",
       "concepto": "La mano descansa sobre los mandos sin apretar ninguno, mientras en la pantalla de al lado la ciudad entera de luces sigue encendida abajo, como si esperara la orden.",
       "anio": 2025,
@@ -8945,7 +8883,7 @@
     {
       "slug": "felix-vallottons-painting-slice-of-life-in-carac-ffd0fd28-0",
       "serie": "archivo",
-      "orden": 290,
+      "orden": 288,
       "estado": "publicada",
       "concepto": "El árbol deja caer sus flores rosadas sobre la banca donde los dos se sientan, y el carro negro estacionado lleva tantos años ahí que ya le brotan pétalos en el capó.",
       "anio": 2025,
@@ -8975,7 +8913,7 @@
     {
       "slug": "felix-vallottons-painting-slice-of-life-in-carac-ffd0fd28-3",
       "serie": "archivo",
-      "orden": 291,
+      "orden": 289,
       "estado": "publicada",
       "concepto": "El papel tapiz verde repite su propio dibujo detrás de ella una y otra vez, hasta que el rojo de los labios queda como lo único en la habitación que no se repite.",
       "anio": 2025,
@@ -9005,7 +8943,7 @@
     {
       "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-0",
       "serie": "archivo",
-      "orden": 292,
+      "orden": 290,
       "estado": "publicada",
       "concepto": "Levanta un brazo hacia la luna nueva mientras el fuego le sube por el manto color cobre, y nadie más se mueve hasta que la llama le toca el codo.",
       "anio": 2025,
@@ -9036,7 +8974,7 @@
     {
       "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-1",
       "serie": "archivo",
-      "orden": 293,
+      "orden": 291,
       "estado": "publicada",
       "concepto": "El círculo completo rodea el fuego sin dejar un solo hueco entre manto y manto, mientras los árboles de ambos lados de la playa se inclinan igual de negros hacia el centro.",
       "anio": 2025,
@@ -9067,7 +9005,7 @@
     {
       "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-2",
       "serie": "archivo",
-      "orden": 294,
+      "orden": 292,
       "estado": "publicada",
       "concepto": "El fuego les llega más alto que la cintura y ninguno retrocede un paso, mientras la luna en cuarto menguante se queda justo encima como si vigilara el tamaño de las brasas.",
       "anio": 2025,
@@ -9098,7 +9036,7 @@
     {
       "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-585c508a-3",
       "serie": "archivo",
-      "orden": 295,
+      "orden": 293,
       "estado": "publicada",
       "concepto": "Siete cuerpos envueltos en blanco giran alrededor de la hoguera, y la luna llevaba tres noches acercándose tanto que el humo ya le toca el filo.",
       "anio": 2025,
@@ -9129,7 +9067,7 @@
     {
       "slug": "fhzlew3f0w-35mm-cinematic-prehispanic-scene-a-c-fdc77c5a-2",
       "serie": "archivo",
-      "orden": 296,
+      "orden": 294,
       "estado": "publicada",
       "concepto": "El fuego les llega a la cintura y ningún pie descalzo se quema, porque esa arena aprendió hace generaciones a enfriarse justo antes de que la pisen.",
       "anio": 2025,
@@ -9160,7 +9098,7 @@
     {
       "slug": "first-class-spacefreighter-docked-to-02ec42f2-2",
       "serie": "archivo",
-      "orden": 297,
+      "orden": 295,
       "estado": "publicada",
       "concepto": "Las antenas de la estación cuelgan sobre el desierto rosado y proyectan una sombra tan larga que a esa hora ya oscurece el valle siguiente.",
       "anio": 2025,
@@ -9191,7 +9129,7 @@
     {
       "slug": "fishermen-in-a-fishing-boat-at-the-distance-0422a9d1-1",
       "serie": "archivo",
-      "orden": 298,
+      "orden": 296,
       "estado": "publicada",
       "concepto": "El remo levanta gotas que tardan tanto en caer que el segundo pescador ya cambió de lado antes de que toquen el agua otra vez.",
       "anio": 2025,
@@ -9222,7 +9160,7 @@
     {
       "slug": "frank-whittier-on-his-egyptian-expedition-1910-1-12cc7e4a-0",
       "serie": "archivo",
-      "orden": 299,
+      "orden": 297,
       "estado": "publicada",
       "concepto": "Cuenta los surcos de la espiral tallada en la tierra y son tantos que ha perdido la cuenta siete veces sin moverse un paso del borde.",
       "anio": 2025,
@@ -9253,7 +9191,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-count-1a12a89c-1",
       "serie": "archivo",
-      "orden": 300,
+      "orden": 298,
       "estado": "publicada",
       "concepto": "Levanta el machete tan alto que la nube se abre justo encima de la mano, y el caballo blanco no baja el paso aunque arrastre otro caballo vacío detrás.",
       "anio": 2025,
@@ -9284,7 +9222,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-count-4f326c24-1",
       "serie": "archivo",
-      "orden": 301,
+      "orden": 299,
       "estado": "publicada",
       "concepto": "Sostiene la lanza tan derecha que parte el cielo en dos mitades exactas, mientras el caballo oscuro devora la sabana sin pisar dos veces la misma brizna.",
       "anio": 2025,
@@ -9315,7 +9253,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-country-folk-hors-667b37a5-2",
       "serie": "archivo",
-      "orden": 302,
+      "orden": 300,
       "estado": "publicada",
       "concepto": "El pañuelo rojo del que va al frente ondea tanto que el polvo detrás alcanza a cubrir a los seis jinetes que lo siguen sin perderle el paso.",
       "anio": 2025,
@@ -9346,7 +9284,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-country-folk-hors-8734ce23-3",
       "serie": "archivo",
-      "orden": 303,
+      "orden": 301,
       "estado": "publicada",
       "concepto": "Lleva la faja naranja cruzada al pecho y el fusil en alto, y los soldados que vienen detrás no logran alcanzar la nube de polvo que levanta su caballo blanco.",
       "anio": 2025,
@@ -9377,7 +9315,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-country-folk-hors-e460132f-1",
       "serie": "archivo",
-      "orden": 304,
+      "orden": 302,
       "estado": "publicada",
       "concepto": "El penacho rojo de la lanza se mece tanto con el galope que ya rozó dos veces las palmas antes de llegar a la cerca de madera.",
       "anio": 2025,
@@ -9408,7 +9346,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-country-folk-hors-fb9cd5fb-2",
       "serie": "archivo",
-      "orden": 305,
+      "orden": 303,
       "estado": "publicada",
       "concepto": "Alza el sable tan derecho que el sol se detiene un segundo en el filo, antes de que caigan detrás los jinetes de casaca roja que lo siguen.",
       "anio": 2025,
@@ -9439,7 +9377,7 @@
     {
       "slug": "front-shot-scene-of-venezuelan-country-folk-hors-ffdda037-1",
       "serie": "archivo",
-      "orden": 306,
+      "orden": 304,
       "estado": "publicada",
       "concepto": "La punta de la lanza va tan adelantada que llega a la loma tres pasos antes que el caballo blanco que la sostiene.",
       "anio": 2025,
@@ -9470,7 +9408,7 @@
     {
       "slug": "full-body-front-shot-portrait-of-a-middle-1c787ec6-3",
       "serie": "archivo",
-      "orden": 307,
+      "orden": 305,
       "estado": "publicada",
       "concepto": "Sobre la camioneta blanca se amontonan tantos cambures que ya no se ve el capó, y el hombre apoya las manos en la cintura como si acabara de bajar la montaña él mismo.",
       "anio": 2025,
@@ -9500,7 +9438,7 @@
     {
       "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-0",
       "serie": "archivo",
-      "orden": 308,
+      "orden": 306,
       "estado": "publicada",
       "concepto": "El humo del cigarrillo sube tan recto en la noche sin viento que parece otra columna del carro negro contra el que se apoya.",
       "anio": 2025,
@@ -9530,7 +9468,7 @@
     {
       "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-2",
       "serie": "archivo",
-      "orden": 309,
+      "orden": 307,
       "estado": "publicada",
       "concepto": "Lleva la insignia dorada prendida al pecho y una nube tan blanca detrás que parece haberse detenido solo para hacerle de fondo mientras termina el cigarrillo.",
       "anio": 2025,
@@ -9560,7 +9498,7 @@
     {
       "slug": "full-body-front-shot-portrait-of-a-middle-fb1941ba-3",
       "serie": "archivo",
-      "orden": 310,
+      "orden": 308,
       "estado": "publicada",
       "concepto": "Cruza los brazos con tanta firmeza que la hebilla dorada del cinturón no se mueve ni cuando el cartel a medio leer parpadea detrás en verde.",
       "anio": 2025,
@@ -9590,7 +9528,7 @@
     {
       "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-1",
       "serie": "archivo",
-      "orden": 311,
+      "orden": 309,
       "estado": "publicada",
       "concepto": "Alza tanto la barbilla que el degradado del fondo parece partirse justo en la línea de los lentes, mitad rojo y mitad amarillo sin que se note la costura.",
       "anio": 2025,
@@ -9621,7 +9559,7 @@
     {
       "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-2",
       "serie": "archivo",
-      "orden": 312,
+      "orden": 310,
       "estado": "publicada",
       "concepto": "Contra el fondo que se derrite de rojo en amarillo, la cadena dorada apenas tiembla sobre el perfil quieto.",
       "anio": 2025,
@@ -9652,7 +9590,7 @@
     {
       "slug": "full-body-photography-of-african-teenager-with-s-7ed24ffd-3",
       "serie": "archivo",
-      "orden": 313,
+      "orden": 311,
       "estado": "publicada",
       "concepto": "La camisa se le resbala del hombro mientras mira hacia arriba, y el rojo del fondo es tan intenso que le tiñe hasta el blanco de los ojos.",
       "anio": 2025,
@@ -9683,7 +9621,7 @@
     {
       "slug": "full-body-picture-of-a-man-with-a-0dd88675-3",
       "serie": "archivo",
-      "orden": 314,
+      "orden": 312,
       "estado": "publicada",
       "concepto": "El guacamayo rojo le clava las garras en el hombro con tanta calma que hace veinte años que no lo suelta, ni cuando cambia la marea detrás.",
       "anio": 2025,
@@ -9714,7 +9652,7 @@
     {
       "slug": "full-body-picture-of-a-man-with-a-c00da319-1",
       "serie": "archivo",
-      "orden": 315,
+      "orden": 313,
       "estado": "publicada",
       "concepto": "Las plumas de la cola del guacamayo alcanzan a rozarle la espalda mientras el cielo detrás quema tan lento que lleva media hora sin terminar de amanecer.",
       "anio": 2025,
@@ -9745,7 +9683,7 @@
     {
       "slug": "full-body-picture-of-a-man-with-a-f8a97c19-0",
       "serie": "archivo",
-      "orden": 316,
+      "orden": 314,
       "estado": "publicada",
       "concepto": "Frente al mar azul y liso, el rojo del guacamayo es la única mancha que se mueve en toda la costa esa mañana.",
       "anio": 2025,
@@ -9776,7 +9714,7 @@
     {
       "slug": "full-body-picture-of-a-man-with-a-f8a97c19-3",
       "serie": "archivo",
-      "orden": 317,
+      "orden": 315,
       "estado": "publicada",
       "concepto": "La luz dorada del final de la tarde se le queda pegada en el pelo tanto como el guacamayo se le queda pegado en el hombro.",
       "anio": 2025,
@@ -9807,7 +9745,7 @@
     {
       "slug": "full-body-picture-of-buchibe-the-last-manaure-e953e0cf-2",
       "serie": "archivo",
-      "orden": 318,
+      "orden": 316,
       "estado": "publicada",
       "concepto": "En la niebla azul del bosque, la pluma roja del tocado no se mueve pese al viento, como si la noche llevara horas conteniendo el aire.",
       "anio": 2025,
@@ -9837,7 +9775,7 @@
     {
       "slug": "full-body-portrait-of-a-young-soilder-conquistad-0d6148cc-2",
       "serie": "archivo",
-      "orden": 319,
+      "orden": 317,
       "estado": "publicada",
       "concepto": "La luz roja le cae tan directa en la cota de malla que cada anillo brilla por separado, mientras sostiene la pica firme contra el marco de piedra.",
       "anio": 2025,
@@ -9868,7 +9806,7 @@
     {
       "slug": "full-shot-of-japanese-geisha-wearing-0fb0dd46-1",
       "serie": "archivo",
-      "orden": 320,
+      "orden": 318,
       "estado": "publicada",
       "concepto": "Pulsa la última cuerda del shamisen con el bachi dorado y el azul del cielo se detiene una hora entera, prendido a las flores de cerezo que crecen junto a sus rodillas.",
       "anio": 2025,
@@ -9899,7 +9837,7 @@
     {
       "slug": "full-shot-of-japanese-geisha-wearing-a-colorful-64aa9b47-0",
       "serie": "archivo",
-      "orden": 321,
+      "orden": 319,
       "estado": "publicada",
       "concepto": "Las flores bordadas en la manga se abren al mismo ritmo que el cielo cambia del añil al violeta, y para cuando termina el último acorde ya lucen el color exacto del ocaso.",
       "anio": 2025,
@@ -9930,7 +9868,7 @@
     {
       "slug": "full-shot-of-japanese-geisha-wearing-f3a8fe57-3",
       "serie": "archivo",
-      "orden": 322,
+      "orden": 320,
       "estado": "publicada",
       "concepto": "Los hilos dorados del kimono brillan tanto contra la noche que las montañas del fondo se apagan una a una, como si le cedieran su luz a cada puntada del bordado.",
       "anio": 2025,
@@ -9961,7 +9899,7 @@
     {
       "slug": "full-view-o-89e0a919-3",
       "serie": "archivo",
-      "orden": 323,
+      "orden": 321,
       "estado": "publicada",
       "concepto": "Los botones dorados de su casaca llevan sumergidos tanto tiempo en la tormenta que ya conocen cada ola por su nombre, y ninguna ha logrado opacarles el brillo.",
       "anio": 2025,
@@ -9992,7 +9930,7 @@
     {
       "slug": "full-view-of-cinematographic-scene-o-ea321999-1",
       "serie": "archivo",
-      "orden": 324,
+      "orden": 322,
       "estado": "publicada",
       "concepto": "Sostiene la capa verde doblada sobre el brazo con tanta firmeza que ni el volcán humeante detrás ni el oleaje logran moverle un solo pliegue de la tela.",
       "anio": 2025,
@@ -10023,7 +9961,7 @@
     {
       "slug": "futuristic-city-inside-a-dome-in-pla-774ab977-0",
       "serie": "archivo",
-      "orden": 325,
+      "orden": 323,
       "estado": "publicada",
       "concepto": "La nave cruza el mismo tramo de desierto ocre desde hace tres lunas y todavía no llega a las torres de la ciudad que se ve enmarcada en la escotilla.",
       "anio": 2025,
@@ -10054,7 +9992,7 @@
     {
       "slug": "futuristic-city-inside-a-dome-in-planet-mars-03b89f48-0",
       "serie": "archivo",
-      "orden": 326,
+      "orden": 324,
       "estado": "publicada",
       "concepto": "La cúpula negra se traga el cielo rojo del atardecer y proyecta las sombras de sus torres tan lejos que llegan hasta las naves que apenas despegan del suelo.",
       "anio": 2025,
@@ -10085,7 +10023,7 @@
     {
       "slug": "futuristic-city-inside-a-dome-in-planet-mars-03b89f48-2",
       "serie": "archivo",
-      "orden": 327,
+      "orden": 325,
       "estado": "publicada",
       "concepto": "La sombra de la torre en primer plano se estira tanto que cruza toda la explanada y llega a tocar el borde curvo de la cúpula iluminada al fondo.",
       "anio": 2025,
@@ -10116,7 +10054,7 @@
     {
       "slug": "futuristic-city-inside-a-dome-in-planet-mars-890dd33d-2",
       "serie": "archivo",
-      "orden": 328,
+      "orden": 326,
       "estado": "publicada",
       "concepto": "El sol de la tarde se enreda en los paneles curvos de la cúpula y tarda tanto en soltarse que la nave alcanza a cruzar toda la ciudad antes de que se apague el reflejo.",
       "anio": 2025,
@@ -10147,7 +10085,7 @@
     {
       "slug": "futuristic-retro-of-an-orbital-spacestation-in-s-6b4f4d63-1",
       "serie": "archivo",
-      "orden": 329,
+      "orden": 327,
       "estado": "publicada",
       "concepto": "Los anillos de luz derriten la nieve en círculos perfectos a su alrededor, y el hielo solo empieza otra vez justo donde termina el último aro de la estructura.",
       "anio": 2025,
@@ -10178,7 +10116,7 @@
     {
       "slug": "futuristic-retro-poster-of-orbital-spacestation-12c48e17-0",
       "serie": "archivo",
-      "orden": 330,
+      "orden": 328,
       "estado": "publicada",
       "concepto": "Cada centímetro de la superficie del planeta esconde otra torre, otro cable, otro circuito, tantos que ni las lunas que lo rodean alcanzan a contarlos todos.",
       "anio": 2025,
@@ -10209,7 +10147,7 @@
     {
       "slug": "futuristic-retro-poster-of-orbital-spacestation-2bf81f57-2",
       "serie": "archivo",
-      "orden": 331,
+      "orden": 329,
       "estado": "publicada",
       "concepto": "El fuego anaranjado de la base lleva ardiendo tanto tiempo que ya forma caminos propios en la arena, sin subir jamás hasta las esferas que flotan sobre los tallos.",
       "anio": 2025,
@@ -10240,7 +10178,7 @@
     {
       "slug": "futuristic-retro-poster-of-orbital-spacestation-fb9fe24c-0",
       "serie": "archivo",
-      "orden": 332,
+      "orden": 330,
       "estado": "publicada",
       "concepto": "La nave esférica lleva grabado en su casco más dibujos que estrellas hay alrededor, y ni Saturno con todos sus anillos logra competirle en adornos.",
       "anio": 2025,
@@ -10271,7 +10209,7 @@
     {
       "slug": "gazing-at-earth-through-a-large-circ-dcd48366-0",
       "serie": "archivo",
-      "orden": 333,
+      "orden": 331,
       "estado": "publicada",
       "concepto": "Se sienta a contar las luces de las ciudades que pasan bajo la nave y para cuando termina de nombrar la primera ya se encendieron mil más.",
       "anio": 2025,
@@ -10302,7 +10240,7 @@
     {
       "slug": "gazing-at-earth-through-a-large-circ-dcd48366-2",
       "serie": "archivo",
-      "orden": 334,
+      "orden": 332,
       "estado": "publicada",
       "concepto": "Los pinos plantados junto a la escalera se inclinan un poco más cada año hacia la abertura, como si quisieran alcanzar las luces de la Tierra que se ven al fondo.",
       "anio": 2025,
@@ -10333,7 +10271,7 @@
     {
       "slug": "gazing-at-earth-through-a-large-circular-window-a39b6706-0",
       "serie": "archivo",
-      "orden": 335,
+      "orden": 333,
       "estado": "publicada",
       "concepto": "Su capa roja es el único color que se sostiene en kilómetros de arena gris, y ni la luna gigante que asoma tras las rocas logra competirle el brillo.",
       "anio": 2025,
@@ -10364,7 +10302,7 @@
     {
       "slug": "grainy-overexposed-photo-of-scene-of-argentinian-207dcfd5-0",
       "serie": "archivo",
-      "orden": 336,
+      "orden": 334,
       "estado": "publicada",
       "concepto": "La chaqueta rosa lleva más corazones rojos estampados que botones tiene el autobús entero, y el pelaje blanco del cuello se le eriza con cada frenada.",
       "anio": 2025,
@@ -10395,7 +10333,7 @@
     {
       "slug": "grainy-overexposed-photo-of-scene-of-argentinian-69961938-2",
       "serie": "archivo",
-      "orden": 337,
+      "orden": 335,
       "estado": "publicada",
       "concepto": "La camisa de lentejuelas azules refleja cada tubo de luz del techo del autobús, así que camina sentado bajo un cielo entero de estrellas fluorescentes.",
       "anio": 2025,
@@ -10426,7 +10364,7 @@
     {
       "slug": "grainy-overexposed-photo-of-scene-of-argentinian-cf464c66-0",
       "serie": "archivo",
-      "orden": 338,
+      "orden": 336,
       "estado": "publicada",
       "concepto": "Los rizos rubios le ocupan tanto espacio que el pasajero de al lado ya perdió medio asiento, y los lunares negros del abrigo blanco parecen contarlos uno por uno.",
       "anio": 2025,
@@ -10457,7 +10395,7 @@
     {
       "slug": "grainy-overexposed-photo-of-scene-of-argentinian-dd26f839-0",
       "serie": "archivo",
-      "orden": 339,
+      "orden": 337,
       "estado": "publicada",
       "concepto": "El abrigo morado combina tanto con los asientos rosados del autobús que si cerrara los ojos un segundo más se confundiría entero con la tapicería.",
       "anio": 2025,
@@ -10488,7 +10426,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-242cacc4-2",
       "serie": "archivo",
-      "orden": 340,
+      "orden": 338,
       "estado": "publicada",
       "concepto": "Tensa el arco bajo el agua con tanta calma que la flecha ya sabe dónde va a clavarse antes de que la cuerda termine de soltarse.",
       "anio": 2025,
@@ -10519,7 +10457,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-31b29143-0",
       "serie": "archivo",
-      "orden": 341,
+      "orden": 339,
       "estado": "publicada",
       "concepto": "Las puntas amarillas de las lanzas flotan tan quietas junto a los cuerpos que la corriente lleva media hora sin decidirse a moverlas un centímetro.",
       "anio": 2025,
@@ -10550,7 +10488,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-3a996db7-2",
       "serie": "archivo",
-      "orden": 342,
+      "orden": 340,
       "estado": "publicada",
       "concepto": "El arrecife de abajo lleva tantas formas talladas por el agua que ya parece guardar la cuenta exacta de cada cuerpo que ha flotado sobre él.",
       "anio": 2025,
@@ -10581,7 +10519,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-4eb2ce92-2",
       "serie": "archivo",
-      "orden": 343,
+      "orden": 341,
       "estado": "publicada",
       "concepto": "Las plumas que llevan en el cabello rozan la superficie del agua sin mojarse nunca del todo, aunque las olas alrededor no dejen de moverse.",
       "anio": 2025,
@@ -10612,7 +10550,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-4eb2ce92-3",
       "serie": "archivo",
-      "orden": 344,
+      "orden": 342,
       "estado": "publicada",
       "concepto": "Levantan tantos brazos al mismo tiempo desde el fondo rocoso que parecen empujar el agua entera hacia arriba, mientras las lanzas quedan clavadas atrás como una valla.",
       "anio": 2025,
@@ -10643,7 +10581,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-a3c44b74-1",
       "serie": "archivo",
-      "orden": 345,
+      "orden": 343,
       "estado": "publicada",
       "concepto": "Siete cuerpos color brasa flotan bocarriba sin mover un dedo, y las flechas que cargan llevan tres mareas completas esperando el primer tirón de cuerda.",
       "anio": 2025,
@@ -10674,7 +10612,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-aa613638-0",
       "serie": "archivo",
-      "orden": 346,
+      "orden": 344,
       "estado": "publicada",
       "concepto": "La sombra en cruz abre los brazos y las piernas hasta tocar los cuatro bordes del encuadre, y tarda seis mareas en llegar al fondo verde aunque nadie la empuje.",
       "anio": 2025,
@@ -10705,7 +10643,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-aa613638-1",
       "serie": "archivo",
-      "orden": 347,
+      "orden": 345,
       "estado": "publicada",
       "concepto": "Cuatro lanzas se alzan derechas justo sobre la línea de arena, y los cuerpos color naranja caen tres brazadas más abajo antes de tocar el mosaico azul del fondo.",
       "anio": 2025,
@@ -10736,7 +10674,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-1",
       "serie": "archivo",
-      "orden": 348,
+      "orden": 346,
       "estado": "publicada",
       "concepto": "El arco y las flechas trazan una equis exacta sobre el agua, y los seis cuerpos que la sostienen no la sueltan aunque lleven cuatro horas flotando en la misma corriente.",
       "anio": 2025,
@@ -10767,7 +10705,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-2",
       "serie": "archivo",
-      "orden": 349,
+      "orden": 347,
       "estado": "publicada",
       "concepto": "El cuerpo cae de cabeza con las piernas apuntando al cielo, y tarda cinco brazadas en decidir si termina la vuelta o se queda a medio camino para siempre.",
       "anio": 2025,
@@ -10798,7 +10736,7 @@
     {
       "slug": "grim-shot-arrows-and-bows-floating-underwater-ne-f048c9b8-3",
       "serie": "archivo",
-      "orden": 350,
+      "orden": 348,
       "estado": "publicada",
       "concepto": "La sombra oscura se pega al fondo rayado de verde y avanza un metro entero por cada cuerpo rojo que pasa flotando encima sin advertirla.",
       "anio": 2025,
@@ -10829,7 +10767,7 @@
     {
       "slug": "grungy-analog-photo-of-man-playing-call-of-bac3420e-0",
       "serie": "archivo",
-      "orden": 351,
+      "orden": 349,
       "estado": "publicada",
       "concepto": "Voltea la cabeza sin soltar el mando, y dentro del televisor la guerra sigue disparando sola durante los cuatro segundos exactos que dura la mirada.",
       "anio": 2025,
@@ -10860,7 +10798,7 @@
     {
       "slug": "gzlv4dp1s-panoramic-view-of-a-city-of-stilt-8f551616-1",
       "serie": "archivo",
-      "orden": 352,
+      "orden": 350,
       "estado": "publicada",
       "concepto": "Los pilotes de las casas se clavan derechos en el fondo turquesa, y los tres hombres de short naranja cruzan por debajo sin que el agua les suba nunca más allá de la rodilla.",
       "anio": 2025,
@@ -10891,7 +10829,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-5856b9f0-0",
       "serie": "archivo",
-      "orden": 353,
+      "orden": 351,
       "estado": "publicada",
       "concepto": "El velo azul le cubre toda la cara salvo los ojos, y las vueltas de collar dorado que lleva puestas pesan más que la carga de los dos camellos que lo flanquean.",
       "anio": 2025,
@@ -10922,7 +10860,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-5856b9f0-2",
       "serie": "archivo",
-      "orden": 354,
+      "orden": 352,
       "estado": "publicada",
       "concepto": "Dos jinetes envueltos hasta los ojos cruzan la duna montados en camellos cargados de cadenas y borlas, y ninguno afloja las riendas aunque lleven media jornada sin ver un pozo.",
       "anio": 2025,
@@ -10953,7 +10891,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-5cf798de-0",
       "serie": "archivo",
-      "orden": 355,
+      "orden": 353,
       "estado": "publicada",
       "concepto": "Cada jinete sostiene sobre las piernas una caja de madera tallada con las cuerdas tensas, y los camellos se quedan clavados en la arena para no desafinar ni una nota.",
       "anio": 2025,
@@ -10984,7 +10922,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-5cf798de-2",
       "serie": "archivo",
-      "orden": 356,
+      "orden": 354,
       "estado": "publicada",
       "concepto": "Entre los dos jinetes se asoma una tercera figura envuelta en blanco que sostiene en alto un bastón coronado de metal, y ningún camello vuelve la cabeza aunque la sombra le roce la oreja.",
       "anio": 2025,
@@ -11015,7 +10953,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-5cf798de-3",
       "serie": "archivo",
-      "orden": 357,
+      "orden": 355,
       "estado": "publicada",
       "concepto": "Sobre las cabezas cubiertas cuelga una luna del tamaño de una moneda, y el jinete de verde oscuro sostiene un bastón dorado tan derecho que parece sujetarla él solo desde abajo.",
       "anio": 2025,
@@ -11046,7 +10984,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-0",
       "serie": "archivo",
-      "orden": 358,
+      "orden": 356,
       "estado": "publicada",
       "concepto": "El jinete del centro lleva tantas vueltas de oro al cuello que el camello acorta el paso, mientras los dos que lo escoltan de blanco brillan recién salidos del telar.",
       "anio": 2025,
@@ -11077,7 +11015,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-1",
       "serie": "archivo",
-      "orden": 359,
+      "orden": 357,
       "estado": "publicada",
       "concepto": "El velo añil les ha teñido la piel del mismo azul después de tantos años de roce, y ya no se sabe si el color se lo puso la tela o el desierto.",
       "anio": 2025,
@@ -11108,7 +11046,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-c9f684b5-3",
       "serie": "archivo",
-      "orden": 360,
+      "orden": 358,
       "estado": "publicada",
       "concepto": "La caravana avanza en fila sobre el filo exacto de la duna, y las sombras que proyecta cada camello son tan largas que llegan al valle antes que ellos.",
       "anio": 2025,
@@ -11139,7 +11077,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-0",
       "serie": "archivo",
-      "orden": 361,
+      "orden": 359,
       "estado": "publicada",
       "concepto": "La luna llena cuelga exacta sobre las tres cabezas cubiertas, y el que viste de turquesa no suelta la guitarra ni cuando el camello se acomoda entero bajo su peso.",
       "anio": 2025,
@@ -11170,7 +11108,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-1",
       "serie": "archivo",
-      "orden": 362,
+      "orden": 360,
       "estado": "publicada",
       "concepto": "El jinete del centro sostiene un jarro de metal labrado que parece gotear luz en vez de agua, y los otros dos no apartan la vista aunque lleven toda la noche mirándolo brillar.",
       "anio": 2025,
@@ -11201,7 +11139,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-dd8239fa-3",
       "serie": "archivo",
-      "orden": 363,
+      "orden": 361,
       "estado": "publicada",
       "concepto": "El camello del centro carga tantas hileras de cuentas al cuello que el jinete apenas necesita sujetar la caja de madera tallada que lleva sobre las piernas.",
       "anio": 2025,
@@ -11232,7 +11170,7 @@
     {
       "slug": "hgpo2myyw-httpss-mj-r-ef8cb3eb-1",
       "serie": "archivo",
-      "orden": 364,
+      "orden": 362,
       "estado": "publicada",
       "concepto": "El cielo se corta en un rectángulo exacto sobre las dunas, como si alguien lo hubiera pegado encima de la arena, y a los pies de los camellos queda tendido un laúd que nadie recoge.",
       "anio": 2025,
@@ -11263,7 +11201,7 @@
     {
       "slug": "high-heel-over-the-knee-boots-with-platform-1b8b6a94-0",
       "serie": "archivo",
-      "orden": 365,
+      "orden": 363,
       "estado": "publicada",
       "concepto": "El brazo derecho se pliega en placas de metal como una armadura de bisagras, y las botas de charol suben tan por encima de la rodilla que rozan el dobladillo de la camiseta.",
       "anio": 2025,
@@ -11293,7 +11231,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-34f26cb7-2",
       "serie": "archivo",
-      "orden": 366,
+      "orden": 364,
       "estado": "publicada",
       "concepto": "De pie detrás, las manos ajustan hebra por hebra un peinado que no existe todavía, frente a un valle entero cubierto por la misma neblina azul que los tiñe a los dos.",
       "anio": 2025,
@@ -11324,7 +11262,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-56bdc61e-1",
       "serie": "archivo",
-      "orden": 367,
+      "orden": 365,
       "estado": "publicada",
       "concepto": "La mano articulada del robot sostiene la barbilla del hombre como si calibrara cada arruga, y el rostro azul que lo mira no parpadea desde que se apagaron las luces de la ciudad de abajo.",
       "anio": 2025,
@@ -11355,7 +11293,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-5a953274-0",
       "serie": "archivo",
-      "orden": 368,
+      "orden": 366,
       "estado": "publicada",
       "concepto": "El anciano lo mira desde la camilla sin apartar los ojos del casco espejado, y en el reflejo del vidrio caben las montañas enteras que se ven por la ventana detrás de los dos.",
       "anio": 2025,
@@ -11386,7 +11324,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-64e69518-1",
       "serie": "archivo",
-      "orden": 369,
+      "orden": 367,
       "estado": "publicada",
       "concepto": "La corona de oro parece soldada al cráneo de metal desde hace siglos, y la mano se posa suave en la mejilla de la anciana sin que los ojos rojos dejen de mirar fijo.",
       "anio": 2025,
@@ -11417,7 +11355,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-725932c9-0",
       "serie": "archivo",
-      "orden": 370,
+      "orden": 368,
       "estado": "publicada",
       "concepto": "El ojo azul del cirujano parpadea una sola vez y cuenta, sin prisa, los ciento diez años que le quedan al hombre que tiene debajo.",
       "anio": 2025,
@@ -11448,7 +11386,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-725932c9-1",
       "serie": "archivo",
-      "orden": 371,
+      "orden": 369,
       "estado": "publicada",
       "concepto": "Le conectan un solo cable a la nuca y el robot blanco memoriza, en ese instante, cada nube que cubre la Tierra a través de la cúpula.",
       "anio": 2025,
@@ -11479,7 +11417,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-7dbf7e10-3",
       "serie": "archivo",
-      "orden": 372,
+      "orden": 370,
       "estado": "publicada",
       "concepto": "Apoya dos dedos azules y dorados en la sien del anciano, y basta ese roce para que las luces de la ciudad, abajo, se enciendan todas a la vez.",
       "anio": 2025,
@@ -11510,7 +11448,7 @@
     {
       "slug": "high-tech-operating-room-a-cyborg-doctor-is-923a241c-1",
       "serie": "archivo",
-      "orden": 373,
+      "orden": 371,
       "estado": "publicada",
       "concepto": "Los cables le entran por la nuca de hueso y el copiloto de cráneo descubierto no aparta la vista del desierto que corre, quieto, bajo la cabina.",
       "anio": 2025,
@@ -11541,7 +11479,7 @@
     {
       "slug": "high-tech-operating-room-the-doctor-inserts-a-b52724d8-3",
       "serie": "archivo",
-      "orden": 374,
+      "orden": 372,
       "estado": "publicada",
       "concepto": "Detrás de ellos el muro entero se llena de columnas de números rojos, y ninguno de los dos gira la cabeza para leer los dígitos que ya lleva memorizados de nacimiento.",
       "anio": 2025,
@@ -11572,7 +11510,7 @@
     {
       "slug": "httpss-mj-r-16baf748-0",
       "serie": "archivo",
-      "orden": 375,
+      "orden": 373,
       "estado": "publicada",
       "concepto": "Cuarenta techos de paja se paran sobre el agua turquesa sin mojarse un solo día del año, y el cielo se pinta de verde solo para hacerles compañía.",
       "anio": 2025,
@@ -11603,7 +11541,7 @@
     {
       "slug": "httpss-mj-r-1f4f0793-0",
       "serie": "archivo",
-      "orden": 376,
+      "orden": 374,
       "estado": "publicada",
       "concepto": "El agua devuelve cada techo de paja al revés con tanta exactitud que quien cruza de noche ya no sabe cuál de las dos mitades está pisando.",
       "anio": 2025,
@@ -11634,7 +11572,7 @@
     {
       "slug": "httpss-mj-r-1f8924b6-1",
       "serie": "archivo",
-      "orden": 377,
+      "orden": 375,
       "estado": "publicada",
       "concepto": "Lleva dos aros de oro cruzados en el tabique y tantos anillos de metal apilados en el cuello que ninguna brisa del Caribe logra moverle ni un solo mechón.",
       "anio": 2025,
@@ -11664,7 +11602,7 @@
     {
       "slug": "httpss-mj-r-1f8924b6-2",
       "serie": "archivo",
-      "orden": 378,
+      "orden": 376,
       "estado": "publicada",
       "concepto": "El collar le suma tantas conchas de mar y cuentas de vidrio al cuello que el peso entero de la orilla parece haberse mudado ahí, capa sobre capa.",
       "anio": 2025,
@@ -11694,7 +11632,7 @@
     {
       "slug": "httpss-mj-r-1f8924b6-3",
       "serie": "archivo",
-      "orden": 379,
+      "orden": 377,
       "estado": "publicada",
       "concepto": "Le sembraron puntos rojos por toda la cara, uno por uno, hasta cubrirle las mejillas de una constelación entera que ningún cielo del Caribe llegó a tener.",
       "anio": 2025,
@@ -11724,7 +11662,7 @@
     {
       "slug": "httpss-mj-r-1fd50f6c-1",
       "serie": "archivo",
-      "orden": 380,
+      "orden": 378,
       "estado": "publicada",
       "concepto": "Por el canal central pasan tantas balsas cargadas de gente esa noche que el agua entera del pueblo se pone a flotar en vez de correr.",
       "anio": 2025,
@@ -11755,7 +11693,7 @@
     {
       "slug": "httpss-mj-r-1fd50f6c-3",
       "serie": "archivo",
-      "orden": 381,
+      "orden": 379,
       "estado": "publicada",
       "concepto": "Mira de frente aunque tenga el pueblo entero de techos cónicos desplegado a la espalda, y ni un tejado se le refleja en los ojos por más que la luna azul insista.",
       "anio": 2025,
@@ -11786,7 +11724,7 @@
     {
       "slug": "httpss-mj-r-26a96291-0",
       "serie": "archivo",
-      "orden": 382,
+      "orden": 380,
       "estado": "publicada",
       "concepto": "El visor de placa verde le cubre los ojos con tantos cables soldados que ya no necesita parpadear para saber qué hora es en cualquier parte del mundo.",
       "anio": 2025,
@@ -11817,7 +11755,7 @@
     {
       "slug": "httpss-mj-r-26a96291-1",
       "serie": "archivo",
-      "orden": 383,
+      "orden": 381,
       "estado": "publicada",
       "concepto": "Cosieron cuenta a cuenta el casco verde que lleva, y ni girando la cabeza hacia la sombra pierde el brillo dorado del uniforme.",
       "anio": 2025,
@@ -11848,7 +11786,7 @@
     {
       "slug": "httpss-mj-r-2d12c98d-3",
       "serie": "archivo",
-      "orden": 384,
+      "orden": 382,
       "estado": "publicada",
       "concepto": "Las rayas rojas le cruzan la cara de lado a lado y aun así sonríe apenas, como si llevara pintadas encima todas las tardes que ha visto el sol caer sobre el golfo.",
       "anio": 2025,
@@ -11878,7 +11816,7 @@
     {
       "slug": "httpss-mj-r-3b4bc54d-0",
       "serie": "archivo",
-      "orden": 385,
+      "orden": 383,
       "estado": "publicada",
       "concepto": "Desde la loma más alta se ve arder una sola nube dorada tan despacio que el pueblo entero, abajo, alcanza a terminar el mercado antes de que se apague.",
       "anio": 2025,
@@ -11909,7 +11847,7 @@
     {
       "slug": "httpss-mj-r-3b4bc54d-2",
       "serie": "archivo",
-      "orden": 386,
+      "orden": 384,
       "estado": "publicada",
       "concepto": "Se detiene entre las flores blancas con la túnica naranja tan quieta que el río, al copiarla, tarda toda la noche en decidirse a moverse.",
       "anio": 2025,
@@ -11940,7 +11878,7 @@
     {
       "slug": "httpss-mj-r-3b4bc54d-3",
       "serie": "archivo",
-      "orden": 387,
+      "orden": 385,
       "estado": "publicada",
       "concepto": "El techo cónico se levanta tan alto sobre el agua verde que las canoas de abajo parecen juguetes olvidados junto a la puerta.",
       "anio": 2025,
@@ -11971,7 +11909,7 @@
     {
       "slug": "httpss-mj-r-43f24e50-1",
       "serie": "archivo",
-      "orden": 388,
+      "orden": 386,
       "estado": "publicada",
       "concepto": "Bajan la escalera de madera despacio, y el único pájaro que cruza el cielo esa tarde alcanza a contarles cada peldaño antes de perderse entre los techos de paja.",
       "anio": 2025,
@@ -12002,7 +11940,7 @@
     {
       "slug": "httpss-mj-r-43f24e50-2",
       "serie": "archivo",
-      "orden": 389,
+      "orden": 387,
       "estado": "publicada",
       "concepto": "Se paran sobre las ramas más altas del acantilado y desde ahí llevan la cuenta exacta de las canoas que entran al pueblo antes de que oscurezca del todo.",
       "anio": 2025,
@@ -12033,7 +11971,7 @@
     {
       "slug": "httpss-mj-r-43f24e50-3",
       "serie": "archivo",
-      "orden": 390,
+      "orden": 388,
       "estado": "publicada",
       "concepto": "Se reúnen en las plataformas de madera a ambos lados del canal justo cuando el agua se pone dorada, y nadie se mueve hasta que el color entero se apaga.",
       "anio": 2025,
@@ -12064,7 +12002,7 @@
     {
       "slug": "httpss-mj-r-4be9a7f3-0",
       "serie": "archivo",
-      "orden": 391,
+      "orden": 389,
       "estado": "publicada",
       "concepto": "El código le cubre la cara entera, línea por línea, hasta que ya no queda un centímetro de piel sin una cifra corriendo encima.",
       "anio": 2025,
@@ -12095,7 +12033,7 @@
     {
       "slug": "httpss-mj-r-4be9a7f3-3",
       "serie": "archivo",
-      "orden": 392,
+      "orden": 390,
       "estado": "publicada",
       "concepto": "Le baja el código azul por la cara en hileras tan largas que parece llorar cifras enteras desde antes de nacer.",
       "anio": 2025,
@@ -12126,7 +12064,7 @@
     {
       "slug": "httpss-mj-r-4c015cd6-0",
       "serie": "archivo",
-      "orden": 393,
+      "orden": 391,
       "estado": "publicada",
       "concepto": "El símbolo de la frente se repite después en el aro de la nariz y en cada anillo del cuello, como si un solo dibujo hubiera decidido cubrirle el cuerpo entero.",
       "anio": 2025,
@@ -12156,7 +12094,7 @@
     {
       "slug": "httpss-mj-r-4c015cd6-2",
       "serie": "archivo",
-      "orden": 394,
+      "orden": 392,
       "estado": "publicada",
       "concepto": "El adorno de oro en forma de ave le cuelga de la nariz tan quieto que parece llevar posado ahí desde el primer amanecer del golfo.",
       "anio": 2025,
@@ -12186,7 +12124,7 @@
     {
       "slug": "httpss-mj-r-4c015cd6-3",
       "serie": "archivo",
-      "orden": 395,
+      "orden": 393,
       "estado": "publicada",
       "concepto": "Cinco vueltas de hueso le rodean el cuello, pesadas como si cargaran solas la historia entera de la aldea, y el nudo de conchas del centro nunca roza el suelo aunque ella incline la cabeza.",
       "anio": 2025,
@@ -12216,7 +12154,7 @@
     {
       "slug": "httpss-mj-r-551e89c3-0",
       "serie": "archivo",
-      "orden": 396,
+      "orden": 394,
       "estado": "publicada",
       "concepto": "Golpea el cuero del tambor con las manos tan rápido que la foto solo logra pintarlas de niebla, y el mar detrás se queda quieto para no llevarse el compás.",
       "anio": 2025,
@@ -12247,7 +12185,7 @@
     {
       "slug": "httpss-mj-r-6a1ad429-0",
       "serie": "archivo",
-      "orden": 397,
+      "orden": 395,
       "estado": "publicada",
       "concepto": "En las mejillas le arden dos soles pequeños, tan fijos que el techo de paja de atrás solo se atreve a dorarse cuando ella gira la cara hacia la puerta.",
       "anio": 2025,
@@ -12277,7 +12215,7 @@
     {
       "slug": "httpss-mj-r-6a1ad429-1",
       "serie": "archivo",
-      "orden": 398,
+      "orden": 396,
       "estado": "publicada",
       "concepto": "Las cuentas azules le trepan el cuello anillo tras anillo, y ya van tantas vueltas que una más y le tocaría la barbilla.",
       "anio": 2025,
@@ -12307,7 +12245,7 @@
     {
       "slug": "httpss-mj-r-7d86befe-0",
       "serie": "archivo",
-      "orden": 399,
+      "orden": 397,
       "estado": "publicada",
       "concepto": "Le cubre la cara el código, línea por línea, y ya son tantas que solo los ojos azules quedan afuera del programa.",
       "anio": 2025,
@@ -12338,7 +12276,7 @@
     {
       "slug": "httpss-mj-r-7f39f421-3",
       "serie": "archivo",
-      "orden": 400,
+      "orden": 398,
       "estado": "publicada",
       "concepto": "Detrás de él el cielo se enrosca en un remolino azul y dorado tan cerrado que parece que el tambor lo estuviera hilando con cada golpe.",
       "anio": 2025,
@@ -12369,7 +12307,7 @@
     {
       "slug": "httpss-mj-r-8fd2b300-0",
       "serie": "archivo",
-      "orden": 401,
+      "orden": 399,
       "estado": "publicada",
       "concepto": "Las casas se paran sobre el agua en una sola pata de madera cada una, y la choza naranja del centro guarda el último sol del día para prestárselo a la luna.",
       "anio": 2025,
@@ -12400,7 +12338,7 @@
     {
       "slug": "httpss-mj-r-a03a000f-0",
       "serie": "archivo",
-      "orden": 402,
+      "orden": 400,
       "estado": "publicada",
       "concepto": "Tanto se afilan en punta los techos de paja que parecen contar, uno por uno, cada canoa que cruza despacio entre las casas hasta la última luz verde del cielo.",
       "anio": 2025,
@@ -12431,7 +12369,7 @@
     {
       "slug": "httpss-mj-r-b55e571f-3",
       "serie": "archivo",
-      "orden": 403,
+      "orden": 401,
       "estado": "publicada",
       "concepto": "Levanta la lanza tan alto sobre el caballo blanco que el galope entero parece sostenerse solo para no hacerla temblar.",
       "anio": 2025,
@@ -12462,7 +12400,7 @@
     {
       "slug": "httpss-mj-r-baf42107-0",
       "serie": "archivo",
-      "orden": 404,
+      "orden": 402,
       "estado": "publicada",
       "concepto": "Las espirales pintadas le nacen en la cara y no se detienen ahí: le bajan por el cuello y el pecho como si seis vueltas de collar no alcanzaran para pararlas.",
       "anio": 2025,
@@ -12492,7 +12430,7 @@
     {
       "slug": "httpss-mj-r-baf42107-1",
       "serie": "archivo",
-      "orden": 405,
+      "orden": 403,
       "estado": "publicada",
       "concepto": "Le cubre la nariz entera un adorno dorado, y dos aros más cuelgan debajo, uno dentro del otro, como si la nariz necesitara tres anuncios distintos de que ahí empieza la cara.",
       "anio": 2025,
@@ -12522,7 +12460,7 @@
     {
       "slug": "httpss-mj-r-baf42107-2",
       "serie": "archivo",
-      "orden": 406,
+      "orden": 404,
       "estado": "publicada",
       "concepto": "Sobre toda la cara le tienden una red de pintura roja tan cerrada que no queda piel sin cruzar, y el aro dorado de la nariz es la única línea recta de todo el dibujo.",
       "anio": 2025,
@@ -12552,7 +12490,7 @@
     {
       "slug": "httpss-mj-r-cc768606-1",
       "serie": "archivo",
-      "orden": 407,
+      "orden": 405,
       "estado": "publicada",
       "concepto": "Diez veces cabría la persona que camina al frente dentro de un solo techo de paja, y el pueblo entero se acomoda a la sombra de tres puntas.",
       "anio": 2025,
@@ -12583,7 +12521,7 @@
     {
       "slug": "httpss-mj-r-f4a20894-0",
       "serie": "archivo",
-      "orden": 408,
+      "orden": 406,
       "estado": "publicada",
       "concepto": "El cerro baja tan despacio hasta el agua que las últimas chozas ya no distinguen la tierra del río, y las dos personas de rojo en la orilla vigilan la frontera.",
       "anio": 2025,
@@ -12614,7 +12552,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-057075f5-0",
       "serie": "archivo",
-      "orden": 409,
+      "orden": 407,
       "estado": "publicada",
       "concepto": "Las rayas del fondo se le enroscan alrededor como olas paradas en el aire, y él las mira tan fijo que ninguna se atreve a moverse.",
       "anio": 2025,
@@ -12645,7 +12583,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-237116cf-1",
       "serie": "archivo",
-      "orden": 410,
+      "orden": 408,
       "estado": "publicada",
       "concepto": "Le cae por el hombro el bordado dorado de la bufanda, con tantas vueltas que cualquiera diría que ahí guarda todo el oro que nunca mostró en la cara.",
       "anio": 2025,
@@ -12676,7 +12614,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-59616bc8-3",
       "serie": "archivo",
-      "orden": 411,
+      "orden": 409,
       "estado": "publicada",
       "concepto": "Toda la luz del cuadro se le escapó a una esquina de arriba, y a él no le hizo falta ni un rayo para que los ojos igual quemaran.",
       "anio": 2025,
@@ -12707,7 +12645,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-780fcb70-1",
       "serie": "archivo",
-      "orden": 412,
+      "orden": 410,
       "estado": "publicada",
       "concepto": "Justo detrás de la cabeza le crece un triángulo verde, tan puntiagudo que parece una montaña que decidió asomarse solo para él.",
       "anio": 2025,
@@ -12738,7 +12676,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-780fcb70-2",
       "serie": "archivo",
-      "orden": 413,
+      "orden": 411,
       "estado": "publicada",
       "concepto": "El fondo se queda tan en blanco que el azul del abrigo tiene que sostener solo todo el color de la escena.",
       "anio": 2025,
@@ -12769,7 +12707,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-84c04a57-2",
       "serie": "archivo",
-      "orden": 414,
+      "orden": 412,
       "estado": "publicada",
       "concepto": "Ni un color cálido sobrevive en ese fondo pálido y helado, así que la mirada oscura tiene que cargar sola con toda la temperatura del cuadro.",
       "anio": 2025,
@@ -12800,7 +12738,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-8a539940-3",
       "serie": "archivo",
-      "orden": 415,
+      "orden": 413,
       "estado": "publicada",
       "concepto": "Tiene las manos tan apretadas frente al pecho que el barco del fondo ya se rindió a esperar y sigue navegando solo, chiquito, contra el cielo dorado.",
       "anio": 2025,
@@ -12831,7 +12769,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-a0e6e495-1",
       "serie": "archivo",
-      "orden": 416,
+      "orden": 414,
       "estado": "publicada",
       "concepto": "Las ojeras se le hunden tanto que parecen llevar sin dormir todo el tiempo que el pincel tardó en pintar cada una de esas rayas blancas del fondo.",
       "anio": 2025,
@@ -12862,7 +12800,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-b9ab3891-0",
       "serie": "archivo",
-      "orden": 417,
+      "orden": 415,
       "estado": "publicada",
       "concepto": "Contra el pecho esconde un papel doblado, tan pequeño y tan blanco que es lo único del cuadro que el mar azul no logra teñir.",
       "anio": 2025,
@@ -12893,7 +12831,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-ba586301-0",
       "serie": "archivo",
-      "orden": 418,
+      "orden": 416,
       "estado": "publicada",
       "concepto": "Dos espadas cruzadas le cuelgan a la espalda, y ninguna mano busca la empuñadura, como si la sola mirada bastara para que nadie se atreviera a probar cuál desenvaina primero.",
       "anio": 2025,
@@ -12924,7 +12862,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-ba586301-3",
       "serie": "archivo",
-      "orden": 419,
+      "orden": 417,
       "estado": "publicada",
       "concepto": "Sostiene el palo de madera con el puño tan cerrado que el botón dorado del pecho es lo único de todo el cuadro que se permite brillar.",
       "anio": 2025,
@@ -12955,7 +12893,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-ca5f5381-0",
       "serie": "archivo",
-      "orden": 420,
+      "orden": 418,
       "estado": "publicada",
       "concepto": "La correa le cruza el pecho tan ceñida que el triángulo de luz violeta que se abre detrás no encuentra otro hueco por donde colarse.",
       "anio": 2025,
@@ -12986,7 +12924,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-e1a2747f-3",
       "serie": "archivo",
-      "orden": 421,
+      "orden": 419,
       "estado": "publicada",
       "concepto": "Sostiene una pluma tan delgada entre los dedos que basta con que la deje quieta un segundo para que el barco entero, a su espalda, se detenga a esperarla.",
       "anio": 2025,
@@ -13017,7 +12955,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-d-fc9c8ad9-2",
       "serie": "archivo",
-      "orden": 422,
+      "orden": 420,
       "estado": "publicada",
       "concepto": "El ceño se le hunde tan hondo entre las cejas que raja en dos mitades exactas el azul liso del fondo, sin dejar ni una costura visible.",
       "anio": 2025,
@@ -13048,7 +12986,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-22a985ea-2",
       "serie": "archivo",
-      "orden": 423,
+      "orden": 421,
       "estado": "publicada",
       "concepto": "A la altura exacta del cuello le corta el horizonte el retrato en dos: arriba, la arena entera del cielo; abajo, el mar cabe en un dedo de franja.",
       "anio": 2025,
@@ -13079,7 +13017,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-22a985ea-3",
       "serie": "archivo",
-      "orden": 424,
+      "orden": 422,
       "estado": "publicada",
       "concepto": "Le quitaron el mar de detrás y solo dejaron la luz color arena, así que ahora el único horizonte que queda en el cuadro es la línea recta de su ceño.",
       "anio": 2025,
@@ -13110,7 +13048,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-26bb487d-3",
       "serie": "archivo",
-      "orden": 425,
+      "orden": 423,
       "estado": "publicada",
       "concepto": "El cielo se le parte justo detrás de la cabeza: a la izquierda cae la noche entera, a la derecha todavía queda oro suficiente para no apagarle el mar.",
       "anio": 2025,
@@ -13141,7 +13079,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-35560008-0",
       "serie": "archivo",
-      "orden": 426,
+      "orden": 424,
       "estado": "publicada",
       "concepto": "La sombra le come media cara con tanta hambre que solo deja libres un ojo, el bigote y el cuello blanco de la camisa, y ni así queda satisfecha.",
       "anio": 2025,
@@ -13172,7 +13110,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-4450a4b7-0",
       "serie": "archivo",
-      "orden": 427,
+      "orden": 425,
       "estado": "publicada",
       "concepto": "Lleva una mancha oscura en el pómulo que ninguna tormenta ha logrado lavarle, ni esta agua verde que se le enrosca detrás como si quisiera tragarse el mástil entero.",
       "anio": 2025,
@@ -13203,7 +13141,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-4450a4b7-1",
       "serie": "archivo",
-      "orden": 428,
+      "orden": 426,
       "estado": "publicada",
       "concepto": "Se planta justo en medio de dos barcos que navegan en direcciones contrarias, y ninguno de los dos consigue moverle ni un grado la mirada.",
       "anio": 2025,
@@ -13234,7 +13172,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-455b8ad3-0",
       "serie": "archivo",
-      "orden": 429,
+      "orden": 427,
       "estado": "publicada",
       "concepto": "Un arcoíris entero decide cruzarle la cara justo cuando el velero de mástiles dorados pasa detrás, y no hay quien lo convenza de moverse antes de que termine de pasar.",
       "anio": 2025,
@@ -13265,7 +13203,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-4bd650fe-2",
       "serie": "archivo",
-      "orden": 430,
+      "orden": 428,
       "estado": "publicada",
       "concepto": "Un palo de madera le cruza tan exacto detrás de la nuca que parece sostenerle la cabeza en su sitio mientras el mar gris se mueve solo.",
       "anio": 2025,
@@ -13296,7 +13234,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-5349d98a-2",
       "serie": "archivo",
-      "orden": 431,
+      "orden": 429,
       "estado": "publicada",
       "concepto": "Carga a la espalda un edificio entero de arcos de piedra y techo de teja, y aun así el ceño le pesa más que toda la construcción.",
       "anio": 2025,
@@ -13327,7 +13265,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-5349d98a-3",
       "serie": "archivo",
-      "orden": 432,
+      "orden": 430,
       "estado": "publicada",
       "concepto": "La luz dorada le cae tan pareja sobre la cara y el mar que ya no se distingue dónde termina su piel y dónde empieza el agua.",
       "anio": 2025,
@@ -13358,7 +13296,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-5a509ab8-2",
       "serie": "archivo",
-      "orden": 433,
+      "orden": 431,
       "estado": "publicada",
       "concepto": "Junta las manos y le nace fuego entre los dedos, tan vivo que los dientes apretados le brillan del mismo naranja antes de que el viento azul de atrás se lo lleve.",
       "anio": 2025,
@@ -13389,7 +13327,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-70810425-1",
       "serie": "archivo",
-      "orden": 434,
+      "orden": 432,
       "estado": "publicada",
       "concepto": "Se anuda un pañuelo oscuro en la cabeza y, detrás, tan chiquito que cabe bajo su propia ceja, navega un bote que tarda un siglo en cruzar el atardecer morado.",
       "anio": 2025,
@@ -13420,7 +13358,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-799e10c0-0",
       "serie": "archivo",
-      "orden": 435,
+      "orden": 433,
       "estado": "publicada",
       "concepto": "La luz le reparte la cara en dos climas exactos: un lado tibio como si aún fuera tarde, el otro ya frío como si el mar de atrás le hubiera adelantado la noche.",
       "anio": 2025,
@@ -13451,7 +13389,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-799e10c0-3",
       "serie": "archivo",
-      "orden": 436,
+      "orden": 434,
       "estado": "publicada",
       "concepto": "El azul del atardecer le gana tanto terreno a la piel que ya no se distingue si el mar se le pega a la cara o si la cara se derrama sobre el mar.",
       "anio": 2025,
@@ -13482,7 +13420,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-87322e48-0",
       "serie": "archivo",
-      "orden": 437,
+      "orden": 435,
       "estado": "publicada",
       "concepto": "Levanta los ojos hacia un punto que solo él parece ver, mientras la pared de piedra gris de atrás se le cierra sobre los hombros como si quisiera detenerle el gesto.",
       "anio": 2025,
@@ -13513,7 +13451,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-87d936de-2",
       "serie": "archivo",
-      "orden": 438,
+      "orden": 436,
       "estado": "publicada",
       "concepto": "Los ojos le brillan de un blanco pálido justo cuando el cielo verde se apaga en una sola línea naranja al fondo, como si la última luz del día se le hubiera escondido ahí.",
       "anio": 2025,
@@ -13544,7 +13482,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-a836637d-1",
       "serie": "archivo",
-      "orden": 439,
+      "orden": 437,
       "estado": "publicada",
       "concepto": "El cielo se despeja entero y el mar se pone azul de postal, pero ni un solo rayo de sol le afloja el ceño fruncido.",
       "anio": 2025,
@@ -13575,7 +13513,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-ad8cc8ed-1",
       "serie": "archivo",
-      "orden": 440,
+      "orden": 438,
       "estado": "publicada",
       "concepto": "La chaqueta le suma tantos botones de metal en fila que, cuando el sol pega, parecen un collar entero de monedas, mientras la roca de la costa se queda callada detrás.",
       "anio": 2025,
@@ -13606,7 +13544,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-af5396cf-2",
       "serie": "archivo",
-      "orden": 441,
+      "orden": 439,
       "estado": "publicada",
       "concepto": "Detrás, el cielo entero se le incendia de naranja hasta el borde del mar, y ni el reflejo del fuego le alcanza para entibiarle la cara azul.",
       "anio": 2025,
@@ -13637,7 +13575,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-c22eec5e-2",
       "serie": "archivo",
-      "orden": 442,
+      "orden": 440,
       "estado": "publicada",
       "concepto": "Un solo foco le cae desde arriba y apenas le rescata la cara y la correa cruzada al pecho; todo lo demás se lo traga la oscuridad del fondo.",
       "anio": 2025,
@@ -13668,7 +13606,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-c4167ca9-0",
       "serie": "archivo",
-      "orden": 443,
+      "orden": 441,
       "estado": "publicada",
       "concepto": "El mismo hombre se multiplica tres veces en el mismo azul verdoso: de perfil, de cuerpo entero y de cerca, como si no lograra decidir en cuál instante quedarse.",
       "anio": 2025,
@@ -13699,7 +13637,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-c4b6cc2e-3",
       "serie": "archivo",
-      "orden": 444,
+      "orden": 442,
       "estado": "publicada",
       "concepto": "Apoya el codo y deja la mano flotando cerca de la barbilla, mientras la cortina blanca de atrás cuelga tan quieta que parece llevar toda la función esperándolo.",
       "anio": 2025,
@@ -13730,7 +13668,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-cdf3f12b-3",
       "serie": "archivo",
-      "orden": 445,
+      "orden": 443,
       "estado": "publicada",
       "concepto": "Frunce el ceño con tanta fuerza que la arruga central le divide la frente en dos mitades que ya no vuelven a encontrarse, ni siquiera cuando gira la cara hacia la sombra.",
       "anio": 2025,
@@ -13761,7 +13699,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-cf88fee8-1",
       "serie": "archivo",
-      "orden": 446,
+      "orden": 444,
       "estado": "publicada",
       "concepto": "Las olas de atrás se quedan tan quietas bajo su mirada que la espuma tarda un minuto entero en decidirse a romper contra la roca.",
       "anio": 2025,
@@ -13792,7 +13730,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-d634b332-0",
       "serie": "archivo",
-      "orden": 447,
+      "orden": 445,
       "estado": "publicada",
       "concepto": "Detrás de su hombro un velero de vela dorada lleva toda la tarde intentando alejarse mar adentro sin conseguir ganar ni un metro de distancia.",
       "anio": 2025,
@@ -13823,7 +13761,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-d634b332-1",
       "serie": "archivo",
-      "orden": 448,
+      "orden": 446,
       "estado": "publicada",
       "concepto": "Sostiene el cuchillo tan pegado al pecho que el filo le devuelve el mismo mar de atrás, reducido entero a una sola línea de acero.",
       "anio": 2025,
@@ -13854,7 +13792,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-d77639d9-0",
       "serie": "archivo",
-      "orden": 449,
+      "orden": 447,
       "estado": "publicada",
       "concepto": "La sombra que proyecta contra el muro se alarga tanto que dobla la esquina del pasillo antes de que él mismo alcance a dar el primer paso.",
       "anio": 2025,
@@ -13885,7 +13823,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-dc5e217d-0",
       "serie": "archivo",
-      "orden": 450,
+      "orden": 448,
       "estado": "publicada",
       "concepto": "Las nubes que se amontonan detrás llevan tres días completos sin decidirse a romper sobre el mismo trozo de mar que él observa con el ceño fruncido.",
       "anio": 2025,
@@ -13916,7 +13854,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-de5308d8-0",
       "serie": "archivo",
-      "orden": 451,
+      "orden": 449,
       "estado": "publicada",
       "concepto": "Se planta justo en la línea donde el azul de la mañana todavía no le cede el sitio por completo al naranja que ya empieza a subirle por el hombro.",
       "anio": 2025,
@@ -13947,7 +13885,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-f8ba322e-1",
       "serie": "archivo",
-      "orden": 452,
+      "orden": 450,
       "estado": "publicada",
       "concepto": "Las cejas se le tensan tan rectas que igualan la línea exacta del horizonte que tiene detrás, sin una sola curva de diferencia entre las dos.",
       "anio": 2025,
@@ -13978,7 +13916,7 @@
     {
       "slug": "juan-de-la-torre-from-cadiz-medium-dark-f8ba322e-3",
       "serie": "archivo",
-      "orden": 453,
+      "orden": 451,
       "estado": "publicada",
       "concepto": "El barco diminuto que aparece detrás de su hombro lleva media vida cruzando el mismo trozo de mar sin alcanzar nunca el borde de la imagen.",
       "anio": 2025,
@@ -14007,37 +13945,9 @@
       "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f"
     },
     {
-      "slug": "kintsugi-digital",
-      "titulo": "Kintsugi digital",
-      "alt": "Vasija de barro antigua sobre fondo oscuro, con las grietas rellenas de luz y píxeles luminosos en lugar de oro.",
-      "serie": "umbral",
-      "orden": 454,
-      "estado": "pendiente",
-      "tags": [
-        "bodegón",
-        "cerámica",
-        "reparación"
-      ],
-      "licencia": "cc-by-nc",
-      "w": null,
-      "h": null,
-      "anchos": [],
-      "color": "#4f3e35",
-      "concepto": "Bodegón mínimo. Una vasija de barro antigua reparada con kintsugi digital: las grietas son luz y píxel en vez de oro.",
-      "anio": 2025,
-      "licenciaDetalle": {
-        "tipo": "cc-by-nc",
-        "print": true
-      },
-      "procedencia": {
-        "herramienta": "Midjourney"
-      },
-      "edicion": "01"
-    },
-    {
       "slug": "latin-american-boy-with-an-alternative-nu-metal-61e3ec5c-1",
       "serie": "archivo",
-      "orden": 455,
+      "orden": 452,
       "estado": "publicada",
       "concepto": "Lleva tantos collares superpuestos que el espejo de al lado necesita reflejarlos dos veces para no perder ni una sola vuelta de cadena.",
       "anio": 2025,
@@ -14068,7 +13978,7 @@
     {
       "slug": "latin-american-boy-with-an-alternative-nu-metal-61e3ec5c-2",
       "serie": "archivo",
-      "orden": 456,
+      "orden": 453,
       "estado": "publicada",
       "concepto": "El tinte azul del pelo se le mezcla tanto con la pared que hace falta contar los mechones dos veces para saber dónde termina el cuarto y empieza la cabeza.",
       "anio": 2025,
@@ -14099,7 +14009,7 @@
     {
       "slug": "latin-american-etnicity-moon-human-gazes-at-eart-95e801a2-0",
       "serie": "archivo",
-      "orden": 457,
+      "orden": 454,
       "estado": "publicada",
       "concepto": "Se queda de pie con la bata puesta como si fuera a asomarse al patio, mientras la Tierra entera gira despacio detrás, esperando su turno de mirada.",
       "anio": 2025,
@@ -14130,7 +14040,7 @@
     {
       "slug": "latin-american-etnicity-moon-human-gazes-at-eart-af07695a-3",
       "serie": "archivo",
-      "orden": 458,
+      "orden": 455,
       "estado": "publicada",
       "concepto": "El traje naranja es el único color en kilómetros de piedra gris, y aun así la Tierra que cuelga del cielo se las arregla para robarle todo el protagonismo.",
       "anio": 2025,
@@ -14161,7 +14071,7 @@
     {
       "slug": "life-still-in-caracas-1830b0dd-1",
       "serie": "archivo",
-      "orden": 459,
+      "orden": 456,
       "estado": "publicada",
       "concepto": "En esa cocina las ollas guardan el sonido de las comidas anteriores, y por eso él se sienta callado: espera a que terminen de sonar.",
       "anio": 2025,
@@ -14192,7 +14102,7 @@
     {
       "slug": "life-still-in-caracas-1830b0dd-2",
       "serie": "archivo",
-      "orden": 460,
+      "orden": 457,
       "estado": "publicada",
       "concepto": "Se sienta a la mesa rodeado de tantas plantas que el mesero tarda un minuto entero en encontrar el hueco exacto por donde servirle el café.",
       "anio": 2025,
@@ -14223,7 +14133,7 @@
     {
       "slug": "life-still-in-caracas-1830b0dd-3",
       "serie": "archivo",
-      "orden": 461,
+      "orden": 458,
       "estado": "publicada",
       "concepto": "Contra la misma pared se sientan los dos, pero dejan entre ambos el largo exacto de una acera entera, como si la calle tuviera que caber de por medio.",
       "anio": 2025,
@@ -14254,7 +14164,7 @@
     {
       "slug": "life-still-in-caracas-1dc5ac9e-1",
       "serie": "archivo",
-      "orden": 462,
+      "orden": 459,
       "estado": "publicada",
       "concepto": "Camina con la gorra calada hasta las cejas mientras a su espalda una fila entera de torres se estira para alcanzar la altura exacta de la montaña.",
       "anio": 2025,
@@ -14285,7 +14195,7 @@
     {
       "slug": "life-still-in-caracas-1dc5ac9e-2",
       "serie": "archivo",
-      "orden": 463,
+      "orden": 460,
       "estado": "publicada",
       "concepto": "El chándal metalizado le devuelve a la ciudad la misma luz que ella empieza a encender abajo, ventana por ventana, mientras el cielo termina de apagarse.",
       "anio": 2025,
@@ -14316,7 +14226,7 @@
     {
       "slug": "life-still-in-caracas-28e76c57-0",
       "serie": "archivo",
-      "orden": 464,
+      "orden": 461,
       "estado": "publicada",
       "concepto": "Se recuesta contra la reja verde con los ojos cerrados, y dos periódicos sin vender siguen esperando en el kiosco a que despierte para cobrarle el vuelto.",
       "anio": 2025,
@@ -14347,7 +14257,7 @@
     {
       "slug": "life-still-in-caracas-397d7ceb-1",
       "serie": "archivo",
-      "orden": 465,
+      "orden": 462,
       "estado": "publicada",
       "concepto": "El televisor lleva tanto tiempo sentado entre las macetas que las flores anaranjadas ya le crecen alrededor como si fuera una maceta más del patio.",
       "anio": 2025,
@@ -14378,7 +14288,7 @@
     {
       "slug": "life-still-in-caracas-4ea279aa-2",
       "serie": "archivo",
-      "orden": 466,
+      "orden": 463,
       "estado": "publicada",
       "concepto": "La fila de carros se estira tanto calle abajo que el último parachoques todavía no consigue ver la montaña que corona al primero de todos.",
       "anio": 2025,
@@ -14409,7 +14319,7 @@
     {
       "slug": "life-still-in-caracas-946cf2ed-2",
       "serie": "archivo",
-      "orden": 467,
+      "orden": 464,
       "estado": "publicada",
       "concepto": "Las torres altas y las casas bajas del barrio comparten la misma nube morada del atardecer, aunque a las primeras les sobren diez pisos para alcanzarla primero.",
       "anio": 2025,
@@ -14440,7 +14350,7 @@
     {
       "slug": "life-still-in-caracas-98f2844e-0",
       "serie": "archivo",
-      "orden": 468,
+      "orden": 465,
       "estado": "publicada",
       "concepto": "Extiende sobre el mantel de colores más aparatos de los que la mesa alcanza a sostener, y aun así encuentra sitio para señalar uno más con la mano.",
       "anio": 2025,
@@ -14471,7 +14381,7 @@
     {
       "slug": "life-still-in-caracas-98f2844e-1",
       "serie": "archivo",
-      "orden": 469,
+      "orden": 466,
       "estado": "publicada",
       "concepto": "La ventana enmarca la montaña con tanta precisión que las macetas del alféizar parecen puestas ahí solo para no dejarla escapar del cuadro.",
       "anio": 2025,
@@ -14502,7 +14412,7 @@
     {
       "slug": "life-still-in-caracas-a13e96b0-0",
       "serie": "archivo",
-      "orden": 470,
+      "orden": 467,
       "estado": "publicada",
       "concepto": "Instala el televisor en la ladera y luego le da la espalda, prefiriendo la ciudad entera que ya transmite en vivo cuesta abajo sin necesidad de antena.",
       "anio": 2025,
@@ -14533,7 +14443,7 @@
     {
       "slug": "life-still-in-caracas-b86cf818-3",
       "serie": "archivo",
-      "orden": 471,
+      "orden": 468,
       "estado": "publicada",
       "concepto": "La tela blanca del traje es lo único que el asfalto gris no logra tragarse, aunque él se acomode con las piernas cruzadas justo en el borde de la avenida vacía.",
       "anio": 2025,
@@ -14564,7 +14474,7 @@
     {
       "slug": "life-still-in-caracas-c0a2992f-0",
       "serie": "archivo",
-      "orden": 472,
+      "orden": 469,
       "estado": "publicada",
       "concepto": "Se sienta justo en el borde donde la sombra del edificio corta la acera al medio, y ese filo de diez centímetros le basta para leer sin que el mediodía le queme una letra.",
       "anio": 2025,
@@ -14595,7 +14505,7 @@
     {
       "slug": "life-still-in-caracas-c0a2992f-1",
       "serie": "archivo",
-      "orden": 473,
+      "orden": 470,
       "estado": "publicada",
       "concepto": "Al lado deja una silla plástica blanca completamente vacía, reservada con tanta constancia que ya lleva catorce años esperando a que alguien se siente.",
       "anio": 2025,
@@ -14626,7 +14536,7 @@
     {
       "slug": "life-still-in-caracas-d4cbe190-0",
       "serie": "archivo",
-      "orden": 474,
+      "orden": 471,
       "estado": "publicada",
       "concepto": "Un relámpago le enciende las nubes por detrás a las torres más altas, y el destello dura lo bastante para contar, una por una, las mil ventanas encendidas del barrio de abajo.",
       "anio": 2025,
@@ -14657,7 +14567,7 @@
     {
       "slug": "life-still-in-caracas-e13c784e-3",
       "serie": "archivo",
-      "orden": 475,
+      "orden": 472,
       "estado": "publicada",
       "concepto": "Lleva la camisa cubierta de salpicaduras blancas que parecen haber caído gota a gota durante los mismos veinte años que lleva parado en esa esquina junto al kiosco verde.",
       "anio": 2025,
@@ -14688,7 +14598,7 @@
     {
       "slug": "life-still-in-caracas-with-guacamayas-57e84694-0",
       "serie": "archivo",
-      "orden": 476,
+      "orden": 473,
       "estado": "publicada",
       "concepto": "Vuelan tan pegadas ala con ala que desde las azoteas de abajo cuesta contar si son dos guacamayas o una sola con cuatro alas.",
       "anio": 2025,
@@ -14719,7 +14629,7 @@
     {
       "slug": "life-still-in-caracas-with-guacamayas-5bfc12b2-2",
       "serie": "archivo",
-      "orden": 477,
+      "orden": 474,
       "estado": "publicada",
       "concepto": "La bandada pasa tan espesa que por tres segundos las dos torres más altas de la avenida desaparecen detrás de puras alas azules y amarillas.",
       "anio": 2025,
@@ -14750,7 +14660,7 @@
     {
       "slug": "life-still-in-paraguan-055ea6b8-2",
       "serie": "archivo",
-      "orden": 478,
+      "orden": 475,
       "estado": "publicada",
       "concepto": "Estaciona la moto verde y blanca tan pegada a la reja de la ventana que en veinte años de subir esa acera nunca ha rozado ni un barrote.",
       "anio": 2025,
@@ -14781,7 +14691,7 @@
     {
       "slug": "life-still-in-paraguan-7243af9b-1",
       "serie": "archivo",
-      "orden": 479,
+      "orden": 476,
       "estado": "publicada",
       "concepto": "El portón de hierro se oxidó tanto esperando que alguien lo cierre que las flores rosadas ya le treparon por encima los seis barrotes.",
       "anio": 2025,
@@ -14812,7 +14722,7 @@
     {
       "slug": "life-still-in-paraguan-f47b6efe-1",
       "serie": "archivo",
-      "orden": 480,
+      "orden": 477,
       "estado": "publicada",
       "concepto": "Las flores azules de la camisa se repiten tantas veces sobre la tela que ya superan, una por una, los destellos que ha dado el faro blanco de allá atrás en toda la tarde.",
       "anio": 2025,
@@ -14843,7 +14753,7 @@
     {
       "slug": "life-still-in-paraguan-f47b6efe-2",
       "serie": "archivo",
-      "orden": 481,
+      "orden": 478,
       "estado": "publicada",
       "concepto": "Al otro lado del agua la refinería enciende tantas torres a la vez que desde este patio de zinc y palmeras hace más luz que la luna llena.",
       "anio": 2025,
@@ -14874,7 +14784,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-22bc6902-0",
       "serie": "archivo",
-      "orden": 482,
+      "orden": 479,
       "estado": "publicada",
       "concepto": "La camisa de flores azules queda tan pegada al vestido morado de la vecina de asiento que entre los dos estampados no cabe ni el aire del vagón.",
       "anio": 2025,
@@ -14905,7 +14815,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-2592a93b-1",
       "serie": "archivo",
-      "orden": 483,
+      "orden": 480,
       "estado": "publicada",
       "concepto": "El tren lleva pintada una franja de siete colores a lo largo del vagón, y la multitud que baja logra vestir, entre camisas y blusas, exactamente los mismos siete sin ponerse de acuerdo.",
       "anio": 2025,
@@ -14936,7 +14846,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-4487d810-2",
       "serie": "archivo",
-      "orden": 484,
+      "orden": 481,
       "estado": "publicada",
       "concepto": "Camina por el andén tan mojado por la lluvia que el reflejo del tren duplica cada luz roja, y por un segundo parecen dos trenes esperando en vez de uno.",
       "anio": 2025,
@@ -14967,7 +14877,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-7384e7bf-1",
       "serie": "archivo",
-      "orden": 485,
+      "orden": 482,
       "estado": "publicada",
       "concepto": "Lleva el pelo teñido de un rojo tan fijo que aunque el vagón entero tiembla y se desenfoca detrás de ella, ni un solo mechón se le mueve del sitio.",
       "anio": 2025,
@@ -14998,7 +14908,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-ba90e8ae-2",
       "serie": "archivo",
-      "orden": 486,
+      "orden": 483,
       "estado": "publicada",
       "concepto": "El pantalón morado le brilla tanto bajo la luz del vagón que refleja, uno por uno, los cinco tubos fluorescentes del techo mientras cruza las piernas.",
       "anio": 2025,
@@ -15029,7 +14939,7 @@
     {
       "slug": "life-still-in-the-metro-of-caracas-ba90e8ae-3",
       "serie": "archivo",
-      "orden": 487,
+      "orden": 484,
       "estado": "publicada",
       "concepto": "Comparten el mismo asiento de metal aunque entre la camisa estampada del mayor y la camisa azul lisa del joven se cuenten cuarenta años exactos de diferencia.",
       "anio": 2025,
@@ -15060,7 +14970,7 @@
     {
       "slug": "liminal-image-of-a-restaurant-postcard-in-the-e9155478-0",
       "serie": "archivo",
-      "orden": 488,
+      "orden": 485,
       "estado": "publicada",
       "concepto": "El toldo blanco lleva tantas lluvias encima que ya deja pasar el sol como si fuera una sábana tendida sobre las mesas y sillas plásticas de abajo.",
       "anio": 2025,
@@ -15091,7 +15001,7 @@
     {
       "slug": "liminal-image-of-a-restaurant-postcard-in-the-ef172ec5-2",
       "serie": "archivo",
-      "orden": 489,
+      "orden": 486,
       "estado": "publicada",
       "concepto": "Ninguna de las sillas combina con la de al lado —azules, rojas, plateadas— y aun así cada mesa vacía tiene sus cuatro puestas en el orden exacto de siempre.",
       "anio": 2025,
@@ -15122,7 +15032,7 @@
     {
       "slug": "low-shot-of-3d6e4044-2",
       "serie": "archivo",
-      "orden": 490,
+      "orden": 487,
       "estado": "publicada",
       "concepto": "Lleva soldadas sobre los ojos dos placas de circuito verde tan densas que en vez de parpadear parece que procesa cada segundo que pasa frente a él.",
       "anio": 2025,
@@ -15153,7 +15063,7 @@
     {
       "slug": "low-shot-of-3d6e4044-3",
       "serie": "archivo",
-      "orden": 491,
+      "orden": 488,
       "estado": "publicada",
       "concepto": "Tiene el rostro conectado a un manojo de cables que le sale de la sien izquierda, y respira tan despacio recostado en el cojín verde que ninguno de los cables se mueve ni un milímetro.",
       "anio": 2025,
@@ -15184,7 +15094,7 @@
     {
       "slug": "low-shot-of-7b37ca9b-2",
       "serie": "archivo",
-      "orden": 492,
+      "orden": 489,
       "estado": "publicada",
       "concepto": "La corona le cubre la cabeza con tantas perlas cosidas una a una que ya pesa lo mismo que el libro de tapa enjoyada que sostiene con la otra mano.",
       "anio": 2025,
@@ -15215,7 +15125,7 @@
     {
       "slug": "low-shot-of-c969b056-0",
       "serie": "archivo",
-      "orden": 493,
+      "orden": 490,
       "estado": "publicada",
       "concepto": "Un cilindro de metal cuelga apenas a dos dedos de su frente, y lleva tantas horas fijo en ese mismo punto que ya no hace falta que nadie lo sostenga.",
       "anio": 2025,
@@ -15246,7 +15156,7 @@
     {
       "slug": "low-shot-of-martian-film-the-scene-shows-2ad60863-1",
       "serie": "archivo",
-      "orden": 494,
+      "orden": 491,
       "estado": "publicada",
       "concepto": "Cientos de piezas diminutas y brillantes forman el casco que lleva puesto, tan pulidas que en cada una cabe, en miniatura, todo lo que tiene delante.",
       "anio": 2025,
@@ -15277,7 +15187,7 @@
     {
       "slug": "low-shot-of-martian-film-the-scene-shows-2ad60863-3",
       "serie": "archivo",
-      "orden": 495,
+      "orden": 492,
       "estado": "publicada",
       "concepto": "Se enrolla en la cabeza tantas cadenas de cuentas plateadas que si las estirara todas en línea recta le darían tres vueltas completas al cuello del abrigo verde.",
       "anio": 2025,
@@ -15308,7 +15218,7 @@
     {
       "slug": "low-shot-of-student-in-formal-attire-from-f0eed234-1",
       "serie": "archivo",
-      "orden": 496,
+      "orden": 493,
       "estado": "publicada",
       "concepto": "El visor le cruza la frente entera armado con decenas de piezas diminutas y cables soldados, y bajo esa maraña metálica el cráneo rapado no deja ver un centímetro de piel.",
       "anio": 2025,
@@ -15339,7 +15249,7 @@
     {
       "slug": "lunar-punk-green-goblin-under-a-big-red-4c5b73b1-0",
       "serie": "archivo",
-      "orden": 497,
+      "orden": 494,
       "estado": "publicada",
       "concepto": "El fósforo asoma su cabeza de ceniza sobre el mar y tarda tres mareas en apagarse, mientras la fruta partida bajo la manzana-luna gotea semillas rojas sobre el agua.",
       "anio": 2025,
@@ -15369,7 +15279,7 @@
     {
       "slug": "magazine-font-title-for-curiana-radio-90s-print-9f8a2b1e-1",
       "serie": "archivo",
-      "orden": 498,
+      "orden": 495,
       "estado": "publicada",
       "concepto": "El marco dorado se garabatea a mano alrededor del cartel, y los faros del callejón detrás siguen encendidos aunque la fotografía tenga treinta años de grano azul.",
       "anio": 2025,
@@ -15400,7 +15310,7 @@
     {
       "slug": "main-deck-of-a-intergalactic-freighter-navigatio-794b6938-0",
       "serie": "archivo",
-      "orden": 499,
+      "orden": 496,
       "estado": "publicada",
       "concepto": "La pantalla circular del centro repite el mismo pulso azul desde hace siete turnos, y ningún tripulante levanta la vista de sus propios once monitores encendidos.",
       "anio": 2025,
@@ -15431,7 +15341,7 @@
     {
       "slug": "main-deck-of-a-intergalactic-freighter-navigatio-b7931fda-0",
       "serie": "archivo",
-      "orden": 500,
+      "orden": 497,
       "estado": "publicada",
       "concepto": "Cuatro siluetas se recortan contra el ventanal blanco, y la luz que entra por el cristal borra el horizonte hasta que no queda mar, solo una hoja en blanco de sol.",
       "anio": 2025,
@@ -15462,7 +15372,7 @@
     {
       "slug": "man-practicing-kung-fu-in-a-traditional-shaolin-42d93de0-3",
       "serie": "archivo",
-      "orden": 501,
+      "orden": 498,
       "estado": "publicada",
       "concepto": "La mano se acerca tanto al lente que borra cuatro de sus cinco dedos, y el fondo rojo detrás de la mirada no ha bajado de temperatura en lo que va del retrato.",
       "anio": 2025,
@@ -15491,38 +15401,9 @@
       "generacion": "42d93de0-5ba1-49fa-a639-884cb7119e4f"
     },
     {
-      "slug": "medanos-circuito",
-      "titulo": "Médanos, circuito",
-      "alt": "Dunas de arena al atardecer con patrones de circuito impresos en la superficie y una antena de barro y cobre en el horizonte.",
-      "serie": "umbral",
-      "orden": 502,
-      "estado": "pendiente",
-      "tags": [
-        "paisaje",
-        "solarpunk",
-        "desierto",
-        "señal"
-      ],
-      "licencia": "cc-by-nc",
-      "w": null,
-      "h": null,
-      "anchos": [],
-      "color": "#4f3e35",
-      "concepto": "Paisaje de los Médanos de Coro al atardecer. La arena lleva impresos patrones de circuito y ondas de sonido. En el horizonte, una antena solarpunk de barro y cobre silueteada contra un sol naranja.",
-      "anio": 2025,
-      "licenciaDetalle": {
-        "tipo": "cc-by-nc",
-        "print": true
-      },
-      "procedencia": {
-        "herramienta": "Midjourney"
-      },
-      "edicion": "01"
-    },
-    {
       "slug": "men-in-hats-standing-on-snow-next-to-940f9ae4-1",
       "serie": "archivo",
-      "orden": 503,
+      "orden": 499,
       "estado": "publicada",
       "concepto": "Los dos sombreros llevan tanta nieve en el ala que parecen llevar el invierno entero encima, mientras miran una sierra que no ha cambiado de sitio en blanco y negro desde hace un siglo.",
       "anio": 2025,
@@ -15553,7 +15434,7 @@
     {
       "slug": "minimalist-logo-for-pulse-an-asistant-for-keepin-5448c501-3",
       "serie": "archivo",
-      "orden": 504,
+      "orden": 500,
       "estado": "publicada",
       "concepto": "Del punto blanco del centro salen ondas que se repiten cien veces hacia cada lado sin perder el ritmo, y las líneas rojas cosen el cielo justo por encima del perfil oscuro de la montaña.",
       "anio": 2025,
@@ -15584,7 +15465,7 @@
     {
       "slug": "minimalist-logo-in-the-shape-of-wave-lenghts-abfc611c-0",
       "serie": "archivo",
-      "orden": 505,
+      "orden": 501,
       "estado": "publicada",
       "concepto": "La onda dibuja dos jorobas de luz hechas de puntos sueltos, y ninguno de esos puntos toca al de al lado aunque el negro alrededor los junte a todos en la misma curva.",
       "anio": 2025,
@@ -15615,7 +15496,7 @@
     {
       "slug": "minimalist-monochromatic-for-pulse-an-asistant-f-94d3370b-1",
       "serie": "archivo",
-      "orden": 506,
+      "orden": 502,
       "estado": "publicada",
       "concepto": "El único cuadro naranja de la pared lleva encendido su color desde antes de que pintaran el resto del cuarto de azul, y la luz de la ventana solo calienta la mitad de la alfombra.",
       "anio": 2025,
@@ -15646,7 +15527,7 @@
     {
       "slug": "minimalist-monochromatic-for-pulse-an-asistant-f-94d3370b-2",
       "serie": "archivo",
-      "orden": 507,
+      "orden": 503,
       "estado": "publicada",
       "concepto": "La línea de pulso azul le atraviesa la cara y la blusa a rayas sin desviarse un milímetro, y justo sobre la frente da su salto más alto de la noche.",
       "anio": 2025,
@@ -15677,7 +15558,7 @@
     {
       "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-0",
       "serie": "archivo",
-      "orden": 508,
+      "orden": 504,
       "estado": "publicada",
       "concepto": "La capa roja es lo único que tiene color en todo el desierto, y la sombra del disco que flota encima le cabe en el cuerpo sin que se le mueva un pliegue de tela.",
       "anio": 2025,
@@ -15708,7 +15589,7 @@
     {
       "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-1",
       "serie": "archivo",
-      "orden": 509,
+      "orden": 505,
       "estado": "publicada",
       "concepto": "La luna verde se deja ver solo a medias detrás del pico más alto, y la escarcha blanca le cubre la roca entera como si nunca hubiera dejado de nevar.",
       "anio": 2025,
@@ -15739,7 +15620,7 @@
     {
       "slug": "minimalist-science-fiction-magazine-cover-photog-2b2906ce-2",
       "serie": "archivo",
-      "orden": 510,
+      "orden": 506,
       "estado": "publicada",
       "concepto": "El sol rojo es un círculo tan perfecto que parece recortado con tijera, y su color se derrama camino abajo hasta teñir de rosa las botas de los dos que caminan hacia él.",
       "anio": 2025,
@@ -15770,7 +15651,7 @@
     {
       "slug": "minimalist-science-fiction-magazine-cover-photog-53702410-2",
       "serie": "archivo",
-      "orden": 511,
+      "orden": 507,
       "estado": "publicada",
       "concepto": "El halo blanco dibuja un anillo tan ancho que no cabe entero en la vista, y la persona de abajo apenas le llega al tobillo con la sombra de su propio cuerpo.",
       "anio": 2025,
@@ -15801,7 +15682,7 @@
     {
       "slug": "minimalist-science-fiction-magazine-cover-photog-53702410-3",
       "serie": "archivo",
-      "orden": 512,
+      "orden": 508,
       "estado": "publicada",
       "concepto": "La grieta roja del monolito es la única luz que la niebla no se atreve a tragarse, y la figura que la mira desde abajo no le llega ni a la mitad de la base.",
       "anio": 2025,
@@ -15832,7 +15713,7 @@
     {
       "slug": "movie-cinematic-still-of-a-medium-sh-2c992c98-0",
       "serie": "archivo",
-      "orden": 513,
+      "orden": 509,
       "estado": "publicada",
       "concepto": "Se le cuentan uno a uno los colmillos mientras aúlla, y la luna se ha corrido tanto hacia la esquina del cuadro que parece que intenta salirse del retrato.",
       "anio": 2025,
@@ -15863,7 +15744,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-08b62b1e-3",
       "serie": "archivo",
-      "orden": 514,
+      "orden": 510,
       "estado": "publicada",
       "concepto": "A la luna se le corrió el rojo como si alguien la hubiera rozado con la misma zarpa que le tiñó el pecho al lobo, y ninguno de los dos colores ha terminado de secar.",
       "anio": 2025,
@@ -15894,7 +15775,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-3f7f6f89-1",
       "serie": "archivo",
-      "orden": 515,
+      "orden": 511,
       "estado": "publicada",
       "concepto": "De toda la oscuridad del lobo solo se le enciende un punto, el ojo, y ese punto rojo pesa más en la imagen que la luna entera detrás de él.",
       "anio": 2025,
@@ -15925,7 +15806,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-3f7f6f89-3",
       "serie": "archivo",
-      "orden": 516,
+      "orden": 512,
       "estado": "publicada",
       "concepto": "Los hombros del lobo son tan anchos que le tapan medio bosque detrás, y cada pelo del lomo se le para por separado como si contara los segundos hasta la luna llena.",
       "anio": 2025,
@@ -15956,7 +15837,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-4ae21d91-0",
       "serie": "archivo",
-      "orden": 517,
+      "orden": 513,
       "estado": "publicada",
       "concepto": "Le pintaron el pelaje con pinceladas moradas que no existen en ningún lobo real, y echa tanto la cabeza atrás para aullar que la nuca casi le toca la espalda.",
       "anio": 2025,
@@ -15987,7 +15868,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-6ca482c8-0",
       "serie": "archivo",
-      "orden": 518,
+      "orden": 514,
       "estado": "publicada",
       "concepto": "Las ramas secas se cierran alrededor del lobo y la luna como un marco que alguien talló a propósito, y ninguna rama se anima a cruzar el círculo rosado de luz.",
       "anio": 2025,
@@ -16018,7 +15899,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-8df90112-1",
       "serie": "archivo",
-      "orden": 519,
+      "orden": 515,
       "estado": "publicada",
       "concepto": "Solo dos cosas del lobo resisten la oscuridad, el ojo rojo y la luna, y entre las dos no juntan luz suficiente para dibujarle el resto del pelaje.",
       "anio": 2025,
@@ -16048,7 +15929,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-d49b413f-2",
       "serie": "archivo",
-      "orden": 520,
+      "orden": 516,
       "estado": "publicada",
       "concepto": "Las garras delanteras se le quedan justo en el borde de la roca, sin pasarse ni un centímetro, mientras el resto del cuerpo se estira entero hacia la luna amarilla.",
       "anio": 2025,
@@ -16079,7 +15960,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-sc-f33e029e-3",
       "serie": "archivo",
-      "orden": 521,
+      "orden": 517,
       "estado": "publicada",
       "concepto": "Se yergue tan derecho sobre dos patas que desde abajo parece más alto que los árboles que lo rodean, y el pecho se le hincha con cada nota del aullido.",
       "anio": 2025,
@@ -16110,7 +15991,7 @@
     {
       "slug": "movie-still-of-a-medium-shot-grim-scene-7d1a34b0-0",
       "serie": "archivo",
-      "orden": 522,
+      "orden": 518,
       "estado": "publicada",
       "concepto": "Abre los brazos tanto que las garras le llegan a los árboles de los dos costados a la vez, y en medio de ese abrazo imposible sigue aullando sin bajar la cabeza.",
       "anio": 2025,
@@ -16141,7 +16022,7 @@
     {
       "slug": "mulato-man-with-dark-skin-wears-a-vintage-30802e38-2",
       "serie": "archivo",
-      "orden": 523,
+      "orden": 519,
       "estado": "publicada",
       "concepto": "Empuña la espada envainada de cara al mar, y desde el hombro hasta la mandíbula la luz azul lleva grabada la misma marea desde hace tres siglos.",
       "anio": 2025,
@@ -16172,7 +16053,7 @@
     {
       "slug": "mulato-man-with-dark-skin-wears-a-vintage-3ae49587-1",
       "serie": "archivo",
-      "orden": 524,
+      "orden": 520,
       "estado": "publicada",
       "concepto": "Tiene la cara partida en dos luces, la mitad tibia y la mitad azul marino, y ninguna de las dos gana terreno aunque lleve toda una vida de espaldas al sol.",
       "anio": 2025,
@@ -16203,7 +16084,7 @@
     {
       "slug": "music-magazine-cover-of-a-futuristic-caqueto-wom-a1101b34-0",
       "serie": "archivo",
-      "orden": 525,
+      "orden": 521,
       "estado": "publicada",
       "concepto": "Lleva puesto un chaleco tejido con cuentas de todos los colores del mercado y los audífonos blancos le tapan tanto los oídos que ya no escucha nada que no sea la propia música.",
       "anio": 2025,
@@ -16233,7 +16114,7 @@
     {
       "slug": "music-magazine-cover-of-a-futuristic-caqueto-wom-a1101b34-3",
       "serie": "archivo",
-      "orden": 526,
+      "orden": 522,
       "estado": "publicada",
       "concepto": "El collar de cuentas rojas y turquesas le sube por el cuello capa sobre capa, tantas vueltas que ya no se sabe dónde empieza el bordado y dónde termina la garganta.",
       "anio": 2025,
@@ -16263,7 +16144,7 @@
     {
       "slug": "music-magazine-curiana-radio-title-type-in-90s-dc2600db-3",
       "serie": "archivo",
-      "orden": 527,
+      "orden": 523,
       "estado": "publicada",
       "concepto": "El cartel rojo y amarillo descansa apoyado sobre el radio como si fuera una antena, y desde ahí lleva sintonizada la misma frecuencia sin moverse un centímetro.",
       "anio": 2025,
@@ -16294,7 +16175,7 @@
     {
       "slug": "music-magazine-titled-curiana-radio-ce96d707-3",
       "serie": "archivo",
-      "orden": 528,
+      "orden": 524,
       "estado": "publicada",
       "concepto": "Se cubre la cabeza con un tocado de plumas que pesa como si cargara todos los pájaros que las soltaron, y aun así se ajusta los audífonos sin que se le mueva una sola.",
       "anio": 2025,
@@ -16324,7 +16205,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-06c61482-1",
       "serie": "archivo",
-      "orden": 529,
+      "orden": 525,
       "estado": "publicada",
       "concepto": "La luz roja se queda encendida en la azotea mientras la lluvia raya el cielo entero de arriba abajo, y ya lleva tantas noches ahí que se volvió parte del techo.",
       "anio": 2025,
@@ -16355,7 +16236,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-0d45fa0b-0",
       "serie": "archivo",
-      "orden": 530,
+      "orden": 526,
       "estado": "publicada",
       "concepto": "El edificio se estira tanto hacia las nubes moradas que termina por rozarlas, mientras abajo los carros hacen fila como si nada, ajenos a la altura que cargan encima.",
       "anio": 2025,
@@ -16386,7 +16267,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-1cf26918-1",
       "serie": "archivo",
-      "orden": 531,
+      "orden": 527,
       "estado": "publicada",
       "concepto": "El camino de luces rojas baja directo hacia las montañas mientras un marco de manchas como piel de fiera envuelve la postal entera, dispuesto a guardarla otro siglo.",
       "anio": 2025,
@@ -16417,7 +16298,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-1cf26918-2",
       "serie": "archivo",
-      "orden": 532,
+      "orden": 528,
       "estado": "publicada",
       "concepto": "Los faros de los carros se estiran en hilos de colores por toda la avenida, tan largos que parece que ningún carro haya llegado a frenar todavía esta noche.",
       "anio": 2025,
@@ -16448,7 +16329,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-398b77bf-1",
       "serie": "archivo",
-      "orden": 533,
+      "orden": 529,
       "estado": "publicada",
       "concepto": "El carro cruza la avenida entera teñido de un rojo tan parejo que hasta el asfalto se pinta del mismo color, como si la ciudad completa ardiera despacio esa noche.",
       "anio": 2025,
@@ -16479,7 +16360,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-85c7980f-3",
       "serie": "archivo",
-      "orden": 534,
+      "orden": 530,
       "estado": "publicada",
       "concepto": "Los letreros le cubren toda la fachada de arriba abajo, tantos y tan juntos que la calle mojada de enfrente se los bebe enteros sin dejar uno solo sin reflejo.",
       "anio": 2025,
@@ -16510,7 +16391,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-9a5e59c0-0",
       "serie": "archivo",
-      "orden": 535,
+      "orden": 531,
       "estado": "publicada",
       "concepto": "La neblina se traga los rascacielos del fondo casi por completo, y solo la camioneta estacionada al frente se salva del naranja espeso que cubre la calle entera.",
       "anio": 2025,
@@ -16541,7 +16422,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-9dc8b50c-2",
       "serie": "archivo",
-      "orden": 536,
+      "orden": 532,
       "estado": "publicada",
       "concepto": "Las dos torres se alzan tan rojas sobre la ciudad que parecen dos brasas paradas, y abajo miles de ventanas encendidas hacen de chispas que nunca llegan a apagarse.",
       "anio": 2025,
@@ -16572,7 +16453,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-a1069948-2",
       "serie": "archivo",
-      "orden": 537,
+      "orden": 533,
       "estado": "publicada",
       "concepto": "Camina de espaldas por el callejón mojado con un abrigo tan blanco que hasta los letreros rojos a los lados se apagan un poco para dejarlo pasar.",
       "anio": 2025,
@@ -16603,7 +16484,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-cf4db9a0-3",
       "serie": "archivo",
-      "orden": 538,
+      "orden": 534,
       "estado": "publicada",
       "concepto": "La autopista se curva entera en un solo trazo rojo que no se corta ni un segundo, como si todos los carros de la noche hubieran salido a la misma hora exacta.",
       "anio": 2025,
@@ -16634,7 +16515,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-e117d47b-2",
       "serie": "archivo",
-      "orden": 539,
+      "orden": 535,
       "estado": "publicada",
       "concepto": "Las cúpulas doradas se quedan encendidas sobre el cuerpo azul del edificio mientras abajo los carros pasan tan rápido que se vuelven líneas, y ni una sola luz se mueve un milímetro.",
       "anio": 2025,
@@ -16665,7 +16546,7 @@
     {
       "slug": "night-in-the-city-postcard-in-the-style-f2cfba9b-2",
       "serie": "archivo",
-      "orden": 540,
+      "orden": 536,
       "estado": "publicada",
       "concepto": "La gente cruza la calle entera bajo un techo de letreros y bombillos que cuelgan tan bajo que casi les rozan la cabeza, y nadie levanta la vista para mirarlos.",
       "anio": 2025,
@@ -16696,7 +16577,7 @@
     {
       "slug": "night-in-the-sea-postcard-in-the-style-020002d0-2",
       "serie": "archivo",
-      "orden": 541,
+      "orden": 537,
       "estado": "publicada",
       "concepto": "Se sienta en la orilla con las piernas cruzadas frente a dos canoas ancladas que no se mueven ni un centímetro, como si el mar entero contuviera la respiración por él.",
       "anio": 2025,
@@ -16725,37 +16606,9 @@
       "generacion": "020002d0-d027-4a46-af2c-552c8ccc170e"
     },
     {
-      "slug": "noche-de-desierto",
-      "titulo": "Noche de desierto",
-      "alt": "Desierto nocturno panorámico bajo un cielo de estrellas densas, con una única luz diminuta encendida a lo lejos.",
-      "serie": "umbral",
-      "orden": 542,
-      "estado": "pendiente",
-      "tags": [
-        "paisaje",
-        "noche",
-        "desierto"
-      ],
-      "licencia": "cc-by-nc",
-      "w": null,
-      "h": null,
-      "anchos": [],
-      "color": "#4f3e35",
-      "concepto": "El desierto de noche bajo un cielo estrellado denso. Una sola luz pequeña —fogata o LED— sostiene la inmensidad.",
-      "anio": 2025,
-      "licenciaDetalle": {
-        "tipo": "cc-by-nc",
-        "print": true
-      },
-      "procedencia": {
-        "herramienta": "Midjourney"
-      },
-      "edicion": "01"
-    },
-    {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-0ce8227e-3",
       "serie": "archivo",
-      "orden": 543,
+      "orden": 538,
       "estado": "publicada",
       "concepto": "La túnica estampada le llega hasta las rodillas y ahí empiezan las piernas de metal, articuladas pieza por pieza, que sostienen el peso entero del cuerpo sin un solo crujido.",
       "anio": 2025,
@@ -16785,7 +16638,7 @@
     {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-1192c8a4-2",
       "serie": "archivo",
-      "orden": 544,
+      "orden": 539,
       "estado": "publicada",
       "concepto": "La camisa cambia de color con el paso que da, del dorado al verde al rosado, y el brazo de acero que le cuelga al lado no cambia nunca, fiel siempre al mismo gris.",
       "anio": 2025,
@@ -16815,7 +16668,7 @@
     {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-1a6caa8a-3",
       "serie": "archivo",
-      "orden": 545,
+      "orden": 540,
       "estado": "publicada",
       "concepto": "Las botas rojas le suben hasta la pantorrilla con placas de armadura completas, tan pesadas que cada paso debería hundir la acera, y sin embargo camina como si no cargara nada.",
       "anio": 2025,
@@ -16845,7 +16698,7 @@
     {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-775591d8-0",
       "serie": "archivo",
-      "orden": 546,
+      "orden": 541,
       "estado": "publicada",
       "concepto": "Las cadenas le cruzan el pecho en tantas vueltas como bombillos hay encendidos detrás, y desde el amplificador donde está sentada domina el escenario entero sin decir una palabra.",
       "anio": 2025,
@@ -16875,7 +16728,7 @@
     {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-7866ae51-0",
       "serie": "archivo",
-      "orden": 547,
+      "orden": 542,
       "estado": "publicada",
       "concepto": "Se para junto a la columna blanca mientras la palmera del jardín se le mete de reflejo entero en el vidrio de al lado, sin pedir permiso para compartir la foto.",
       "anio": 2025,
@@ -16906,7 +16759,7 @@
     {
       "slug": "non-binary-character-with-caribbean-ancestry-a-b-acbe3176-2",
       "serie": "archivo",
-      "orden": 548,
+      "orden": 543,
       "estado": "publicada",
       "concepto": "El guantelete de metal le descansa sobre la rodilla como si fuera una mascota dormida, mientras los tatuajes le suben por el otro brazo hasta perderse bajo la manga de la camiseta negra.",
       "anio": 2025,
@@ -16936,7 +16789,7 @@
     {
       "slug": "nw22o-httpss-mj-r-4af9de2d-3",
       "serie": "archivo",
-      "orden": 549,
+      "orden": 544,
       "estado": "publicada",
       "concepto": "Los hilos de plata le cercan el cráneo en veinte vueltas exactas y sintonizan la única emisora que sigue transmitiendo desde 1962.",
       "anio": 2025,
@@ -16967,7 +16820,7 @@
     {
       "slug": "nw22o-httpss-mj-r-ae8608b6-3",
       "serie": "archivo",
-      "orden": 550,
+      "orden": 545,
       "estado": "publicada",
       "concepto": "El yelmo le cose mil cuentas de plata alrededor de la cara y ninguna se mueve aunque el viento lleve tres días soplando sin parar.",
       "anio": 2025,
@@ -16998,7 +16851,7 @@
     {
       "slug": "o6k-futuristic-city-inside-a-dome-in-pla-2af63a93-1",
       "serie": "archivo",
-      "orden": 551,
+      "orden": 546,
       "estado": "publicada",
       "concepto": "La cúpula de vidrio guarda la última ciudad en pie, y por dentro cae exactamente la misma lluvia que caía antes de que el planeta se pusiera rojo por fuera.",
       "anio": 2025,
@@ -17029,7 +16882,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-171de610-3",
       "serie": "archivo",
-      "orden": 552,
+      "orden": 547,
       "estado": "publicada",
       "concepto": "El grano cae justo en el centro y empuja veintitrés anillos dorados hacia el borde negro sin gastarse nunca.",
       "anio": 2025,
@@ -17060,7 +16913,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-17dc456a-3",
       "serie": "archivo",
-      "orden": 553,
+      "orden": 548,
       "estado": "publicada",
       "concepto": "Tres gotas cayeron sobre la arena hace un instante y la más grande todavía tiembla, aunque el agua se secó hace mil años.",
       "anio": 2025,
@@ -17091,7 +16944,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-21734978-1",
       "serie": "archivo",
-      "orden": 554,
+      "orden": 549,
       "estado": "publicada",
       "concepto": "Dos espirales de arena se buscan desde extremos opuestos del círculo y llevan girando la una hacia la otra desde antes de que existiera el reloj.",
       "anio": 2025,
@@ -17122,7 +16975,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-2481fcaa-2",
       "serie": "archivo",
-      "orden": 555,
+      "orden": 550,
       "estado": "publicada",
       "concepto": "Dos oleajes de arena se cruzan en el aire y dejan grabada la marca exacta del segundo en que chocaron, antes de seguir cada uno su camino.",
       "anio": 2025,
@@ -17153,7 +17006,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-2ec1e10e-2",
       "serie": "archivo",
-      "orden": 556,
+      "orden": 551,
       "estado": "publicada",
       "concepto": "La montaña se levanta en veinte anillos exactos hasta terminar en una sola punta que roza el borde del cartel sin llegar nunca a tocarlo.",
       "anio": 2025,
@@ -17184,7 +17037,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-3b16cf33-1",
       "serie": "archivo",
-      "orden": 557,
+      "orden": 552,
       "estado": "publicada",
       "concepto": "La arena se curva en diez crestas paralelas y todos sus granos devuelven una chispa distinta de luz, como si el sol se hubiera quedado a vivir ahí abajo.",
       "anio": 2025,
@@ -17214,7 +17067,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-434962ca-3",
       "serie": "archivo",
-      "orden": 558,
+      "orden": 553,
       "estado": "publicada",
       "concepto": "El círculo dibuja una huella digital tan antigua que ya nadie recuerda a quién pertenecía el dedo, y aun así sigue girando hacia su propio centro.",
       "anio": 2025,
@@ -17245,7 +17098,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-4fe3520b-2",
       "serie": "archivo",
-      "orden": 559,
+      "orden": 554,
       "estado": "publicada",
       "concepto": "El remolino lleva girando en el mismo punto veinte vueltas completas y todavía no decide si es un agujero o una montaña.",
       "anio": 2025,
@@ -17276,7 +17129,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-940edc4d-3",
       "serie": "archivo",
-      "orden": 560,
+      "orden": 555,
       "estado": "publicada",
       "concepto": "La mitad de arriba quedó lisa como si nunca hubiera soplado el viento, y la de abajo guarda catorce olas que se formaron esa misma tarde.",
       "anio": 2025,
@@ -17307,7 +17160,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-a1db1804-1",
       "serie": "archivo",
-      "orden": 561,
+      "orden": 556,
       "estado": "publicada",
       "concepto": "Arriba giran nueve anillos completos y abajo la arena se extiende en una sola ola ancha, y entre las dos mitades no cae ni un grano de más.",
       "anio": 2025,
@@ -17338,7 +17191,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-ab31399b-1",
       "serie": "archivo",
-      "orden": 562,
+      "orden": 557,
       "estado": "publicada",
       "concepto": "Dos espirales se cruzan formando una malla de veinte hilos, y ninguno se rompe aunque el círculo entero no deje de girar en direcciones opuestas.",
       "anio": 2025,
@@ -17369,7 +17222,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b47420a9-1",
       "serie": "archivo",
-      "orden": 563,
+      "orden": 558,
       "estado": "publicada",
       "concepto": "La tapa de arriba y el cuenco de abajo llevan catorce líneas cada uno y encajan tan justo que ni la línea negra que los separa se mueve.",
       "anio": 2025,
@@ -17400,7 +17253,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b8e33fb5-1",
       "serie": "archivo",
-      "orden": 564,
+      "orden": 559,
       "estado": "publicada",
       "concepto": "El sol amarillo se sienta justo en la cresta de la montaña azul y ahí se queda, sin subir ni bajar, desde la primera vez que alguien miró hacia el oeste.",
       "anio": 2025,
@@ -17431,7 +17284,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-b8e33fb5-2",
       "serie": "archivo",
-      "orden": 565,
+      "orden": 560,
       "estado": "publicada",
       "concepto": "La esfera pierde su forma grano a grano y en el suelo se acomoda en diez círculos perfectos, como si llevara cayendo despacio desde hace un siglo.",
       "anio": 2025,
@@ -17462,7 +17315,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-bdd5c1a6-1",
       "serie": "archivo",
-      "orden": 566,
+      "orden": 561,
       "estado": "publicada",
       "concepto": "Dentro del círculo caben veinte olas de arena exactas y ninguna se sale del borde, aunque el viento sople siempre hacia el mismo lado.",
       "anio": 2025,
@@ -17493,7 +17346,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-bdd5c1a6-3",
       "serie": "archivo",
-      "orden": 567,
+      "orden": 562,
       "estado": "publicada",
       "concepto": "Dos espirales doradas flotan sobre una malla azul de mil celdas iguales y giran cada una a su ritmo sin chocar nunca entre ellas.",
       "anio": 2025,
@@ -17524,7 +17377,7 @@
     {
       "slug": "organic-flowing-logo-for-curiana-radio-three-mai-e43a51dc-1",
       "serie": "archivo",
-      "orden": 568,
+      "orden": 563,
       "estado": "publicada",
       "concepto": "El caparazón guarda catorce vueltas apretadas y descansa sobre una arena que se curva en las mismas líneas, como si el cielo entero girara alrededor de esa sola pieza.",
       "anio": 2025,
@@ -17554,7 +17407,7 @@
     {
       "slug": "painting-of-a-demon-having-his-eyes-on-3a24e9ed-0",
       "serie": "archivo",
-      "orden": 569,
+      "orden": 564,
       "estado": "publicada",
       "concepto": "Le crecen tres ojos y ninguno parpadea, y las llamas rojas que la rodean llevan ardiendo alrededor de su cabeza desde antes de que existiera la primera sombra.",
       "anio": 2025,
@@ -17584,7 +17437,7 @@
     {
       "slug": "painting-of-a-spaceship-going-through-a-spacial-08a32afd-0",
       "serie": "archivo",
-      "orden": 570,
+      "orden": 565,
       "estado": "publicada",
       "concepto": "La nave atraviesa un remolino partido en dos colores, naranja de un lado y azul del otro, y vuela en línea recta sin que ninguno de los dos la alcance.",
       "anio": 2025,
@@ -17615,7 +17468,7 @@
     {
       "slug": "painting-of-a-spaceship-going-through-a-spacial-504ec514-0",
       "serie": "archivo",
-      "orden": 571,
+      "orden": 566,
       "estado": "publicada",
       "concepto": "El arco de red blanca cruza el cielo entero en una sola curva, y bajo él el campo morado sigue sus surcos exactos, sin torcerse un grado, hacia el horizonte rojo.",
       "anio": 2025,
@@ -17646,7 +17499,7 @@
     {
       "slug": "panorama-of-a-pintoresque-scene-a-young-couple-99e1b4fc-1",
       "serie": "archivo",
-      "orden": 572,
+      "orden": 567,
       "estado": "publicada",
       "concepto": "El jinete cruza frente al caserío al paso lento del caballo, y la sombra de los dos dura lo mismo que tarda el sol en cambiar de lado del techo de paja.",
       "anio": 2025,
@@ -17677,7 +17530,7 @@
     {
       "slug": "panorama-of-a-pintoresque-scene-a-young-couple-b8489318-2",
       "serie": "archivo",
-      "orden": 573,
+      "orden": 568,
       "estado": "publicada",
       "concepto": "El burro trota bajo una luna tan redonda y tan llena que parece haberse detenido solo para alumbrarle el camino hasta la casa con las luces encendidas.",
       "anio": 2025,
@@ -17708,7 +17561,7 @@
     {
       "slug": "panorama-of-a-pintoresque-scene-of-a-quintet-6debf54a-0",
       "serie": "archivo",
-      "orden": 574,
+      "orden": 569,
       "estado": "publicada",
       "concepto": "Cuelgan bombillos de palmera en palmera hasta cercar el palenque de luz, y la luna se sienta a escuchar en primera fila, junto a los que llegaron con sillas propias.",
       "anio": 2025,
@@ -17739,7 +17592,7 @@
     {
       "slug": "panorama-of-a-pintoresque-scene-of-a-quintet-d94dcb7c-2",
       "serie": "archivo",
-      "orden": 575,
+      "orden": 570,
       "estado": "publicada",
       "concepto": "Hilos de luces cruzan la enramada de extremo a extremo hasta fabricarle un cielo propio, y los cinco sombreros se inclinan hacia las cuerdas sin que ninguno alce la vista para comprobarlo.",
       "anio": 2025,
@@ -17770,7 +17623,7 @@
     {
       "slug": "panoramic-and-cinematic-movie-still-depiction-of-a0f3cf50-2",
       "serie": "archivo",
-      "orden": 576,
+      "orden": 571,
       "estado": "publicada",
       "concepto": "Sostiene una esfera de oro contra la cadera con la misma firmeza con que el otro sostiene la espada, y ninguno de los dos la suelta aunque el cielo se les oscurezca encima.",
       "anio": 2025,
@@ -17801,7 +17654,7 @@
     {
       "slug": "panoramic-and-cinematic-movie-still-depiction-of-a0f3cf50-3",
       "serie": "archivo",
-      "orden": 577,
+      "orden": 572,
       "estado": "publicada",
       "concepto": "Una cruz de metal le cubre el pecho, y al otro un incendio de plumas rojas le corona la cabeza, quietos los dos aunque el viento suba desde la colina.",
       "anio": 2025,
@@ -17832,7 +17685,7 @@
     {
       "slug": "panoramic-view-a-canoe-rests-in-the-shore-391c9cc2-3",
       "serie": "archivo",
-      "orden": 578,
+      "orden": 573,
       "estado": "publicada",
       "concepto": "Entre las piedras de la orilla, la canoa lleva tanto tiempo varada que la marea se ha corrido cien metros mar adentro, y las dos personas que caminan la orilla parecen no haberlo notado todavía.",
       "anio": 2025,
@@ -17863,7 +17716,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-25cbccf8-1",
       "serie": "archivo",
-      "orden": 579,
+      "orden": 574,
       "estado": "publicada",
       "concepto": "Se sienta de espaldas al pueblo de palafitos con las líneas del cuerpo recién pintadas, y el sol tarda tanto en secarlas que los otros ya llevan rato nadando cuando ella no se mueve.",
       "anio": 2025,
@@ -17894,7 +17747,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-25cbccf8-2",
       "serie": "archivo",
-      "orden": 580,
+      "orden": 575,
       "estado": "publicada",
       "concepto": "Entre ella y el grupo que nada hay veinte brazadas exactas de agua color té, y las casas de paja se alinean detrás como si custodiaran cada metro de esa distancia.",
       "anio": 2025,
@@ -17925,7 +17778,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-44fff746-1",
       "serie": "archivo",
-      "orden": 581,
+      "orden": 576,
       "estado": "publicada",
       "concepto": "Los rayos caen tan rectos sobre el canal que parecen postes de luz clavados desde el cielo, y la única canoa que cruza arrastra tras de sí todos los colores del agua.",
       "anio": 2025,
@@ -17956,7 +17809,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-44fff746-3",
       "serie": "archivo",
-      "orden": 582,
+      "orden": 577,
       "estado": "publicada",
       "concepto": "Se parte la fotografía justo en la línea del agua, y bajo esa costura de burbujas los mismos postes sostienen el caserío por abajo sin que nadie arriba lo note.",
       "anio": 2025,
@@ -17987,7 +17840,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-46b16266-1",
       "serie": "archivo",
-      "orden": 583,
+      "orden": 578,
       "estado": "publicada",
       "concepto": "Desde la sombra de la colina se cuentan más de treinta techos de paja apretados sobre el agua, y la única canoa que se mueve entre todos ellos tarda una eternidad en cruzarlos.",
       "anio": 2025,
@@ -18018,7 +17871,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-46b16266-2",
       "serie": "archivo",
-      "orden": 584,
+      "orden": 579,
       "estado": "publicada",
       "concepto": "Avanza tan despacio la niebla sobre la laguna que ya se comió la mitad de los techos del fondo, y solo los más cercanos a la orilla alcanzan a asomar la punta.",
       "anio": 2025,
@@ -18049,7 +17902,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-4771b1a7-0",
       "serie": "archivo",
-      "orden": 585,
+      "orden": 580,
       "estado": "publicada",
       "concepto": "La pasarela de tablas tuerce tres veces antes de llegar a la puerta, como si la casa de techo dorado no quisiera dejarse encontrar por cualquiera que camine derecho.",
       "anio": 2025,
@@ -18080,7 +17933,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-6ab28b3f-3",
       "serie": "archivo",
-      "orden": 586,
+      "orden": 581,
       "estado": "publicada",
       "concepto": "Cae el rayo de luz tan preciso sobre el muelle que parece medido con regla, y las dos que llevan rojo no dan ni medio paso fuera de esa columna.",
       "anio": 2025,
@@ -18111,7 +17964,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-7df7f9c2-0",
       "serie": "archivo",
-      "orden": 587,
+      "orden": 582,
       "estado": "publicada",
       "concepto": "Cada choza de la fila se pinta la puerta de un rojo distinto, y el agua, partida en dos por la fotografía, repite las mismas puertas boca abajo sin equivocarse de color ni una vez.",
       "anio": 2025,
@@ -18142,7 +17995,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-9454aa5a-1",
       "serie": "archivo",
-      "orden": 588,
+      "orden": 583,
       "estado": "publicada",
       "concepto": "Vistos desde arriba, los techos se aprietan tanto unos contra otros que apenas dejan un hilo de agua libre, y por ese hilo exacto avanza la única canoa de todo el poblado.",
       "anio": 2025,
@@ -18173,7 +18026,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-955996eb-3",
       "serie": "archivo",
-      "orden": 589,
+      "orden": 584,
       "estado": "publicada",
       "concepto": "El canal central es tan ancho que los techos de los dos lados apenas se rozan con la niebla, y el bote que lo cruza parece la única cosa en kilómetros que sabe adónde va.",
       "anio": 2025,
@@ -18204,7 +18057,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-9702d5d6-3",
       "serie": "archivo",
-      "orden": 590,
+      "orden": 585,
       "estado": "publicada",
       "concepto": "Rema de espaldas a la cámara sin saber que la fotografía le corta el mundo justo a la altura del agua, y bajo su canoa las mismas casas repiten los postes como si fueran raíces.",
       "anio": 2025,
@@ -18235,7 +18088,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-9c382ad4-0",
       "serie": "archivo",
-      "orden": 591,
+      "orden": 586,
       "estado": "publicada",
       "concepto": "Los botes que cruzan el canal a la vez se pierden de la cuenta antes de llegar a la última choza, con montañas veladas al fondo bajo el mismo sol de todos.",
       "anio": 2025,
@@ -18266,7 +18119,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-b417955e-0",
       "serie": "archivo",
-      "orden": 592,
+      "orden": 587,
       "estado": "publicada",
       "concepto": "Copia el agua cada techo con tanta exactitud que hacen falta los botes, únicos que se mueven, para saber cuál mitad de la simetría es la de verdad.",
       "anio": 2025,
@@ -18297,7 +18150,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-b4d0daa4-0",
       "serie": "archivo",
-      "orden": 593,
+      "orden": 588,
       "estado": "publicada",
       "concepto": "El techo más grande de todos junta a su gente en la base, como si fuera el único que diera sombra de verdad, mientras los demás, más lejos, se quedan sin nadie cerca.",
       "anio": 2025,
@@ -18328,7 +18181,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-b4d0daa4-3",
       "serie": "archivo",
-      "orden": 594,
+      "orden": 589,
       "estado": "publicada",
       "concepto": "De todo el pueblo solo quedan encendidas las ventanas, una hilera de puntos amarillos flotando en la niebla azul, y la canoa vacía del primer plano parece llevar horas esperando a que alguna se apague.",
       "anio": 2025,
@@ -18359,7 +18212,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-debc367b-1",
       "serie": "archivo",
-      "orden": 595,
+      "orden": 590,
       "estado": "publicada",
       "concepto": "La choza se queda entera del lado seco de la fotografía, y del otro lado, bajo el agua, cinco pares de piernas esperan de pie sobre una pasarela que el mar no deja salir.",
       "anio": 2025,
@@ -18390,7 +18243,7 @@
     {
       "slug": "panoramic-view-of-a-city-of-stilt-houses-debc367b-3",
       "serie": "archivo",
-      "orden": 596,
+      "orden": 591,
       "estado": "publicada",
       "concepto": "Le sale la sombra más larga que el muelle mismo, alargándose sobre las tablas mientras camina hacia las casas de paja que ya se encienden de azul con la caída de la tarde.",
       "anio": 2025,
@@ -18421,7 +18274,7 @@
     {
       "slug": "panoramic-view-of-hundreds-of-space-74295479-1",
       "serie": "archivo",
-      "orden": 597,
+      "orden": 592,
       "estado": "publicada",
       "concepto": "La mitad del cielo se vuelve roja de golpe justo donde termina la nave grande, y ninguna de las que la escoltan cruza esa frontera exacta entre el negro y el óxido.",
       "anio": 2025,
@@ -18452,7 +18305,7 @@
     {
       "slug": "panoramic-view-of-the-battle-of-cara-8c72e9f0-0",
       "serie": "archivo",
-      "orden": 598,
+      "orden": 593,
       "estado": "publicada",
       "concepto": "Cruzan el valle al galope cientos de jinetes con los sables ya desenvainados, y el humo de la pólvora sube tan alto que empieza a confundirse con las nubes que cubren la montaña del fondo.",
       "anio": 2025,
@@ -18484,7 +18337,7 @@
     {
       "slug": "panoramic-view-of-the-battle-of-cara-8c72e9f0-2",
       "serie": "archivo",
-      "orden": 599,
+      "orden": 594,
       "estado": "publicada",
       "concepto": "Los jinetes bajan la colina con tanta prisa que la hierba tarda tres días en levantarse otra vez.",
       "anio": 2025,
@@ -18516,7 +18369,7 @@
     {
       "slug": "panoramic-view-of-the-battle-of-cara-959f30d9-0",
       "serie": "archivo",
-      "orden": 600,
+      "orden": 595,
       "estado": "publicada",
       "concepto": "Bajan tantos caballos por la ladera que el polvo tarda una hora entera en decidir si es nube o es humo de cañón.",
       "anio": 2025,
@@ -18547,7 +18400,7 @@
     {
       "slug": "panoramic-view-of-the-battle-of-carabobo-the-8606b895-1",
       "serie": "archivo",
-      "orden": 601,
+      "orden": 596,
       "estado": "publicada",
       "concepto": "La ladera se llena de tantos jinetes que, desde la cima, ya no se cuenta gente: se cuenta hectáreas.",
       "anio": 2025,
@@ -18578,7 +18431,7 @@
     {
       "slug": "panoramic-view-of-the-battle-of-carabobo-the-8606b895-3",
       "serie": "archivo",
-      "orden": 602,
+      "orden": 597,
       "estado": "publicada",
       "concepto": "Apenas alcanza la luz de la tarde a tocar los techos del pueblo en el valle, antes de que el humo de la colina la alcance y se la trague entera.",
       "anio": 2025,
@@ -18609,7 +18462,7 @@
     {
       "slug": "photo-of-pink-clouds-depicting-the-form-of-85614378-1",
       "serie": "archivo",
-      "orden": 603,
+      "orden": 598,
       "estado": "publicada",
       "concepto": "La espuma de la ola sube tan alto y tan rosada que por un segundo nadie sabe si el mar rompe contra la arena o contra el cielo.",
       "anio": 2025,
@@ -18640,7 +18493,7 @@
     {
       "slug": "photograph-of-a-panoramic-view-in-outer-space-6a25e6b6-2",
       "serie": "archivo",
-      "orden": 604,
+      "orden": 599,
       "estado": "publicada",
       "concepto": "Tantas naves escoltan al planeta ocre que ya ni los asteroides encuentran hueco para pasar entre ellas.",
       "anio": 2025,
@@ -18671,7 +18524,7 @@
     {
       "slug": "photograph-of-a-panoramic-view-in-outer-space-6a25e6b6-3",
       "serie": "archivo",
-      "orden": 605,
+      "orden": 600,
       "estado": "publicada",
       "concepto": "Vuelan tan cerca del planeta las naves que se les alcanzan a contar los cráteres antes de virar rumbo a las estrellas.",
       "anio": 2025,
@@ -18702,7 +18555,7 @@
     {
       "slug": "photograph-of-a-panoramic-view-in-outer-space-c1c49a7f-1",
       "serie": "archivo",
-      "orden": 606,
+      "orden": 601,
       "estado": "publicada",
       "concepto": "El planeta rojo del centro cabe tan chico entre las naves que parece una brasa que se les apagó en medio del vuelo.",
       "anio": 2025,
@@ -18733,7 +18586,7 @@
     {
       "slug": "photograph-of-a-scene-of-the-sillouette-of-a7889354-1",
       "serie": "archivo",
-      "orden": 607,
+      "orden": 602,
       "estado": "publicada",
       "concepto": "Cae tan preciso el disco de luz del techo sobre el escritorio que el polvo del aire tarda toda la noche en cruzarlo de lado a lado.",
       "anio": 2025,
@@ -18764,7 +18617,7 @@
     {
       "slug": "photograph-of-a-scene-of-the-sillouette-of-a7889354-3",
       "serie": "archivo",
-      "orden": 608,
+      "orden": 603,
       "estado": "publicada",
       "concepto": "La sombra con forma de nube se queda pegada a la pared toda la noche mientras los dos hombres, iluminados solo por las pantallas, ni se giran a mirarla.",
       "anio": 2025,
@@ -18795,7 +18648,7 @@
     {
       "slug": "photograph-of-a-scene-of-the-sillouette-of-c224da8e-1",
       "serie": "archivo",
-      "orden": 609,
+      "orden": 604,
       "estado": "publicada",
       "concepto": "Cuelga medio suelto del techo el panel de luz, y aun así ilumina lo bastante para que el hombre cruce solo, sin tropezar, ocho oficinas vacías.",
       "anio": 2025,
@@ -18826,7 +18679,7 @@
     {
       "slug": "photorealistic-b9cd4ac8-3",
       "serie": "archivo",
-      "orden": 610,
+      "orden": 605,
       "estado": "publicada",
       "concepto": "Tanto sube la espuma por la bañera que ya empieza a treparse por los azulejos negros, buscando salida antes de que cierren el grifo.",
       "anio": 2025,
@@ -18857,7 +18710,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-0455d116-2",
       "serie": "archivo",
-      "orden": 611,
+      "orden": 606,
       "estado": "publicada",
       "concepto": "Los cántaros de barro se le acomodan alrededor tan pegados que la sombra del cuarto no encuentra ni una rendija para colarse entre ellos.",
       "anio": 2025,
@@ -18888,7 +18741,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-a7d49a8b-3",
       "serie": "archivo",
-      "orden": 612,
+      "orden": 607,
       "estado": "publicada",
       "concepto": "Brillan más azules las flores pintadas en los floreros que la propia luz del cuarto, como si hubieran guardado el color del día para gastarlo de noche.",
       "anio": 2025,
@@ -18919,7 +18772,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-0",
       "serie": "archivo",
-      "orden": 613,
+      "orden": 608,
       "estado": "publicada",
       "concepto": "La olla negra ocupa tanto sitio en la penumbra que se le adelanta a la propia mujer, y es lo primero que encuentra la poca luz que entra.",
       "anio": 2025,
@@ -18950,7 +18803,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-1",
       "serie": "archivo",
-      "orden": 614,
+      "orden": 609,
       "estado": "publicada",
       "concepto": "Devuelve tanta luz en la oscuridad el esmalte azul de los cántaros que parece que fueran ellos los que alumbran el cuarto y no al revés.",
       "anio": 2025,
@@ -18981,7 +18834,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-c6a7a19e-2",
       "serie": "archivo",
-      "orden": 615,
+      "orden": 610,
       "estado": "publicada",
       "concepto": "Las dos tinajas lo flanquean tan grandes que, entre la luz roja de una y la azul de la otra, el hombre del medio no termina de decidir de qué color es la noche.",
       "anio": 2025,
@@ -19012,7 +18865,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-ceramic-a-eebb890b-2",
       "serie": "archivo",
-      "orden": 616,
+      "orden": 611,
       "estado": "publicada",
       "concepto": "Del cántaro que amasa con las manos sube un hilo de humo tan delgado que se le enreda en la vincha antes de perderse hacia el techo de piedra.",
       "anio": 2025,
@@ -19043,7 +18896,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-palafitte-6bee269a-3",
       "serie": "archivo",
-      "orden": 617,
+      "orden": 612,
       "estado": "publicada",
       "concepto": "La proa de la canoa apunta tan derecho hacia las casas de paja que el agua no se atreve a moverse un centímetro, no sea que le tuerza el rumbo.",
       "anio": 2025,
@@ -19074,7 +18927,7 @@
     {
       "slug": "photorealistic-portrayal-of-indigenous-palafitte-93c41bf1-3",
       "serie": "archivo",
-      "orden": 618,
+      "orden": 613,
       "estado": "publicada",
       "concepto": "Se inclina tanto sobre el agua azul que las casas de paja del fondo, del techo a los pilotes, se le reflejan completas justo entre las manos.",
       "anio": 2025,
@@ -19105,7 +18958,7 @@
     {
       "slug": "pixel-art-lanscape-photograph-of-rio-de-janeiro-42afcc3d-2",
       "serie": "archivo",
-      "orden": 619,
+      "orden": 614,
       "estado": "publicada",
       "concepto": "La estatua de brazos abiertos en la cima ve encender la ciudad entera casa por casa, antes de que la primera luz de la bahía le llegue a los pies.",
       "anio": 2025,
@@ -19136,7 +18989,7 @@
     {
       "slug": "pixelart-of-scene-with-a-caqueto-boy-in-aaf09862-0",
       "serie": "archivo",
-      "orden": 620,
+      "orden": 615,
       "estado": "publicada",
       "concepto": "Se le tiñen de rosa las plumas del tocado antes que el agua, y para cuando el sol termina de hundirse ya no hay forma de saber dónde acaba su plumaje y empieza el cielo.",
       "anio": 2025,
@@ -19166,7 +19019,7 @@
     {
       "slug": "police-man-incuring-in-a-trafficc-stop-in-35486a22-0",
       "serie": "archivo",
-      "orden": 621,
+      "orden": 616,
       "estado": "publicada",
       "concepto": "Las líneas de luz corren tan rápido hacia el mismo punto que si alguien se asomara al centro exacto, no vería nada, porque ahí la velocidad ya se comió hasta el fondo.",
       "anio": 2025,
@@ -19197,7 +19050,7 @@
     {
       "slug": "police-man-incuring-in-a-trafficc-stop-in-6c60b2b4-0",
       "serie": "archivo",
-      "orden": 622,
+      "orden": 617,
       "estado": "publicada",
       "concepto": "Le pasan tan pegadas a la carrocería roja las estelas de luz blanca que el carro parece quieto en medio de una carretera que sí se mueve.",
       "anio": 2025,
@@ -19228,7 +19081,7 @@
     {
       "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-0",
       "serie": "archivo",
-      "orden": 623,
+      "orden": 618,
       "estado": "publicada",
       "concepto": "La luna rosada se le refleja entera en la máscara de gas, tan grande que las pirámides del fondo le caben enteras en el cristal del visor.",
       "anio": 2025,
@@ -19259,7 +19112,7 @@
     {
       "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-2",
       "serie": "archivo",
-      "orden": 624,
+      "orden": 619,
       "estado": "publicada",
       "concepto": "Se detiene junto al auto cuyas luces traseras encienden trescientas líneas rojas, y la ciudad entera se apaga un segundo para dejarlas brillar solas.",
       "anio": 2025,
@@ -19290,7 +19143,7 @@
     {
       "slug": "police-man-incuring-in-a-trafficc-stop-in-9e2c2ffa-3",
       "serie": "archivo",
-      "orden": 625,
+      "orden": 620,
       "estado": "publicada",
       "concepto": "La lluvia cae tan despacio sobre el asfalto que cada gota alcanza a robarle el color a los cien letreros de neón antes de tocar el suelo.",
       "anio": 2025,
@@ -19321,7 +19174,7 @@
     {
       "slug": "portrait-a-young-latinoamerican-goths-vampire-in-bcf7c3d6-0",
       "serie": "archivo",
-      "orden": 626,
+      "orden": 621,
       "estado": "publicada",
       "concepto": "Las cadenas que le cruzan el pecho pesan lo mismo que el candelabro de hierro que cuelga en medio del cuarto rosado, y aun así camina como si no cargara ninguna de las dos.",
       "anio": 2025,
@@ -19352,7 +19205,7 @@
     {
       "slug": "product-shot-of-a-tin-foil-paper-origami-d2226670-0",
       "serie": "archivo",
-      "orden": 627,
+      "orden": 622,
       "estado": "publicada",
       "concepto": "Cada pliegue de este papel de aluminio guarda un rayo distinto, y el unicornio junta tantos que parece que se hubiera tragado el sol entero de la mesa de estudio.",
       "anio": 2025,
@@ -19383,7 +19236,7 @@
     {
       "slug": "prompt-early-11th-century-medieval-spain-a-figur-a083fe8f-0",
       "serie": "archivo",
-      "orden": 628,
+      "orden": 623,
       "estado": "publicada",
       "concepto": "Asoma un solo ojo por la grieta de la roca, y ese ojo lleva mirando tanto tiempo el mismo camino de piedra que ha aprendido a contar cada grano de la caliza.",
       "anio": 2025,
@@ -19413,7 +19266,7 @@
     {
       "slug": "prompt-early-11th-century-medieval-spain-a-figur-a083fe8f-3",
       "serie": "archivo",
-      "orden": 629,
+      "orden": 624,
       "estado": "publicada",
       "concepto": "El manto negro le cubre hasta los pies dentro de la grieta de piedra, y es tan largo que la roca entera parece haber crecido alrededor para no dejarlo salir.",
       "anio": 2025,
@@ -19443,7 +19296,7 @@
     {
       "slug": "psycodelic-cover-art-of-a-internal-dialog-titled-4b5ac5f3-2",
       "serie": "archivo",
-      "orden": 630,
+      "orden": 625,
       "estado": "publicada",
       "concepto": "De la piel agrietada del rostro se desprenden los mismos asteroides que flotan detrás, como si cada cráter del espacio hubiera nacido primero en esta cara.",
       "anio": 2025,
@@ -19474,7 +19327,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-0",
       "serie": "archivo",
-      "orden": 631,
+      "orden": 626,
       "estado": "publicada",
       "concepto": "Un camino de tierra roja se abre entre las montañas moradas hasta perderse justo debajo de la luna verde, que lleva ahí tanto tiempo como el perfil que la mira.",
       "anio": 2025,
@@ -19505,7 +19358,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-1",
       "serie": "archivo",
-      "orden": 632,
+      "orden": 627,
       "estado": "publicada",
       "concepto": "El agua turquesa se detiene justo a la altura de los ojos, congelada a mitad de una ola que lleva minutos, o años, sin terminar de caer sobre el resto de la cara.",
       "anio": 2025,
@@ -19536,7 +19389,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-2",
       "serie": "archivo",
-      "orden": 633,
+      "orden": 628,
       "estado": "publicada",
       "concepto": "Del cabello rizado le sale un humo de rayas azules, verdes y amarillas que sube en zigzag y parte el cielo en dos mitades, una roja y una morada, sin que él baje la vista.",
       "anio": 2025,
@@ -19567,7 +19420,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-51a1b113-3",
       "serie": "archivo",
-      "orden": 634,
+      "orden": 629,
       "estado": "publicada",
       "concepto": "El coral turquesa le crece pegado a la mejilla y el coral rosado le corona la frente, sin dejarle a la cara más espacio libre que el necesario para mirar al cielo.",
       "anio": 2025,
@@ -19598,7 +19451,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-6c4c92b9-0",
       "serie": "archivo",
-      "orden": 635,
+      "orden": 630,
       "estado": "publicada",
       "concepto": "Tres lunas distintas se le quedaron prendidas en los rizos y ninguna pesa lo suficiente como para caer, aunque el cráneo entero arda en franjas rojas y naranjas como si fuera otro sol.",
       "anio": 2025,
@@ -19629,7 +19482,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-6c4c92b9-2",
       "serie": "archivo",
-      "orden": 636,
+      "orden": 631,
       "estado": "publicada",
       "concepto": "Se sienta de perfil frente a una cordillera azul mientras las nubes rosadas hierven encima, tan despacio que en el tiempo que tarda en girar la cabeza no han cambiado de forma.",
       "anio": 2025,
@@ -19660,7 +19513,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-98e50575-1",
       "serie": "archivo",
-      "orden": 637,
+      "orden": 632,
       "estado": "publicada",
       "concepto": "Detrás de él se abre una ventana perfectamente redonda con un desierto entero adentro, dunas y luna incluidas, y las mismas estrellas que ya brillan afuera vuelven a brillar ahí dentro.",
       "anio": 2025,
@@ -19691,7 +19544,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-c1a4acd8-0",
       "serie": "archivo",
-      "orden": 638,
+      "orden": 633,
       "estado": "publicada",
       "concepto": "De espaldas, mira un mar entero de dunas verdosas que no tienen agua ni la necesitan, porque una nube anaranjada hace de sol y nadie en el paisaje extraña el océano.",
       "anio": 2025,
@@ -19722,7 +19575,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-c1a4acd8-3",
       "serie": "archivo",
-      "orden": 639,
+      "orden": 634,
       "estado": "publicada",
       "concepto": "Miles de puntos diminutos se ordenan en círculos perfectos detrás de la cabeza, como si el cielo entero se hubiera puesto de acuerdo para peinarse alrededor de la cara que mira hacia arriba.",
       "anio": 2025,
@@ -19753,7 +19606,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-d70059ab-3",
       "serie": "archivo",
-      "orden": 640,
+      "orden": 635,
       "estado": "publicada",
       "concepto": "Una sombra a rayas le cruza media cara como si hubiera atravesado una persiana de neón, y detrás los rayos de colores se abren en abanico sin encontrar nunca el mismo punto de fuga.",
       "anio": 2025,
@@ -19784,7 +19637,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-e6626d20-1",
       "serie": "archivo",
-      "orden": 641,
+      "orden": 636,
       "estado": "publicada",
       "concepto": "Se sienta con las piernas cruzadas en el fondo de un túnel de tierra, y arriba, del tamaño justo de una moneda lejana, un círculo de estrellas es la única salida posible.",
       "anio": 2025,
@@ -19815,7 +19668,7 @@
     {
       "slug": "psycodelic-scene-of-a-man-in-deep-internal-e6626d20-3",
       "serie": "archivo",
-      "orden": 642,
+      "orden": 637,
       "estado": "publicada",
       "concepto": "Una escalera dorada se mete de lleno en un túnel hecho de anillos rojos concéntricos, y cada anillo es un escalón de luz distinto que el hombre de perfil aún no decide si bajar.",
       "anio": 2025,
@@ -19846,7 +19699,7 @@
     {
       "slug": "pulp-image-of-high-tech-room-with-a-20753a3a-1",
       "serie": "archivo",
-      "orden": 643,
+      "orden": 638,
       "estado": "publicada",
       "concepto": "Duerme metido dentro de un anillo de luz roja que le rodea la cabeza como un halo de taller, mientras una decena de cables se le enroscan en las piernas sin llegar nunca a despertarlo.",
       "anio": 2025,
@@ -19877,7 +19730,7 @@
     {
       "slug": "pulp-image-of-high-tech-room-with-a-f22e2dee-0",
       "serie": "archivo",
-      "orden": 644,
+      "orden": 639,
       "estado": "publicada",
       "concepto": "En la pared cuelga un sol rojo del tamaño de un puño mientras la pantalla del monitor escupe estática sin parar, y el hombre de bata blanca espera a que alguno hable primero.",
       "anio": 2025,
@@ -19908,7 +19761,7 @@
     {
       "slug": "pulp-image-of-high-tech-room-with-a-f22e2dee-3",
       "serie": "archivo",
-      "orden": 645,
+      "orden": 640,
       "estado": "publicada",
       "concepto": "Un anillo rojo rodea un agujero negro perfecto que flota sobre el mar, y el hombre de bata blanca sigue de espaldas a la computadora como si ese eclipse llevara ahí colgado toda la vida.",
       "anio": 2025,
@@ -19939,7 +19792,7 @@
     {
       "slug": "real-life-portrayal-of-indigenous-palafittes-tow-0f4debfd-1",
       "serie": "archivo",
-      "orden": 646,
+      "orden": 641,
       "estado": "publicada",
       "concepto": "Doce pelícanos se reparten la orilla de arena frente a las casas de paja sobre pilotes, y arriba vuelan cuatro más, citados ahí desde antes de que se levantara el primer techo.",
       "anio": 2025,
@@ -19970,7 +19823,7 @@
     {
       "slug": "real-life-portrayal-of-indigenous-palafittes-tow-0f4debfd-2",
       "serie": "archivo",
-      "orden": 647,
+      "orden": 642,
       "estado": "publicada",
       "concepto": "Una hilera de pelícanos vadea el agua justo entre los pilotes de las casas de paja, tan pegados unos a otros que de lejos parecen una sola ave con veinte cabezas.",
       "anio": 2025,
@@ -20001,7 +19854,7 @@
     {
       "slug": "real-life-portrayal-of-indigenous-palafittes-tow-87cb74eb-2",
       "serie": "archivo",
-      "orden": 648,
+      "orden": 643,
       "estado": "publicada",
       "concepto": "Una sola canoa cruza el canal de agua entre las casas de palafito y el manglar, y el remo deja un único círculo en el agua que tarda más en desvanecerse que la canoa.",
       "anio": 2025,
@@ -20032,7 +19885,7 @@
     {
       "slug": "real-life-portrayal-of-indigenous-palafittes-tow-e2262b4a-0",
       "serie": "archivo",
-      "orden": 649,
+      "orden": 644,
       "estado": "publicada",
       "concepto": "Las nubes se enroscan en la misma punta que los techos de paja, y el remero cuenta que tardó tres tardes en distinguir cuál nube era cuál choza.",
       "anio": 2025,
@@ -20063,7 +19916,7 @@
     {
       "slug": "real-life-portrayal-of-indigenous-palafittes-tow-e2262b4a-2",
       "serie": "archivo",
-      "orden": 650,
+      "orden": 645,
       "estado": "publicada",
       "concepto": "El zócalo rojo de las casas se refleja tan fijo en el canal que el remero guía la canoa sin remo, solo siguiendo la línea de pintura en el agua.",
       "anio": 2025,
@@ -20094,7 +19947,7 @@
     {
       "slug": "realistic-and-cinematic-panoramic-view-of-an-ind-a5019004-3",
       "serie": "archivo",
-      "orden": 651,
+      "orden": 646,
       "estado": "publicada",
       "concepto": "Los puentes de madera atraviesan el poblado como venas encendidas, y siete personas cruzan a la vez sin que ninguna tabla cruja bajo su peso.",
       "anio": 2025,
@@ -20125,7 +19978,7 @@
     {
       "slug": "realistic-photography-of-a-boat-in-the-shore-2efae6ee-2",
       "serie": "archivo",
-      "orden": 652,
+      "orden": 647,
       "estado": "publicada",
       "concepto": "La pintura turquesa del casco lleva tantos años descascarándose que el pelícano posado en la proa ya se cree el capitán y no deja subir a nadie más.",
       "anio": 2025,
@@ -20156,7 +20009,7 @@
     {
       "slug": "red-alien-over-the-city-in-the-style-62939855-1",
       "serie": "archivo",
-      "orden": 653,
+      "orden": 648,
       "estado": "publicada",
       "concepto": "El sol ocupa media ciudad y la figura en la punta de la torre más alta lleva noventa años parada ahí sin que el calor le queme ni una sombra.",
       "anio": 2025,
@@ -20186,7 +20039,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-018b351d-0",
       "serie": "archivo",
-      "orden": 654,
+      "orden": 649,
       "estado": "publicada",
       "concepto": "El collar de plumas azules y verdes cubre el pecho entero, tejido con setecientas plumas cosidas una por una, mientras la barbilla queda alzada hacia un sol que todavía no sale.",
       "anio": 2025,
@@ -20216,7 +20069,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-018b351d-2",
       "serie": "archivo",
-      "orden": 655,
+      "orden": 650,
       "estado": "publicada",
       "concepto": "Catorce líneas curvas le cruzan la cara de sien a mentón, y los discos de madera que le cuelgan de las orejas pesan lo bastante para marcar el rumbo del viento cuando camina.",
       "anio": 2025,
@@ -20246,7 +20099,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-5ec1d003-1",
       "serie": "archivo",
-      "orden": 656,
+      "orden": 651,
       "estado": "publicada",
       "concepto": "Las plumas rojas y azules le crecen detrás de cada oreja como si fueran alas, y cuando gira la cabeza despacio se nota que están a punto de levantar el vuelo.",
       "anio": 2025,
@@ -20276,7 +20129,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-7fa94afc-2",
       "serie": "archivo",
-      "orden": 657,
+      "orden": 652,
       "estado": "publicada",
       "concepto": "Dos dedos de plumas rojas bastan para coronarlo, mientras las cruces verdes pintadas en el pecho tardaron una luna entera en secar bajo el peso de las conchas blancas apiladas hasta la cintura.",
       "anio": 2025,
@@ -20306,7 +20159,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-9ce7c866-0",
       "serie": "archivo",
-      "orden": 658,
+      "orden": 653,
       "estado": "publicada",
       "concepto": "El aro de oro que le atraviesa la nariz da tres vueltas, y de las nueve hileras de cuentas rojas y azules cuelgan conchas que sonarían si el viento se atreviera a soplar fuerte.",
       "anio": 2025,
@@ -20336,7 +20189,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-9ce7c866-3",
       "serie": "archivo",
-      "orden": 659,
+      "orden": 654,
       "estado": "publicada",
       "concepto": "Las ondas verdes pintadas en la cara se curvan igual que el agua del fondo azul, y el broche de madera que cierra la banda del pecho lleva atado un nudo desde hace veinte inviernos.",
       "anio": 2025,
@@ -20366,7 +20219,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-a16ea7ce-1",
       "serie": "archivo",
-      "orden": 660,
+      "orden": 655,
       "estado": "publicada",
       "concepto": "Una sola raya blanca le parte la cara al medio, trazada de un solo pulso que no tembló desde la frente hasta la punta de la barbilla.",
       "anio": 2025,
@@ -20396,7 +20249,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-b940115a-1",
       "serie": "archivo",
-      "orden": 661,
+      "orden": 656,
       "estado": "publicada",
       "concepto": "La cresta de plumas negras se eriza sobre la banda roja como si el viento empujara desde atrás desde siempre, y las hebras turquesa del collar no dejan de moverse aunque él esté quieto.",
       "anio": 2025,
@@ -20426,7 +20279,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-b940115a-3",
       "serie": "archivo",
-      "orden": 662,
+      "orden": 657,
       "estado": "publicada",
       "concepto": "Tiene los ojos cerrados y dos rayas turquesa cruzándole las mejillas, y la piel le brilla tanto de dorado que el collar de conchas parece a punto de derretirse con el calor de la tarde.",
       "anio": 2025,
@@ -20456,7 +20309,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-un-indgena-nativo-bed97181-1",
       "serie": "archivo",
-      "orden": 663,
+      "orden": 658,
       "estado": "publicada",
       "concepto": "Solo la mitad derecha de la cara recibe la luz que entra por el marco azul de la puerta, y las perlas del arete brillan tanto que parecen haber guardado ese resplandor toda la noche.",
       "anio": 2025,
@@ -20486,7 +20339,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-una-indgena-nativo-0555f135-1",
       "serie": "archivo",
-      "orden": 664,
+      "orden": 659,
       "estado": "publicada",
       "concepto": "La diadema de cuentas azules le aprieta la frente desde antes del amanecer, y las conchas que le cuelgan del cuello en seis vueltas completas resuenan apenas gira el cuello hacia la estera tejida detrás.",
       "anio": 2025,
@@ -20516,7 +20369,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-una-indgena-nativo-7f86effa-1",
       "serie": "archivo",
-      "orden": 665,
+      "orden": 660,
       "estado": "publicada",
       "concepto": "Doce anillos amarillos le envuelven el cuello uno sobre otro, y las arrugas del rostro parecen haber tardado exactamente doce inviernos en formarse, uno por anillo.",
       "anio": 2025,
@@ -20546,7 +20399,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-una-mujer-indgena-adb9a6f4-0",
       "serie": "archivo",
-      "orden": 666,
+      "orden": 661,
       "estado": "publicada",
       "concepto": "En medio de las conchas del pecho hay un disco amarillo redondo como un sol pequeño, y la raya rosada de la frente no se ha corrido un milímetro en veinte veranos de barro.",
       "anio": 2025,
@@ -20576,7 +20429,7 @@
     {
       "slug": "retrato-de-cuerpo-entero-de-una-mujer-indgena-adb9a6f4-1",
       "serie": "archivo",
-      "orden": 667,
+      "orden": 662,
       "estado": "publicada",
       "concepto": "Las dos trenzas le llegan hasta la cintura y pesan tanto de tan largas que el colgante dorado que lleva al cuello parece flotar apenas, aliviado de no ser lo más pesado que carga.",
       "anio": 2025,
@@ -20606,7 +20459,7 @@
     {
       "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-47cd527b-2",
       "serie": "archivo",
-      "orden": 668,
+      "orden": 663,
       "estado": "publicada",
       "concepto": "De cada oreja le cuelgan tres perlas del tamaño de una uña, y el rojo de los labios es el único color que se atreve a interrumpir blanco y dorado bajo la oscuridad del fondo.",
       "anio": 2025,
@@ -20636,7 +20489,7 @@
     {
       "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-aef3d91a-1",
       "serie": "archivo",
-      "orden": 669,
+      "orden": 664,
       "estado": "publicada",
       "concepto": "Racimos de conchas doradas le cuelgan de cada oreja, veinte piezas exactas, y la luz anaranjada se mete entre las hileras rojas y blancas del collar hasta hacerlas brillar como brasas.",
       "anio": 2025,
@@ -20666,7 +20519,7 @@
     {
       "slug": "retrato-de-indgena-nativo-americano-del-caribe-d-aef3d91a-3",
       "serie": "archivo",
-      "orden": 670,
+      "orden": 665,
       "estado": "publicada",
       "concepto": "El manto de tela clara le cae de un hombro y ni una arruga se atreve a moverse, mientras las cuentas azules, rojas y blancas del collar se enredan en nueve vueltas imposibles de deshacer.",
       "anio": 2025,
@@ -20696,7 +20549,7 @@
     {
       "slug": "retro-add-for-a-consulting-firm-chucao-consultor-dd4cc2ae-0",
       "serie": "archivo",
-      "orden": 671,
+      "orden": 666,
       "estado": "publicada",
       "concepto": "La corbata roja es el único objeto de toda la sala que se niega a volverse verde, mientras detrás de la ventana giran exactamente tres molinos de viento que nadie en la mesa mira.",
       "anio": 2025,
@@ -20726,7 +20579,7 @@
     {
       "slug": "retro-animation-of-an-spacestation-orbitating-on-12287928-2",
       "serie": "archivo",
-      "orden": 672,
+      "orden": 667,
       "estado": "publicada",
       "concepto": "El anillo dorado que rodea la estación completa una vuelta cada nueve segundos exactos, y la luna pequeña de la esquina lleva siglos intentando alcanzar esa misma velocidad sin lograrlo.",
       "anio": 2025,
@@ -20757,7 +20610,7 @@
     {
       "slug": "roberto-gomez-sci-fi-cover-art-in-the-2fb1301e-2",
       "serie": "archivo",
-      "orden": 673,
+      "orden": 668,
       "estado": "publicada",
       "concepto": "De la cabeza le nacen dieciséis espinas de alambre que se enroscan hacia todos lados sin terminar de decidir su forma, mientras los ojos dorados no parpadean desde que el metal se volvió piel.",
       "anio": 2025,
@@ -20788,7 +20641,7 @@
     {
       "slug": "scene-of-a-spaceship-going-through-a-spacial-4c807b3d-2",
       "serie": "archivo",
-      "orden": 674,
+      "orden": 669,
       "estado": "publicada",
       "concepto": "El motor deja una llamarada rosa tan larga que agujerea el túnel azul por el que vuela, y aún no ha terminado de cerrarse cuando la nave ya está del otro lado.",
       "anio": 2025,
@@ -20819,7 +20672,7 @@
     {
       "slug": "scene-of-a-spaceship-going-through-a-spacial-4c807b3d-3",
       "serie": "archivo",
-      "orden": 675,
+      "orden": 670,
       "estado": "publicada",
       "concepto": "Cruza el remolino de fuego con la aleta en alto, y las vetas anaranjadas tardan trescientos años en cerrarse otra vez detrás del casco plateado.",
       "anio": 2025,
@@ -20850,7 +20703,7 @@
     {
       "slug": "scene-of-argentinian-public-transport-bus-ride-a-2d4247cc-0",
       "serie": "archivo",
-      "orden": 676,
+      "orden": 671,
       "estado": "publicada",
       "concepto": "La chaqueta de camuflaje azul y ladrillo le cubre tanto el cuerpo que dos pasajeros ya lo confundieron con el asiento antes de sentarse encima.",
       "anio": 2025,
@@ -20881,7 +20734,7 @@
     {
       "slug": "scene-of-homer-singing-about-the-illyad-and-6ad819e7-0",
       "serie": "archivo",
-      "orden": 677,
+      "orden": 672,
       "estado": "publicada",
       "concepto": "Levanta un solo brazo hacia el patio de columnas y la frase que suelta tarda tres mil años en dejar de repetirse entre los hombres sentados a sus pies.",
       "anio": 2025,
@@ -20912,7 +20765,7 @@
     {
       "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-0a7391d9-0",
       "serie": "archivo",
-      "orden": 678,
+      "orden": 673,
       "estado": "publicada",
       "concepto": "Junto a la cama, las charreteras doradas de los oficiales alineados brillan más que el sol de mediodía que entra a raudales por la puerta abierta detrás de ellos.",
       "anio": 2025,
@@ -20943,7 +20796,7 @@
     {
       "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-75e515dc-0",
       "serie": "archivo",
-      "orden": 679,
+      "orden": 674,
       "estado": "publicada",
       "concepto": "Las medallas del pecho reflejan tanta luz de ventana que los dos oficiales sentados a los lados quedan medio a oscuras, esperando su turno para brillar también.",
       "anio": 2025,
@@ -20974,7 +20827,7 @@
     {
       "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-8e64f248-0",
       "serie": "archivo",
-      "orden": 680,
+      "orden": 675,
       "estado": "publicada",
       "concepto": "La mano enguantada tarda un minuto entero en cruzar el último centímetro hasta el hombro dormido, mientras los demás oficiales esperan sin moverse un pelo desde la sombra del fondo.",
       "anio": 2025,
@@ -21005,7 +20858,7 @@
     {
       "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-a4542761-3",
       "serie": "archivo",
-      "orden": 681,
+      "orden": 676,
       "estado": "publicada",
       "concepto": "El candelabro de la habitación sigue apagado porque la luz que entra por la puerta abierta ya alcanza para iluminar hasta el retrato colgado en la pared del fondo.",
       "anio": 2025,
@@ -21036,7 +20889,7 @@
     {
       "slug": "scene-of-simn-bolvar-in-his-deathbed-seen-d80aca38-3",
       "serie": "archivo",
-      "orden": 682,
+      "orden": 677,
       "estado": "publicada",
       "concepto": "La manga roja del hombre que se inclina sobre el colchón es lo único que el cuarto entero deja ver con claridad, aunque haya una decena de testigos apretados contra las paredes oscuras.",
       "anio": 2025,
@@ -21067,7 +20920,7 @@
     {
       "slug": "scene-of-simn-bolvar-on-the-deck-of-304e3660-0",
       "serie": "archivo",
-      "orden": 683,
+      "orden": 678,
       "estado": "publicada",
       "concepto": "Apoya las dos manos en la baranda de proa y el rayo que parte la nube en dos tarda un segundo entero en apagarse detrás de su silueta inmóvil.",
       "anio": 2025,
@@ -21098,7 +20951,7 @@
     {
       "slug": "scene-of-simn-bolvar-on-the-deck-of-304e3660-3",
       "serie": "archivo",
-      "orden": 684,
+      "orden": 679,
       "estado": "publicada",
       "concepto": "Abre los brazos en la cubierta y la nube que se levanta encima toma la forma exacta de la explosión anaranjada que arde todavía en el horizonte del mar.",
       "anio": 2025,
@@ -21129,7 +20982,7 @@
     {
       "slug": "scene-of-simn-bolvar-on-the-deck-of-e2ea718d-0",
       "serie": "archivo",
-      "orden": 685,
+      "orden": 680,
       "estado": "publicada",
       "concepto": "Mira la luna llena sin parpadear un solo segundo, y el poncho a rayas no se le mueve ni un hilo pese al viento verde que cruza el cielo sobre el mar picado.",
       "anio": 2025,
@@ -21160,7 +21013,7 @@
     {
       "slug": "scene-of-simn-bolvar-on-the-deck-of-e2ea718d-1",
       "serie": "archivo",
-      "orden": 686,
+      "orden": 681,
       "estado": "publicada",
       "concepto": "La trompa de agua que sube del mar es tan alta que se traga media aurora antes de que el sol termine de asomar sobre la baranda donde él se queda mirando sin moverse.",
       "anio": 2025,
@@ -21191,7 +21044,7 @@
     {
       "slug": "scene-of-the-young-man-from-argentina-is-f905279b-3",
       "serie": "archivo",
-      "orden": 687,
+      "orden": 682,
       "estado": "publicada",
       "concepto": "Al lado de la barra metálica el reflejo se parte en un arcoíris tan completo que ni la camisa a cuadros que lleva puesta consigue quedarse con un solo color.",
       "anio": 2025,
@@ -21222,7 +21075,7 @@
     {
       "slug": "scene-of-the-young-man-is-on-a-34082082-0",
       "serie": "archivo",
-      "orden": 688,
+      "orden": 683,
       "estado": "publicada",
       "concepto": "El sol de la tarde le entra de lleno por la ventanilla y le funde las rayas de la camisa con el color mostaza de la chaqueta que lleva encima de los hombros.",
       "anio": 2025,
@@ -21253,7 +21106,7 @@
     {
       "slug": "scene-of-the-young-man-is-on-a-681333a3-0",
       "serie": "archivo",
-      "orden": 689,
+      "orden": 684,
       "estado": "publicada",
       "concepto": "Las barras rojas y anaranjadas le cruzan la cara de arriba abajo tan cerca del lente que casi tapan del todo la camisa a rayas que lleva debajo.",
       "anio": 2025,
@@ -21284,7 +21137,7 @@
     {
       "slug": "scene-of-the-young-woman-from-chile-is-63444059-0",
       "serie": "archivo",
-      "orden": 690,
+      "orden": 685,
       "estado": "publicada",
       "concepto": "El neón azul y anaranjado del vagón se le mete en los rizos y por un momento parece que el propio cabello estuviera encendido desde adentro.",
       "anio": 2025,
@@ -21315,7 +21168,7 @@
     {
       "slug": "scene-of-the-young-woman-from-chile-is-d6a0a1b7-0",
       "serie": "archivo",
-      "orden": 691,
+      "orden": 686,
       "estado": "publicada",
       "concepto": "La luz dorada del techo del vagón le cae tan derecha sobre el flequillo que parece peinada por la misma lámpara que ilumina el resto del pasillo vacío.",
       "anio": 2025,
@@ -21346,7 +21199,7 @@
     {
       "slug": "scene-of-the-young-woman-is-on-a-8abe0443-1",
       "serie": "archivo",
-      "orden": 692,
+      "orden": 687,
       "estado": "publicada",
       "concepto": "El pelo rubio se le esponja contra la ventana del bus naranja hasta ocupar el mismo espacio que ella y su chaqueta de flores juntas.",
       "anio": 2025,
@@ -21377,7 +21230,7 @@
     {
       "slug": "scene-of-the-young-woman-is-on-a-dc2ff759-0",
       "serie": "archivo",
-      "orden": 693,
+      "orden": 688,
       "estado": "publicada",
       "concepto": "El abrigo marrón y peludo le ocupa tanto asiento azul vacío a los lados que nadie más se anima a sentarse en el resto del vagón.",
       "anio": 2025,
@@ -21408,7 +21261,7 @@
     {
       "slug": "scene-of-the-young-woman-is-on-a-ee5965eb-0",
       "serie": "archivo",
-      "orden": 694,
+      "orden": 689,
       "estado": "publicada",
       "concepto": "La capucha de piel rubia le cubre la cabeza entera y le suma el ancho de dos pasajeros más en un bus donde ya no cabe nadie sentado.",
       "anio": 2025,
@@ -21439,7 +21292,7 @@
     {
       "slug": "simn-bolvar-enters-the-purgatory-and-finds-dante-a8d88371-0",
       "serie": "archivo",
-      "orden": 695,
+      "orden": 690,
       "estado": "publicada",
       "concepto": "El manto rojo se le enciende de a poco a medida que camina hacia el resplandor del fondo de la cueva, mientras dos figuras iguales lo observan sin moverse desde los huecos de la roca.",
       "anio": 2025,
@@ -21470,7 +21323,7 @@
     {
       "slug": "simn-bolvar-enters-the-purgatory-and-finds-dante-a936a203-2",
       "serie": "archivo",
-      "orden": 696,
+      "orden": 691,
       "estado": "publicada",
       "concepto": "La mano se estira hacia el borde del cráter con tanta confianza que el fuego de abajo parece a punto de subir a saludarla, mientras el otro hombre no suelta la espada.",
       "anio": 2025,
@@ -21501,7 +21354,7 @@
     {
       "slug": "simn-bolvar-enters-the-purgatory-and-meets-dante-85d12035-0",
       "serie": "archivo",
-      "orden": 697,
+      "orden": 692,
       "estado": "publicada",
       "concepto": "La capa roja del jinete de adelante flamea y se lleva por delante el resplandor del volcán que revienta detrás de la fila de caballos, como si el fuego mismo la persiguiera.",
       "anio": 2025,
@@ -21532,7 +21385,7 @@
     {
       "slug": "simn-bolvar-enters-the-purgatory-and-meets-dante-85d12035-2",
       "serie": "archivo",
-      "orden": 698,
+      "orden": 693,
       "estado": "publicada",
       "concepto": "El casco negro del jinete brilla tan poco entre el pelaje rojo de los caballos que el hombre encapuchado que se acerca corriendo tiene que estirar el brazo entero para no perderlo de vista.",
       "anio": 2025,
@@ -21563,7 +21416,7 @@
     {
       "slug": "simn-diaz-with-a-llanero-hat-playing-the-3ec2e540-0",
       "serie": "archivo",
-      "orden": 699,
+      "orden": 694,
       "estado": "publicada",
       "concepto": "La luz le entra por el ala del sombrero y le tarda cuarenta años en llegar hasta las cuerdas del cuatro.",
       "anio": 2025,
@@ -21594,7 +21447,7 @@
     {
       "slug": "simn-diaz-with-a-llanero-hat-playing-the-e9b31c68-0",
       "serie": "archivo",
-      "orden": 700,
+      "orden": 695,
       "estado": "publicada",
       "concepto": "Lleva un sol pequeño detenido justo detrás de la nuca, y ni las dos torres de piedra tallada logran repartirse esa luz.",
       "anio": 2025,
@@ -21625,7 +21478,7 @@
     {
       "slug": "slice-of-life-a-blue-jaiba-in-the-5768b748-3",
       "serie": "archivo",
-      "orden": 701,
+      "orden": 696,
       "estado": "publicada",
       "concepto": "El bote azul lleva tanta agua transparente pegada al casco que desde la orilla nadie sabe si flota o si ya echó raíces en el arrecife.",
       "anio": 2025,
@@ -21656,7 +21509,7 @@
     {
       "slug": "slice-of-life-an-arepera-in-caracas-e45e87c0-0",
       "serie": "archivo",
-      "orden": 702,
+      "orden": 697,
       "estado": "publicada",
       "concepto": "Quieto detrás del mostrador se le queda el chaleco verde, mientras Caracas entera parpadea a sus espaldas, luz por luz, como si esperara turno.",
       "anio": 2025,
@@ -21687,7 +21540,7 @@
     {
       "slug": "slice-of-life-an-arepera-in-caracas-e45e87c0-1",
       "serie": "archivo",
-      "orden": 703,
+      "orden": 698,
       "estado": "publicada",
       "concepto": "El azul de la pared se come toda la calle y solo deja un rectángulo de luz cálida donde el hombre despacha su café sin apuro.",
       "anio": 2025,
@@ -21718,7 +21571,7 @@
     {
       "slug": "slice-of-life-human-interaction-in-a-3bbd9168-0",
       "serie": "archivo",
-      "orden": 704,
+      "orden": 699,
       "estado": "publicada",
       "concepto": "Le cruzan la cara líneas naranjas que imitan, sin quererlo, los pilotes que cruzan el agua, mientras el hombre de la canoa reparte naranjas como si repartiera el mismo sol.",
       "anio": 2025,
@@ -21749,7 +21602,7 @@
     {
       "slug": "slice-of-life-in-caracas-17d60dea-1",
       "serie": "archivo",
-      "orden": 705,
+      "orden": 700,
       "estado": "publicada",
       "concepto": "Cada gota que se le pega al vidrio dobla una luz de la ciudad, así que abajo no caben veinte edificios sino el doble, empañados y encendidos.",
       "anio": 2025,
@@ -21780,7 +21633,7 @@
     {
       "slug": "slice-of-life-in-caracas-17d60dea-2",
       "serie": "archivo",
-      "orden": 706,
+      "orden": 701,
       "estado": "publicada",
       "concepto": "Tanto polvo del camino se le pega al sedán azul que termina haciendo juego con el techo de paja de la bomba, como si los hubieran pintado el mismo día.",
       "anio": 2025,
@@ -21811,7 +21664,7 @@
     {
       "slug": "slice-of-life-in-caracas-17d60dea-3",
       "serie": "archivo",
-      "orden": 707,
+      "orden": 702,
       "estado": "publicada",
       "concepto": "Las dos espaldas llevan sentadas ahí el tiempo suficiente para que se les hayan encendido, una por una, las mismas luces que ahora miran allá abajo.",
       "anio": 2025,
@@ -21842,7 +21695,7 @@
     {
       "slug": "slice-of-life-in-caracas-4667fe02-1",
       "serie": "archivo",
-      "orden": 708,
+      "orden": 703,
       "estado": "publicada",
       "concepto": "Tan chiquito es el foco del quiosco que ni once torres de la ciudad, todas encendidas a la vez detrás, consiguen apagárselo.",
       "anio": 2025,
@@ -21873,7 +21726,7 @@
     {
       "slug": "slice-of-life-in-caracas-d0acdc97-2",
       "serie": "archivo",
-      "orden": 709,
+      "orden": 704,
       "estado": "publicada",
       "concepto": "El vestido de flores azules le compite en color a las naranjas que tiene al lado, y en esa mesa nadie sabría decir cuál de las dos cosas maduró primero.",
       "anio": 2025,
@@ -21904,7 +21757,7 @@
     {
       "slug": "slice-of-life-in-caracas-d0acdc97-3",
       "serie": "archivo",
-      "orden": 710,
+      "orden": 705,
       "estado": "publicada",
       "concepto": "Encendido sigue el televisor viejo en la esquina, aunque la ciudad entera, con su torre más alta incluida, se proyecte gratis y en grande por la ventana de al lado.",
       "anio": 2025,
@@ -21935,7 +21788,7 @@
     {
       "slug": "slice-of-life-in-caracas-dbe6719d-2",
       "serie": "archivo",
-      "orden": 711,
+      "orden": 706,
       "estado": "publicada",
       "concepto": "Los libros se le acumulan por los dos costados del puesto hasta taparle casi la entrada, y aun así el hombre de adentro encuentra sitio para sentarse a leer otro.",
       "anio": 2025,
@@ -21966,7 +21819,7 @@
     {
       "slug": "slice-of-life-in-caracas-dbe6719d-3",
       "serie": "archivo",
-      "orden": 712,
+      "orden": 707,
       "estado": "publicada",
       "concepto": "Tan derecho se sienta el perro blanco junto a la silla de ruedas que entre los dos parecen montar guardia igual, uno con patas y el otro con llantas.",
       "anio": 2025,
@@ -21997,7 +21850,7 @@
     {
       "slug": "slice-of-life-in-caracas-df4c31f8-3",
       "serie": "archivo",
-      "orden": 713,
+      "orden": 708,
       "estado": "publicada",
       "concepto": "Las macetas lo rodean tan apretadas que primero hay que cruzar todo un jardín colgante para llegar hasta él, y después toda la ciudad encendida para llegar hasta las montañas.",
       "anio": 2025,
@@ -22028,7 +21881,7 @@
     {
       "slug": "slice-of-life-in-paraguan-5bfefad7-2",
       "serie": "archivo",
-      "orden": 714,
+      "orden": 709,
       "estado": "publicada",
       "concepto": "Afuera, sobre una mesita junto a la puerta azul, vive el televisor, como si la señal le llegara más clara entre las macetas que dentro de la casa.",
       "anio": 2025,
@@ -22059,7 +21912,7 @@
     {
       "slug": "slice-of-life-in-paraguan-8382763d-0",
       "serie": "archivo",
-      "orden": 715,
+      "orden": 710,
       "estado": "publicada",
       "concepto": "La refinería enciende toda la orilla de enfrente con más luces de las que ellos tres necesitan para ver el vaso que tienen sobre la mesa.",
       "anio": 2025,
@@ -22090,7 +21943,7 @@
     {
       "slug": "slice-of-life-in-paraguan-8382763d-1",
       "serie": "archivo",
-      "orden": 716,
+      "orden": 711,
       "estado": "publicada",
       "concepto": "Detrás deja el carro una nube de humo tan azul que por un segundo se confunde con la última luz de la tarde que todavía baja por la calle.",
       "anio": 2025,
@@ -22121,7 +21974,7 @@
     {
       "slug": "slice-of-life-in-paraguan-8382763d-2",
       "serie": "archivo",
-      "orden": 717,
+      "orden": 712,
       "estado": "publicada",
       "concepto": "Firme se le mantiene el sombrero blanco mientras reparte comida a dos manos, como si llevara la mesa entera bajo el ala y no se le fuera a caer nada.",
       "anio": 2025,
@@ -22152,7 +22005,7 @@
     {
       "slug": "slice-of-life-in-paraguan-b196dcb9-1",
       "serie": "archivo",
-      "orden": 718,
+      "orden": 713,
       "estado": "publicada",
       "concepto": "La buganvilia le echa flores rojas a la puerta azul todo el año, y los dos hombres de las sillas ya ni levantan la vista para agradecerle la sombra.",
       "anio": 2025,
@@ -22183,7 +22036,7 @@
     {
       "slug": "slice-of-life-in-paraguan-b5876fbf-1",
       "serie": "archivo",
-      "orden": 719,
+      "orden": 714,
       "estado": "publicada",
       "concepto": "Tanto brillo le roba al sol de mediodía el verde oscuro del carro, que hasta la cal blanca de la fachada parece un poco más pálida a su lado.",
       "anio": 2025,
@@ -22214,7 +22067,7 @@
     {
       "slug": "slice-of-life-in-paraguan-d18ea9ff-3",
       "serie": "archivo",
-      "orden": 720,
+      "orden": 715,
       "estado": "publicada",
       "concepto": "El polvo dorado que flota en la luz de la tarde se le pega igual al sombrero del hombre que a la montaña de panes redondos que tiene delante.",
       "anio": 2025,
@@ -22245,7 +22098,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-32506529-2",
       "serie": "archivo",
-      "orden": 721,
+      "orden": 716,
       "estado": "publicada",
       "concepto": "Tan blancas abre las alas la garza que hasta la casa anaranjada de atrás se ve un poco más apagada mientras ella cruza el aire sobre las flores.",
       "anio": 2025,
@@ -22276,7 +22129,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-5760ecff-0",
       "serie": "archivo",
-      "orden": 722,
+      "orden": 717,
       "estado": "publicada",
       "concepto": "La sonrisa le llena tanto la cara como el arroz le llena el plato verde que tiene servido sobre la mesa de la cocina.",
       "anio": 2025,
@@ -22307,7 +22160,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-6b1ec78b-0",
       "serie": "archivo",
-      "orden": 723,
+      "orden": 718,
       "estado": "publicada",
       "concepto": "Derechito baja hasta el mar el camino de tierra roja, y esa noche trae tantas estrellas prendidas que hasta las olas parecen querer devolver algunas a la orilla.",
       "anio": 2025,
@@ -22338,7 +22191,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-6f0ba75b-2",
       "serie": "archivo",
-      "orden": 724,
+      "orden": 719,
       "estado": "publicada",
       "concepto": "Apoya el talón descalzo en la baranda blanca y desde ahí controla la marea, que no se atreve a subir un peldaño más mientras él no termine el trago.",
       "anio": 2025,
@@ -22369,7 +22222,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-6f0ba75b-3",
       "serie": "archivo",
-      "orden": 725,
+      "orden": 720,
       "estado": "publicada",
       "concepto": "Bajo la sombra espesa del árbol, la conversación de tres camisas blancas dura tanto que dos veleros cruzan el horizonte antes de que alguien pague la cuenta.",
       "anio": 2025,
@@ -22400,7 +22253,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-96c65f44-1",
       "serie": "archivo",
-      "orden": 726,
+      "orden": 721,
       "estado": "publicada",
       "concepto": "El único rayo de sol del patio entra recto por la puerta pintada y ni un paso se atreve a salir de su carril hasta que cae la tarde.",
       "anio": 2025,
@@ -22431,7 +22284,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-96c65f44-3",
       "serie": "archivo",
-      "orden": 727,
+      "orden": 722,
       "estado": "publicada",
       "concepto": "El de la camiseta azul pedalea tan fuerte que dos bicicletas más se ven obligadas a perseguirlo sin que él haya mirado nunca hacia atrás.",
       "anio": 2025,
@@ -22462,7 +22315,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-a25f9e10-0",
       "serie": "archivo",
-      "orden": 728,
+      "orden": 723,
       "estado": "publicada",
       "concepto": "La motocicleta azul lleva tanto tiempo apoyada en la pata de cabra frente al rancho de paja que la buganvilia ya le trepó medio manubrio.",
       "anio": 2025,
@@ -22493,7 +22346,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-a25f9e10-1",
       "serie": "archivo",
-      "orden": 729,
+      "orden": 724,
       "estado": "publicada",
       "concepto": "Pedalea despacio frente a la puerta amarilla justo cuando el azul de la noche empieza a comerse las tejas, y ninguno de los dos colores gana.",
       "anio": 2025,
@@ -22524,7 +22377,7 @@
     {
       "slug": "slice-of-life-in-the-pennsula-of-paraguan-a53629f5-0",
       "serie": "archivo",
-      "orden": 730,
+      "orden": 725,
       "estado": "publicada",
       "concepto": "Cruza las manos sobre el vestido azul y espera tan quieta en su puerta que las flores blancas de al lado llevan una hora sin decidirse a caer.",
       "anio": 2025,
@@ -22555,7 +22408,7 @@
     {
       "slug": "slice-of-utopic-life-in-the-pennsula-of-983eae4b-0",
       "serie": "archivo",
-      "orden": 731,
+      "orden": 726,
       "estado": "publicada",
       "concepto": "Las chimeneas de la refinería fuman en el horizonte desde hace tanto que el rancho de palma de la orilla ya aprendió a ignorarlas por completo.",
       "anio": 2025,
@@ -22586,7 +22439,7 @@
     {
       "slug": "slice-of-utopic-life-in-the-pennsula-of-a19e389c-3",
       "serie": "archivo",
-      "orden": 732,
+      "orden": 727,
       "estado": "publicada",
       "concepto": "El mantel amarillo de la mesa vacía combina tanto con la arena de la laguna que desde lejos parece que el patio se sirvió un pedazo de playa.",
       "anio": 2025,
@@ -22617,7 +22470,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-p-ddab3fca-3",
       "serie": "archivo",
-      "orden": 733,
+      "orden": 728,
       "estado": "publicada",
       "concepto": "Solo asoma los ojos y el lomo acorazado sobre el agua, y lleva tanto tiempo sin moverse que los árboles ya se reflejaron dos veces enteros sobre su piel.",
       "anio": 2025,
@@ -22648,7 +22501,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-18ff04f9-1",
       "serie": "archivo",
-      "orden": 734,
+      "orden": 729,
       "estado": "publicada",
       "concepto": "Las hortensias azules del tiesto se estiran tanto hacia la laguna que casi alcanzan a tocar el filo de la meseta que se recorta al fondo.",
       "anio": 2025,
@@ -22679,7 +22532,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-18ff04f9-3",
       "serie": "archivo",
-      "orden": 735,
+      "orden": 730,
       "estado": "publicada",
       "concepto": "El camino de tierra roja se abre paso entre flores blancas, rosadas y amarillas con tanta insistencia que termina desembocando directo en el mar.",
       "anio": 2025,
@@ -22710,7 +22563,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-3a1f54a6-2",
       "serie": "archivo",
-      "orden": 736,
+      "orden": 731,
       "estado": "publicada",
       "concepto": "Las orejas del burro se paran tan rectas bajo el árbol que parecen sostener solas el techo de paja del bohío de atrás.",
       "anio": 2025,
@@ -22741,7 +22594,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-0",
       "serie": "archivo",
-      "orden": 737,
+      "orden": 732,
       "estado": "publicada",
       "concepto": "Vadea el caño paso a paso, y dos matas de monte se apartan solas para no mojarle ni una crin al caballo blanco.",
       "anio": 2025,
@@ -22772,7 +22625,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-1",
       "serie": "archivo",
-      "orden": 738,
+      "orden": 733,
       "estado": "publicada",
       "concepto": "En medio del pastizal se planta el caballo, y ni las colinas de arena que tiene detrás se atreven a moverse mientras él decide hacia dónde mirar.",
       "anio": 2025,
@@ -22803,7 +22656,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-2",
       "serie": "archivo",
-      "orden": 739,
+      "orden": 734,
       "estado": "publicada",
       "concepto": "La copa del árbol grande alcanza a taparle la sombra entera al caballo, que camina tan pegado a la orilla que no le queda ni un rayo de sol encima.",
       "anio": 2025,
@@ -22834,7 +22687,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-49db312b-3",
       "serie": "archivo",
-      "orden": 740,
+      "orden": 735,
       "estado": "publicada",
       "concepto": "Frente al agua se para tan quieto el burro que los arbustos morados de atrás le crecieron alrededor sin que se apartara ni un paso.",
       "anio": 2025,
@@ -22865,7 +22718,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-55f95e2d-1",
       "serie": "archivo",
-      "orden": 741,
+      "orden": 736,
       "estado": "publicada",
       "concepto": "Camina por la arena como si el oasis entero -palmeras, agua azul y duna- le perteneciera desde antes de que alguien lo nombrara, y nadie se lo discute.",
       "anio": 2025,
@@ -22896,7 +22749,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-62deeb3e-0",
       "serie": "archivo",
-      "orden": 742,
+      "orden": 737,
       "estado": "publicada",
       "concepto": "Tan pequeña es la isla que solo le caben una casa blanca y una palmera, y aun así la nube de allá arriba parece más grande que las dos juntas.",
       "anio": 2025,
@@ -22927,7 +22780,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-62deeb3e-1",
       "serie": "archivo",
-      "orden": 743,
+      "orden": 738,
       "estado": "publicada",
       "concepto": "Entre flores blancas y moradas baja con tanta decisión el camino de ladrillo, que parece que va a meterse derecho en el mar.",
       "anio": 2025,
@@ -22958,7 +22811,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-9940fd95-0",
       "serie": "archivo",
-      "orden": 744,
+      "orden": 739,
       "estado": "publicada",
       "concepto": "Ni una hoja del dosel se anima a caer sobre el caimán, que flota tan inmóvil en el agua oscura que parece parte del reflejo de los árboles.",
       "anio": 2025,
@@ -22989,7 +22842,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-ee146ea9-0",
       "serie": "archivo",
-      "orden": 745,
+      "orden": 740,
       "estado": "publicada",
       "concepto": "Los flamencos se juntan en la orilla en tal cantidad que desde la montaña de atrás el agua ya no se ve azul sino rosada.",
       "anio": 2025,
@@ -23020,7 +22873,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-fb70df30-2",
       "serie": "archivo",
-      "orden": 746,
+      "orden": 741,
       "estado": "publicada",
       "concepto": "En la arena, justo donde terminan las sombras de las palmeras, pace el burro sin dar ni un paso hacia el agua que tiene al lado.",
       "anio": 2025,
@@ -23051,7 +22904,7 @@
     {
       "slug": "slice-of-utopic-life-vistas-in-the-pennsula-fb70df30-3",
       "serie": "archivo",
-      "orden": 747,
+      "orden": 742,
       "estado": "publicada",
       "concepto": "Por encima de las flores azules asoman las orejas del burro como dos mástiles diminutos, con la playa entera de fondo esperando a que decida moverse.",
       "anio": 2025,
@@ -23082,7 +22935,7 @@
     {
       "slug": "soldier-poses-in-his-home-in-venezuela-in-7aeb5fef-1",
       "serie": "archivo",
-      "orden": 748,
+      "orden": 743,
       "estado": "publicada",
       "concepto": "Se sienta con las botas juntas bajo tres retratos enmarcados que cuelgan de la pared verde, y ninguno de los tres se atreve a mirarlo a los ojos como lo hace él a la cámara.",
       "anio": 2025,
@@ -23112,7 +22965,7 @@
     {
       "slug": "space-control-room-with-people-at-desks-and-76f50de1-1",
       "serie": "archivo",
-      "orden": 749,
+      "orden": 744,
       "estado": "publicada",
       "concepto": "Cada consola vigila un fragmento del planeta rojo tras el cristal, y llevan tantas guardias contando sus tormentas que ya las saludan por su nombre.",
       "anio": 2025,
@@ -23143,7 +22996,7 @@
     {
       "slug": "space-control-room-with-people-at-desks-and-76f50de1-2",
       "serie": "archivo",
-      "orden": 750,
+      "orden": 745,
       "estado": "publicada",
       "concepto": "Diez consolas se alinean bajo el muro de luz azulada donde flota un iceberg que nunca se derrite, y el que está de pie lleva media hora sin decidirse a acercarse.",
       "anio": 2025,
@@ -23174,7 +23027,7 @@
     {
       "slug": "stencil-magazine-font-title-for-cmo-ser-buena-9389a5ae-0",
       "serie": "archivo",
-      "orden": 751,
+      "orden": 746,
       "estado": "publicada",
       "concepto": "Bajo tanto grano de tinta que la revista parece llovida, el collar de perlas sigue intacto y brilla como si nadie se hubiese atrevido a imprimir encima.",
       "anio": 2025,
@@ -23205,7 +23058,7 @@
     {
       "slug": "stencil-magazine-font-title-for-cmo-ser-buena-9389a5ae-3",
       "serie": "archivo",
-      "orden": 752,
+      "orden": 747,
       "estado": "publicada",
       "concepto": "El código de barras se cuela en la esquina como si fuera a cobrarle por mirarla, mientras el retrato color musgo aguanta cuarenta años de polvo sin pestañear.",
       "anio": 2025,
@@ -23236,7 +23089,7 @@
     {
       "slug": "stencil-magazine-font-title-for-cmo-ser-buena-dbc0346f-0",
       "serie": "archivo",
-      "orden": 753,
+      "orden": 748,
       "estado": "publicada",
       "concepto": "Las letras grises flotan en tanto ruido de pantalla vieja que parecen buscar la señal desde hace tres décadas, y el sello blanco de la esquina es lo único que no tiembla.",
       "anio": 2025,
@@ -23267,7 +23120,7 @@
     {
       "slug": "stock-image-corporativa-03c30dbc-0",
       "serie": "archivo",
-      "orden": 754,
+      "orden": 749,
       "estado": "publicada",
       "concepto": "El de en medio es el único que se deja ver la cara entre tanto vidrio azul desenfocado, y los otros dos llevan el mismo traje pero caminan tan rápido que se han vuelto humo.",
       "anio": 2025,
@@ -23298,7 +23151,7 @@
     {
       "slug": "stock-image-corporativa-91c23937-0",
       "serie": "archivo",
-      "orden": 755,
+      "orden": 750,
       "estado": "publicada",
       "concepto": "Aplaude con tanta fuerza bajo su chaqueta color cobre que los aros dorados de las orejas llevan repicando desde antes de que empezara el discurso.",
       "anio": 2025,
@@ -23329,7 +23182,7 @@
     {
       "slug": "stock-image-corporativa-91c23937-1",
       "serie": "archivo",
-      "orden": 756,
+      "orden": 751,
       "estado": "publicada",
       "concepto": "El apretón de manos divide el cielo exacto en dos: naranja arriba, azul abajo, y ninguno de los dos suelta hasta que la última fila de puntos termine de imprimirse.",
       "anio": 2025,
@@ -23360,7 +23213,7 @@
     {
       "slug": "stock-image-corporativa-91c23937-3",
       "serie": "archivo",
-      "orden": 757,
+      "orden": 752,
       "estado": "publicada",
       "concepto": "Cruza los brazos contra un cielo tan azul que parece pintado a última hora, y los tres hombres detrás llevan la corbata tan derecha que ni el viento se atreve a tocarla.",
       "anio": 2025,
@@ -23391,7 +23244,7 @@
     {
       "slug": "stock-image-corporativa-da752d00-2",
       "serie": "archivo",
-      "orden": 758,
+      "orden": 753,
       "estado": "publicada",
       "concepto": "Se reúnen tan alto que la ciudad entera cabe bajo la mesa, y las luces de las calles parpadean como si también quisieran opinar en la conversación.",
       "anio": 2025,
@@ -23422,7 +23275,7 @@
     {
       "slug": "stock-image-corporativa-da752d00-3",
       "serie": "archivo",
-      "orden": 759,
+      "orden": 754,
       "estado": "publicada",
       "concepto": "La mitad de su cara vive en luz cálida y la otra ya se rindió al azul de la pantalla, partida entre dos climas desde antes de que empezara la junta.",
       "anio": 2025,
@@ -23453,7 +23306,7 @@
     {
       "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-0",
       "serie": "archivo",
-      "orden": 760,
+      "orden": 755,
       "estado": "publicada",
       "concepto": "Por la ventana redonda de la puerta se le nota la piel del mismo turquesa que el mar de fondo, y las gafas amarillas no dejan pasar ni un rayo de ese sol de playa.",
       "anio": 2025,
@@ -23484,7 +23337,7 @@
     {
       "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-1",
       "serie": "archivo",
-      "orden": 761,
+      "orden": 756,
       "estado": "publicada",
       "concepto": "El ojo de pez le dobla los edificios de atrás como si la ciudad entera se inclinara para caber en la foto, mientras el auto azul viejo ni se entera y sigue parqueado derecho.",
       "anio": 2025,
@@ -23515,7 +23368,7 @@
     {
       "slug": "teenage-wasteland-pop-art-a-character-on-a-547c4f2a-2",
       "serie": "archivo",
-      "orden": 762,
+      "orden": 757,
       "estado": "publicada",
       "concepto": "Se recuesta en el guardabarros como si el auto llevara sesenta años esperándolo justo ahí, y la palmera de atrás se dobla en el lente hasta casi tocarle el hombro.",
       "anio": 2025,
@@ -23546,7 +23399,7 @@
     {
       "slug": "the-cover-art-of-the-apocalypse-zine-in-eca0b207-0",
       "serie": "archivo",
-      "orden": 763,
+      "orden": 758,
       "estado": "publicada",
       "concepto": "Le crecen cadenas donde a otros les crece el brazo, y la luna llena se le queda fija detrás del pelo blanco como si llevara siglos sin moverse de ahí.",
       "anio": 2025,
@@ -23577,7 +23430,7 @@
     {
       "slug": "the-earth-monolith-found-in-centralstan-c1890-wi-d5ac46d9-3",
       "serie": "archivo",
-      "orden": 764,
+      "orden": 759,
       "estado": "publicada",
       "concepto": "Talló tantos círculos concéntricos en la piedra que quien los mire de cerca pierde la cuenta antes de llegar al centro, y el hombre de blanco lleva rato intentándolo sin moverse.",
       "anio": 2025,
@@ -23607,7 +23460,7 @@
     {
       "slug": "the-man-in-white-is-surrounded-by-many-3faad93b-1",
       "serie": "archivo",
-      "orden": 765,
+      "orden": 760,
       "estado": "publicada",
       "concepto": "Entre tantas cabezas iguales solo uno se da la vuelta a mirar la cámara, y lleva puesto el mismo blanco que todos pero la luz decide quedarse justo en él.",
       "anio": 2025,
@@ -23638,7 +23491,7 @@
     {
       "slug": "the-sennheiser-space-station-control-549baf68-0",
       "serie": "archivo",
-      "orden": 766,
+      "orden": 761,
       "estado": "publicada",
       "concepto": "Con un solo audífono puesto vigila la estación entera y la Tierra girando abajo, y el monitor rojo de la izquierda lleva parpadeando una alarma tan floja que ya nadie se levanta a mirarla.",
       "anio": 2025,
@@ -23669,7 +23522,7 @@
     {
       "slug": "the-sennheiser-space-station-control-72a31474-1",
       "serie": "archivo",
-      "orden": 767,
+      "orden": 762,
       "estado": "publicada",
       "concepto": "Arriba las tres pantallas solo hablan en verde, trazando líneas de luz que nunca se repiten, y abajo las otras tres vigilan la Tierra tan de cerca que cuentan sus nubes una por una.",
       "anio": 2025,
@@ -23700,7 +23553,7 @@
     {
       "slug": "the-sennheiser-space-station-control-72a31474-3",
       "serie": "archivo",
-      "orden": 768,
+      "orden": 763,
       "estado": "publicada",
       "concepto": "Va sentado de espaldas con el traje más blanco que cualquier nube de las que ve pasar por la ventana, y la curva entera del planeta le cabe justo entre los dos bordes del vidrio.",
       "anio": 2025,
@@ -23731,7 +23584,7 @@
     {
       "slug": "the-water-has-a-subtle-blue-and-orange-20be483f-0",
       "serie": "archivo",
-      "orden": 769,
+      "orden": 764,
       "estado": "publicada",
       "concepto": "Camina metido hasta la cintura y el sol se le parte en tantas rayas sobre el agua que parece que fuera a cruzar un puente de luz sin mojarse los hombros.",
       "anio": 2025,
@@ -23762,7 +23615,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-151727f6-0",
       "serie": "archivo",
-      "orden": 770,
+      "orden": 765,
       "estado": "publicada",
       "concepto": "El cabello le arde tan naranja que compite con los asientos turquesa del vagón, y en las gafas espejadas se le ve doblada la ciudad entera pasando al revés.",
       "anio": 2025,
@@ -23793,7 +23646,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-151727f6-1",
       "serie": "archivo",
-      "orden": 771,
+      "orden": 766,
       "estado": "publicada",
       "concepto": "Lee sin levantar la vista aunque el tren entero se mueva, y la chaqueta rosa le brilla tanto que hasta las rayas rojas y negras del suéter parecen apagarse a su lado.",
       "anio": 2025,
@@ -23824,7 +23677,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-0",
       "serie": "archivo",
-      "orden": 772,
+      "orden": 767,
       "estado": "publicada",
       "concepto": "Mira por la ventanilla con la cara tan quieta que parece pintada, mientras la chaqueta le hace tanto ruido de colores que el vagón entero se ve más apagado a su lado.",
       "anio": 2025,
@@ -23855,7 +23708,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-2",
       "serie": "archivo",
-      "orden": 773,
+      "orden": 768,
       "estado": "publicada",
       "concepto": "Lleva la cresta tan roja que parece que se le hubiera prendido el pelo con la luz de la tarde, y el aro dorado de la oreja repica en cada frenada del bus.",
       "anio": 2025,
@@ -23886,7 +23739,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-b3e8c7f3-3",
       "serie": "archivo",
-      "orden": 774,
+      "orden": 769,
       "estado": "publicada",
       "concepto": "El remolino naranja de su chaqueta calienta el vidrio del autobús tres grados antes de llegar a la próxima parada.",
       "anio": 2025,
@@ -23917,7 +23770,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-d91839fc-0",
       "serie": "archivo",
-      "orden": 775,
+      "orden": 770,
       "estado": "publicada",
       "concepto": "El pañuelo rosa y azul le crece de la cabeza y ya ocupa dos asientos del vagón, aunque el tren solo lleva cuatro paradas recorridas.",
       "anio": 2025,
@@ -23948,7 +23801,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-d91839fc-1",
       "serie": "archivo",
-      "orden": 776,
+      "orden": 771,
       "estado": "publicada",
       "concepto": "Las púas naranjas del cabello se le enderezan más con el frenazo del autobús, y ya van cuarenta y dos sin doblarse desde la última parada.",
       "anio": 2025,
@@ -23979,7 +23832,7 @@
     {
       "slug": "the-young-man-is-on-a-public-transport-d91839fc-3",
       "serie": "archivo",
-      "orden": 777,
+      "orden": 772,
       "estado": "publicada",
       "concepto": "Las gafas redondas y doradas le devuelven el vagón entero pintado de rosa, y todavía no ha parpadeado desde la última estación.",
       "anio": 2025,
@@ -24010,7 +23863,7 @@
     {
       "slug": "top-view-of-cinematographic-scene-of-83762f01-0",
       "serie": "archivo",
-      "orden": 778,
+      "orden": 773,
       "estado": "publicada",
       "concepto": "La ola verde le cubre los hombros hace tres olas y todavía no decide si tragárselo o devolverlo a la orilla.",
       "anio": 2025,
@@ -24041,7 +23894,7 @@
     {
       "slug": "two-aliens-and-an-astronaut-are-resting-side-4fc9e319-0",
       "serie": "archivo",
-      "orden": 779,
+      "orden": 774,
       "estado": "publicada",
       "concepto": "El visor le devuelve el campo entero de florecillas naranjas, y las llevará reflejadas hasta que se quite el casco en otro planeta.",
       "anio": 2025,
@@ -24072,7 +23925,7 @@
     {
       "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-0",
       "serie": "archivo",
-      "orden": 780,
+      "orden": 775,
       "estado": "publicada",
       "concepto": "Los perfiles verde y azul se acercan tanto que el aro dorado de una roza ya la mejilla de la otra, y ninguna retrocede.",
       "anio": 2025,
@@ -24103,7 +23956,7 @@
     {
       "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-1",
       "serie": "archivo",
-      "orden": 781,
+      "orden": 776,
       "estado": "publicada",
       "concepto": "Las frentes se acercan tanto bajo la luz azul que las flores moradas del primer plano se inclinan solas para no interrumpir.",
       "anio": 2025,
@@ -24134,7 +23987,7 @@
     {
       "slug": "two-people-looking-at-each-other-with-tenderness-9693cea9-3",
       "serie": "archivo",
-      "orden": 782,
+      "orden": 777,
       "estado": "publicada",
       "concepto": "El rojo del fondo se cuela entre los dos perfiles azules sin lograr abrir un centímetro de separación entre sus narices.",
       "anio": 2025,
@@ -24165,7 +24018,7 @@
     {
       "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-3ccb80ec-3",
       "serie": "archivo",
-      "orden": 783,
+      "orden": 778,
       "estado": "publicada",
       "concepto": "La luna ocupa ya la mitad del cielo y sigue creciendo, mientras dos figuras bajan la escalinata naranja sin apurar el paso.",
       "anio": 2025,
@@ -24195,7 +24048,7 @@
     {
       "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-796b7719-0",
       "serie": "archivo",
-      "orden": 784,
+      "orden": 779,
       "estado": "publicada",
       "concepto": "La ciudad entera arde en rojo detrás del cristal y ninguna de las tres pantallas del panel logra igualar ese brillo.",
       "anio": 2025,
@@ -24225,7 +24078,7 @@
     {
       "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-87f22837-2",
       "serie": "archivo",
-      "orden": 785,
+      "orden": 780,
       "estado": "publicada",
       "concepto": "El bloque blanco marcado 9XE flota tan bajo sobre el puerto que las luces rojas del letrero se reflejan ya en el agua entre los barcos.",
       "anio": 2025,
@@ -24255,7 +24108,7 @@
     {
       "slug": "ultra-realistic-photo-of-retro-magazine-cover-of-ca102c98-0",
       "serie": "archivo",
-      "orden": 786,
+      "orden": 781,
       "estado": "publicada",
       "concepto": "El haz de luz sube tan derecho desde la torre que atraviesa las nubes antes de que el operador termine de sentarse frente a la pantalla.",
       "anio": 2025,
@@ -24285,7 +24138,7 @@
     {
       "slug": "un-cuadro-al-leo-de-un-mundo-surreal-905eb375-0",
       "serie": "archivo",
-      "orden": 787,
+      "orden": 782,
       "estado": "publicada",
       "concepto": "El vestido azul y blanco ocupa tanto sitio en la sala que el gato, el perrito y el conejo se acomodan alrededor sin dejarle ni un palmo libre a la fruta del suelo.",
       "anio": 2025,
@@ -24316,7 +24169,7 @@
     {
       "slug": "un-oso-sale-de-su-cueva-despus-de-55d34b6e-1",
       "serie": "archivo",
-      "orden": 788,
+      "orden": 783,
       "estado": "publicada",
       "concepto": "El oso lleva la cabeza levantada tanto tiempo mirando el camino de luna sobre el mar que la marea ya subió dos veces sin que se moviera un paso.",
       "anio": 2025,
@@ -24347,7 +24200,7 @@
     {
       "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-0b915070-2",
       "serie": "archivo",
-      "orden": 789,
+      "orden": 784,
       "estado": "publicada",
       "concepto": "El tocado de plumas se despliega bajo el agua azul como si el viento todavía lo peinara, a nueve metros de la última bocanada de aire.",
       "anio": 2025,
@@ -24378,7 +24231,7 @@
     {
       "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-1db93e4f-1",
       "serie": "archivo",
-      "orden": 790,
+      "orden": 785,
       "estado": "publicada",
       "concepto": "El collar dorado sigue entero alrededor del cuello aunque el agua verde oscura ya se tragó a los demás nadadores detrás.",
       "anio": 2025,
@@ -24409,7 +24262,7 @@
     {
       "slug": "underwater-high-shot-photo-of-lifeless-bodies-of-871edb1c-1",
       "serie": "archivo",
-      "orden": 791,
+      "orden": 786,
       "estado": "publicada",
       "concepto": "El cardumen de peces naranjas atraviesa los chales tejidos sin rozarlos, como si supiera desde siempre por dónde puede pasar y por dónde no.",
       "anio": 2025,
@@ -24440,7 +24293,7 @@
     {
       "slug": "very-detailed-colonial-oil-painting-group-of-mus-5646f29f-2",
       "serie": "archivo",
-      "orden": 792,
+      "orden": 787,
       "estado": "publicada",
       "concepto": "Los cuatro sombreros blancos brillan tanto sobre el agave azul que el volcán del fondo baja el humo un poco para no taparles la luz.",
       "anio": 2025,
@@ -24471,7 +24324,7 @@
     {
       "slug": "very-detailed-colonial-oil-painting-group-of-mus-5646f29f-3",
       "serie": "archivo",
-      "orden": 793,
+      "orden": 788,
       "estado": "publicada",
       "concepto": "El ala del sombrero de paja se enciende de rosa con la última luz del atardecer y todavía no ha terminado de sonar el primer acorde de la guitarra.",
       "anio": 2025,
@@ -24502,7 +24355,7 @@
     {
       "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-0",
       "serie": "archivo",
-      "orden": 794,
+      "orden": 789,
       "estado": "publicada",
       "concepto": "El acorde que suena en la guitarra azul rebota en la pared verde y todavía tarda tres segundos en llegar a los sombreros del fondo.",
       "anio": 2025,
@@ -24533,7 +24386,7 @@
     {
       "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-1",
       "serie": "archivo",
-      "orden": 795,
+      "orden": 790,
       "estado": "publicada",
       "concepto": "La pared de la casa guarda tanto sol del día que sigue iluminando a los que se sientan en círculo mucho después de que el cielo ya se puso negro.",
       "anio": 2025,
@@ -24564,7 +24417,7 @@
     {
       "slug": "very-detailed-colonial-oil-painting-group-of-mus-eed3a9a1-2",
       "serie": "archivo",
-      "orden": 796,
+      "orden": 791,
       "estado": "publicada",
       "concepto": "El vestido blanco se planta entre las hortensias azules con tal quietud que ni el viento de la montaña logra moverle un solo pliegue.",
       "anio": 2025,
@@ -24595,7 +24448,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-373931ab-3",
       "serie": "archivo",
-      "orden": 797,
+      "orden": 792,
       "estado": "publicada",
       "concepto": "La luna sube tan grande sobre las colinas que ilumina las cuerdas de la guitarra antes de que termine de ponerse el sol.",
       "anio": 2025,
@@ -24626,7 +24479,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-4eeb5758-0",
       "serie": "archivo",
-      "orden": 798,
+      "orden": 793,
       "estado": "publicada",
       "concepto": "El sombrero verde le brilla tanto en la penumbra magenta que la luna amarilla del fondo parece apagarse un poco de la envidia.",
       "anio": 2025,
@@ -24657,7 +24510,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-4eeb5758-3",
       "serie": "archivo",
-      "orden": 799,
+      "orden": 794,
       "estado": "publicada",
       "concepto": "Rasguea la guitarra sentado junto a su vasija de barro, y cada acorde tiñe una colina más de rosa hasta que el valle entero arde del color de su camisa.",
       "anio": 2025,
@@ -24688,7 +24541,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-6fa93c15-3",
       "serie": "archivo",
-      "orden": 800,
+      "orden": 795,
       "estado": "publicada",
       "concepto": "Bajo una luna del tamaño de una colina entera, levanta el machete y las luciérnagas del pastizal se encienden todas a la vez, como si el campo respondiera al gesto.",
       "anio": 2025,
@@ -24718,7 +24571,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-be244a62-0",
       "serie": "archivo",
-      "orden": 801,
+      "orden": 796,
       "estado": "publicada",
       "concepto": "La luna, apenas una uña esa noche, se queda prendida de una nube dorada mientras él rasguea la guitarra y los cactos en flor no dejan de escuchar.",
       "anio": 2025,
@@ -24749,7 +24602,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-c41029fa-0",
       "serie": "archivo",
-      "orden": 802,
+      "orden": 797,
       "estado": "publicada",
       "concepto": "Desde el arco pintado de fucsia, la guitarra suena tan fuerte que ilumina los tejados del pueblo entero antes que la luna llena termine de subir.",
       "anio": 2025,
@@ -24780,7 +24633,7 @@
     {
       "slug": "very-detailed-moody-colonial-oil-painting-of-a-c41029fa-3",
       "serie": "archivo",
-      "orden": 803,
+      "orden": 798,
       "estado": "publicada",
       "concepto": "Sentado en una silla rosa que desentona a propósito con la selva, afina la mandolina hasta que las hojas más cercanas se enderezan para escuchar la única nota que falta.",
       "anio": 2025,
@@ -24811,7 +24664,7 @@
     {
       "slug": "very-detailed-photo-of-a-cinematogra-dfcb3380-1",
       "serie": "archivo",
-      "orden": 804,
+      "orden": 799,
       "estado": "publicada",
       "concepto": "La medalla en forma de estrella que lleva al pecho brilla tanto que la ola gigante detrás se detiene un instante antes de romper sobre la cubierta.",
       "anio": 2025,
@@ -24842,7 +24695,7 @@
     {
       "slug": "very-detailed-photo-of-a-cinematogra-dfcb3380-3",
       "serie": "archivo",
-      "orden": 805,
+      "orden": 800,
       "estado": "publicada",
       "concepto": "Se inclina sobre la borda con el brazo estirado hacia el mar, como si pudiera detener la ola más alta con la sola fuerza de sus guantes blancos.",
       "anio": 2025,
@@ -24873,7 +24726,7 @@
     {
       "slug": "very-detailed-photo-of-a-cinematographic-full-vi-8726b12d-2",
       "serie": "archivo",
-      "orden": 806,
+      "orden": 801,
       "estado": "publicada",
       "concepto": "De pie en la cubierta, sostiene la cuerda como si de ella colgara el barco entero y no solo las velas que se sacuden en la tormenta.",
       "anio": 2025,
@@ -24903,7 +24756,7 @@
     {
       "slug": "very-detailed-photo-of-an-indigenous-merchant-se-5107821a-3",
       "serie": "archivo",
-      "orden": 807,
+      "orden": 802,
       "estado": "publicada",
       "concepto": "El techo de paja cubre tanta mercancía que la choza entera flota más baja en el agua, mientras el remero se acerca despacio sobre el mar turquesa antes de que rompa la tormenta.",
       "anio": 2025,
@@ -24934,7 +24787,7 @@
     {
       "slug": "very-detailed-photo-of-an-indigenous-merchant-se-e021cc65-0",
       "serie": "archivo",
-      "orden": 808,
+      "orden": 803,
       "estado": "publicada",
       "concepto": "Se ve el fondo del mar a través del agua tan clara que el hombre de pie en la canoa parece flotar sobre el aire y no sobre las olas.",
       "anio": 2025,
@@ -24965,7 +24818,7 @@
     {
       "slug": "vintage-picture-of-a-horizon-of-a-field-0c1cdd97-2",
       "serie": "archivo",
-      "orden": 809,
+      "orden": 804,
       "estado": "publicada",
       "concepto": "Sobre las colinas teñidas de óxido, cruza un cometa tan despacio que las flores de agave alcanzan a abrirse todas antes de que termine de pasar.",
       "anio": 2025,
@@ -24996,7 +24849,7 @@
     {
       "slug": "vintage-picture-of-a-horizon-of-a-field-0c1cdd97-3",
       "serie": "archivo",
-      "orden": 810,
+      "orden": 805,
       "estado": "publicada",
       "concepto": "Las luces alineadas en el horizonte cuentan cada tallo del trigal, una por una, mientras una estrella fugaz cruza el cielo sin que ninguna se apague para mirarla.",
       "anio": 2025,
@@ -25027,7 +24880,7 @@
     {
       "slug": "vintage-picture-of-a-horizon-of-a-field-3bd72e58-2",
       "serie": "archivo",
-      "orden": 811,
+      "orden": 806,
       "estado": "publicada",
       "concepto": "Dos naves flotan tan quietas sobre el campo rojizo que ni una sola flor amarilla se dobla, como si el viento mismo les tuviera respeto.",
       "anio": 2025,
@@ -25058,7 +24911,7 @@
     {
       "slug": "vintage-picture-of-a-road-to-the-horizonwith-5394b061-1",
       "serie": "archivo",
-      "orden": 812,
+      "orden": 807,
       "estado": "publicada",
       "concepto": "Al final de la carretera desierta, un auto diminuto avanza directo hacia una nave tan alta como la montaña que tiene detrás, y ni siquiera frena.",
       "anio": 2025,
@@ -25089,7 +24942,7 @@
     {
       "slug": "w78je-scene-of-simn-bolvar-in-his-deathbed-2f1f07e7-3",
       "serie": "archivo",
-      "orden": 813,
+      "orden": 808,
       "estado": "publicada",
       "concepto": "Rodean la cama de sábanas blancas tantos uniformes con charreteras doradas que la habitación entera parece un cuartel puesto de pie alrededor de un solo hombre que ya no se mueve.",
       "anio": 2025,
@@ -25120,7 +24973,7 @@
     {
       "slug": "w78je-scene-of-simn-bolvar-in-his-deathbed-314cec35-2",
       "serie": "archivo",
-      "orden": 814,
+      "orden": 809,
       "estado": "publicada",
       "concepto": "Por la única puerta abierta entra tanta luz que alcanza a iluminar solo la cama, dejando a los oficiales que la rodean sumergidos en su propia sombra oscura.",
       "anio": 2025,
@@ -25151,7 +25004,7 @@
     {
       "slug": "walking-perspective-down-a-santiago-chile-neighb-c3687654-3",
       "serie": "archivo",
-      "orden": 815,
+      "orden": 810,
       "estado": "publicada",
       "concepto": "Los cables se cruzan sobre la esquina en tantos nudos que el hombre que camina abajo prefiere mirar la vereda antes que enredarse la vista con ellos.",
       "anio": 2025,
@@ -25182,7 +25035,7 @@
     {
       "slug": "west-african-coast-1462-a-merchant-captain-and-6b59c446-2",
       "serie": "archivo",
-      "orden": 816,
+      "orden": 811,
       "estado": "publicada",
       "concepto": "Rema solo en la canoa mientras un único rayo parte el cielo a lo lejos, tan silencioso que ni el agua bajo el remo se altera.",
       "anio": 2025,
@@ -25213,7 +25066,7 @@
     {
       "slug": "wide-shot-of-a-gothic-vampire-castle-8b1a9ea7-2",
       "serie": "archivo",
-      "orden": 817,
+      "orden": 812,
       "estado": "publicada",
       "concepto": "El castillo entero está a oscuras menos por las ventanas, que arden en naranja y rojo como si cada torre escondiera su propia hoguera detrás del cristal.",
       "anio": 2025,
@@ -25244,7 +25097,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-1c765ecb-1",
       "serie": "archivo",
-      "orden": 818,
+      "orden": 813,
       "estado": "publicada",
       "concepto": "Frente al puerto lleno de gente diminuta, la capa azul le cubre el hombro entero y no se mueve un centímetro aunque el viento del mar empuje cada barco de la bahía.",
       "anio": 2025,
@@ -25275,7 +25128,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-1c765ecb-3",
       "serie": "archivo",
-      "orden": 819,
+      "orden": 814,
       "estado": "publicada",
       "concepto": "La playa se llena de tantas figuras diminutas que parece hormigueo bajo el barco anclado, mientras él, de perfil, no vuelve la cabeza para contarlas.",
       "anio": 2025,
@@ -25306,7 +25159,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-862ac6f5-0",
       "serie": "archivo",
-      "orden": 820,
+      "orden": 815,
       "estado": "publicada",
       "concepto": "Mira hacia el puerto donde el sol recorta en sombra a cada persona del muelle, una fila tan larga y negra que parece la sombra de un solo barco gigante.",
       "anio": 2025,
@@ -25337,7 +25190,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-862ac6f5-2",
       "serie": "archivo",
-      "orden": 821,
+      "orden": 816,
       "estado": "publicada",
       "concepto": "Junto a la torre redonda de piedra, el atardecer dora tanto al barco de banderas que la fila entera de gente en el muelle parece hecha del mismo bronce.",
       "anio": 2025,
@@ -25368,7 +25221,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-0",
       "serie": "archivo",
-      "orden": 822,
+      "orden": 817,
       "estado": "publicada",
       "concepto": "Todo se vuelve azul a esa hora, hasta el pueblo entero al pie del cerro, y el mar se agita tanto que parece querer subir a mirarlo con él desde la muralla.",
       "anio": 2025,
@@ -25399,7 +25252,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-1",
       "serie": "archivo",
-      "orden": 823,
+      "orden": 818,
       "estado": "publicada",
       "concepto": "Las banderas amarillas apenas se mueven mientras él se sienta con las piernas cruzadas en la piedra a esperar que el velero, ya diminuto, termine de cruzar todo el atardecer.",
       "anio": 2025,
@@ -25430,7 +25283,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-2",
       "serie": "archivo",
-      "orden": 824,
+      "orden": 819,
       "estado": "publicada",
       "concepto": "La ciudad blanca lleva cuatrocientos años subiendo la colina piedra a piedra sin llegar nunca a la cima, mientras él la mira envuelto en su manto azul.",
       "anio": 2025,
@@ -25461,7 +25314,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-c053388a-3",
       "serie": "archivo",
-      "orden": 825,
+      "orden": 820,
       "estado": "publicada",
       "concepto": "Sentada de espaldas al muro con el vestido malva desplegado como otra vela, lleva tantos atardeceres esperando que las dos naves ya reconocen el color de su falda antes de atracar.",
       "anio": 2025,
@@ -25492,7 +25345,7 @@
     {
       "slug": "wide-shot-of-a-medieval-plaza-in-the-cb19cb80-0",
       "serie": "archivo",
-      "orden": 826,
+      "orden": 821,
       "estado": "publicada",
       "concepto": "Clava la mirada en el galeón desde el muro de piedra, y el barco lleva tres siglos sin poder zarpar bajo esa fijeza.",
       "anio": 2025,

--- a/content/galeria/obras.json
+++ b/content/galeria/obras.json
@@ -18,7 +18,7 @@
       "serie": "archivo",
       "orden": 1,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ojo ovalado lleva flotando sobre la aguja de piedra desde antes de que el viento le puliera la primera arruga a la roca, y todavía no ha parpadeado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -32,8 +32,8 @@
         "generacion": "b9553ee2-647f-4f27-a063-1cb5f32c1ebc",
         "variante": 2
       },
-      "titulo": "120mm cinematic still of cyberpunk eye shape starship",
-      "alt": "120mm cinematic still of cyberpunk eye shape starship with a",
+      "titulo": "El párpado dorado del desierto",
+      "alt": "Un objeto ovalado de color amarillo pálido con una gran pupila oscura flota en un cielo azul sobre un paisaje desértico con formaciones rocosas y una torre puntiaguda.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -49,7 +49,7 @@
       "serie": "archivo",
       "orden": 2,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuenta cada punto de la pared a cuadros mientras el morro avanza, y para cuando termine de contarlos habrá cruzado el túnel siete veces sin frenar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -63,8 +63,8 @@
         "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e",
         "variante": 0
       },
-      "titulo": "120mm film cinematic still of cyberpunk eye shape",
-      "alt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+      "titulo": "El torpedo verde del túnel",
+      "alt": "Una nave con forma de torpedo de color verde oliva avanza por un túnel largo cuyas paredes están cubiertas de una cuadrícula de puntos luminosos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -80,7 +80,7 @@
       "serie": "archivo",
       "orden": 3,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ni un centímetro de cara se libra de las franjas anaranjadas, menos el ojo azul, al que las mil rayas de luz llevan años sin lograr alcanzar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -94,8 +94,8 @@
         "generacion": "b8ae891e-a189-4ac9-aa3d-ba721cd5276e",
         "variante": 3
       },
-      "titulo": "120mm film cinematic still of cyberpunk eye shape",
-      "alt": "120mm film cinematic still of cyberpunk eye shape starship wi",
+      "titulo": "El ojo entre rayas",
+      "alt": "Primer plano del ojo azul de una persona y parte de su rostro, cruzados por franjas de luz naranja y sombra, como las de una persiana.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -111,7 +111,7 @@
       "serie": "archivo",
       "orden": 4,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre las dos mujeres arde una luz que no viene de leña ni de vela, y la mano llena de anillos la sostiene en alto sin quemarse ni una sola noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -125,8 +125,8 @@
         "generacion": "aff3dc50-44d6-42b1-ad59-7fad783806a2",
         "variante": 0
       },
-      "titulo": "35mm Cinematic close up shot movie s",
-      "alt": "35mm Cinematic close up shot movie s",
+      "titulo": "El fuego entre las dos",
+      "alt": "Dos mujeres mayores retratadas en tonos azules y naranjas entre ramas de árboles, una con la mano alzada mostrando varios anillos, con un resplandor cálido entre ambas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -142,7 +142,7 @@
       "serie": "archivo",
       "orden": 5,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La piel se le agrieta en escamas de corteza vieja, y la luna le cuelga tan cerca del hombro que si girara la cabeza se la llevaría entre el pelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -156,8 +156,8 @@
         "generacion": "2241cc4c-10f6-4d6a-b49b-aed7cd941576",
         "variante": 2
       },
-      "titulo": "35mm Cinematic close up shot movie still of",
-      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "titulo": "El hombre y su luna",
+      "alt": "Retrato de un hombre mayor de cabello largo y canoso, con la piel de textura escamosa iluminada en tonos azules y naranjas, junto a un círculo pálido y brillante similar a una luna.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -173,7 +173,7 @@
       "serie": "archivo",
       "orden": 6,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El búho no le ha quitado los ojos a la capucha desde que salió la luna llena, y en toda la noche ninguno de los dos ha movido un párpado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -187,8 +187,8 @@
         "generacion": "24683f3d-96b5-4924-beb0-d5d18251fd5f",
         "variante": 0
       },
-      "titulo": "35mm Cinematic close up shot movie still of",
-      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "titulo": "La vigilia del búho",
+      "alt": "Un búho posado en una rama sin hojas junto a una persona encapuchada de rostro pálido, bajo una luna llena entre niebla azulada.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -204,7 +204,7 @@
       "serie": "archivo",
       "orden": 7,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene la luna entera cabiendo en la esquina del ojo derecho, y desde que la vio ahí no ha vuelto a parpadear ni una vez completa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -218,8 +218,8 @@
         "generacion": "527313a8-6389-4bdb-a5b9-e74614b3f0b1",
         "variante": 0
       },
-      "titulo": "35mm Cinematic close up shot movie still of",
-      "alt": "35mm Cinematic close up shot movie still of esoteric scene An",
+      "titulo": "Los ojos que no parpadean",
+      "alt": "Primer plano del rostro de una mujer joven con los ojos muy abiertos, iluminado en tonos azules y naranjas, con una pequeña luna visible en la esquina superior del cielo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -235,7 +235,7 @@
       "serie": "archivo",
       "orden": 8,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nube redonda que cuelga entre los árboles cabe entera dentro de sus brazos abiertos, y la mujer de azul solo alcanza a rozarle el borde con una mano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -249,8 +249,8 @@
         "generacion": "1c45bcae-6172-4333-84a2-d03fffd46727",
         "variante": 3
       },
-      "titulo": "35mm Cinematic wide shot movie still",
-      "alt": "35mm Cinematic wide shot movie still",
+      "titulo": "Los brazos y la nube",
+      "alt": "Dos figuras con túnicas se enfrentan en un claro del bosque: una de azul con la mano levantada y otra de blanco con los brazos completamente extendidos, bajo una forma de luz redonda entre los árboles.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -266,7 +266,7 @@
       "serie": "archivo",
       "orden": 9,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Rema derecho hacia la luna llena, y el reflejo se le parte en la estela de la canoa sin que el remo pierda un solo golpe de compás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -280,8 +280,8 @@
         "generacion": "9eace293-9207-47f5-b080-aad58550bac3",
         "variante": 2
       },
-      "titulo": "35mm full shot Cinematic movie still of An",
-      "alt": "35mm full shot Cinematic movie still of An indeginous main m",
+      "titulo": "El remo hacia la luna",
+      "alt": "Un hombre visto de espaldas rema en una canoa de madera hacia una luna llena que se refleja en aguas tranquilas, con una costa de palmeras al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -297,7 +297,7 @@
       "serie": "archivo",
       "orden": 10,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pez lo sostiene tan en alto y tan quieto que las gotas que le caen del cuerpo tardan el doble en llegar a la arena, con el sol pegado en cada una.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -311,8 +311,8 @@
         "generacion": "c1cd86d7-6d8f-4f5e-95be-b60cdcf14b34",
         "variante": 1
       },
-      "titulo": "35mm full shot Cinematic movie still of An",
-      "alt": "35mm full shot Cinematic movie still of An indigenous stands",
+      "titulo": "El pez que aún gotea",
+      "alt": "Un hombre sostiene en alto un pez plateado junto a la playa, con el rostro pintado de rojo y la piel cubierta de sudor, bajo un cielo con nubes y dos canoas al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -328,7 +328,7 @@
       "serie": "archivo",
       "orden": 11,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la cara pintada de un rojo que la noche entera de mar azul no ha logrado apagarle, ni siquiera con la luna encima empujando toda su luz fría.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -342,8 +342,8 @@
         "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6",
         "variante": 0
       },
-      "titulo": "35mm full shot Cinematic panoramic w",
-      "alt": "35mm full shot Cinematic panoramic w",
+      "titulo": "El rojo sin apagar",
+      "alt": "Una persona sentada en una canoa de madera sobre un mar oscuro de noche, con el rostro y el pecho pintados de rojo, bajo un cielo azul con una luna pequeña.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -359,7 +359,7 @@
       "serie": "archivo",
       "orden": 12,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre el cielo y el mar, los dos igual de azules, solo la cara pintada de rojo recuerda cuál de los dos es el agua y cuál es la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -373,8 +373,8 @@
         "generacion": "bedf12e9-0e29-4da0-8f53-c6053f853af6",
         "variante": 3
       },
-      "titulo": "35mm full shot Cinematic panoramic w",
-      "alt": "35mm full shot Cinematic panoramic w",
+      "titulo": "La canoa entre dos azules",
+      "alt": "Una persona sentada en una canoa sostiene un remo sobre un mar oscuro, con el rostro pintado de rojo, bajo un cielo nocturno azul con luna y nubes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -390,7 +390,7 @@
       "serie": "archivo",
       "orden": 13,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Carga la canoa con peces que relumbran más que la luna que todavía no sale, y el añil de la noche se le pega a los hombros como una segunda piel.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -404,8 +404,8 @@
         "generacion": "dd3989df-fff9-4b02-85c9-d8b6a782bf85",
         "variante": 2
       },
-      "titulo": "35mm full shot Cinematic panoramic w",
-      "alt": "35mm full shot Cinematic panoramic w",
+      "titulo": "El pescador del añil",
+      "alt": "Hombre indígena con el rostro pintado de rojo y una pluma en el cabello, sentado en una canoa de madera con pescado, sobre un mar azul oscuro de noche.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -421,7 +421,7 @@
       "serie": "archivo",
       "orden": 14,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene la red de fibra como si cupiera ahí todo el cardumen del golfo, sin que se le enrede un solo hilo entre los dedos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -435,8 +435,8 @@
         "generacion": "52a5b695-7ea7-4b67-bfed-c65c7eb37680",
         "variante": 0
       },
-      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
-      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "titulo": "La red del golfo",
+      "alt": "Hombre indígena con el rostro pintado y una pluma en el cabello, de pie en una playa con una red de pesca en las manos, mar y arena claros de fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -452,7 +452,7 @@
       "serie": "archivo",
       "orden": 15,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sopla la flauta de caña sentado sobre el agua rasa, y la nota final se alarga tanto que el sol espera un segundo de más antes de hundirse en el horizonte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -466,8 +466,8 @@
         "generacion": "5937eba9-874d-4f84-8464-78a537d8deb3",
         "variante": 0
       },
-      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
-      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "titulo": "Flauta al borde del poniente",
+      "alt": "Persona sentada de espaldas sobre el agua poco profunda, tocando una flauta de madera, con el sol poniéndose en el horizonte en tonos pastel.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -483,7 +483,7 @@
       "serie": "archivo",
       "orden": 16,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna llena traza un camino dorado sobre el agua que termina justo debajo de la proa de la canoa, como si lo hubiera trazado solo para él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -497,8 +497,8 @@
         "generacion": "de7ebc7d-12b6-449d-9b28-fea2cb744645",
         "variante": 3
       },
-      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
-      "alt": "35mm full shot Cinematic panoramic wide shot movie still of a",
+      "titulo": "El camino de la luna",
+      "alt": "Silueta de una persona sentada en una canoa de noche sobre un mar oscuro, iluminada por un resplandor cálido, con la luna llena reflejada en el agua.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -514,7 +514,7 @@
       "serie": "archivo",
       "orden": 17,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva en la cabeza un penacho de plumas rojas y verdes tan alto que parece que fuera a despegar antes que las gaviotas que sobrevuelan la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -528,8 +528,8 @@
         "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd",
         "variante": 2
       },
-      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
-      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "titulo": "Penacho rojo sobre la arena",
+      "alt": "Hombre indígena con un tocado de plumas rojas y verdes, sosteniendo una red de pesca, de pie en una playa junto al mar y dos canoas de madera.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -545,7 +545,7 @@
       "serie": "archivo",
       "orden": 18,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Aprieta contra el pecho un pez que todavía relumbra, mientras el machete le cuelga del otro brazo sin que nadie le quite el ojo de encima al penacho de plumas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -559,8 +559,8 @@
         "generacion": "e0615cd4-6ede-478e-a6c0-83df2701c4cd",
         "variante": 3
       },
-      "titulo": "35mm full shot Cinematic panoramic wide shot movie",
-      "alt": "35mm full shot Cinematic panoramic wide shot movie still of",
+      "titulo": "El pez y el machete",
+      "alt": "Hombre indígena con tocado de plumas rojas y verdes, sosteniendo un machete y una red con pescado, de pie en una playa con el mar y una canoa al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -576,7 +576,7 @@
       "serie": "archivo",
       "orden": 19,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada espina de la caracola apunta a un rumbo distinto del Caribe, y el rojo que la cubre parece que todavía no ha terminado de escurrir desde la punta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -590,8 +590,8 @@
         "generacion": "236636af-c376-40fb-a000-68b7f427b538",
         "variante": 2
       },
-      "titulo": "3D graphics 8D Rendering of a caribean conch",
-      "alt": "3D graphics 8D Rendering of a caribean conch shell with metal",
+      "titulo": "Espiral rojo del Caribe",
+      "alt": "Renderizado tridimensional de una caracola marina con espinas puntiagudas, de color rojo y blanco, sobre fondo blanco.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -607,7 +607,7 @@
       "serie": "archivo",
       "orden": 20,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta la barbilla tan alto que los rizos blancos se le van hacia atrás como una ola detenida a medio romper, y los lentes oscuros no dejan pasar ni una gota de luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -621,8 +621,8 @@
         "generacion": "1aedc09f-e82c-46f6-a74b-b446263d3197",
         "variante": 2
       },
-      "titulo": "A black and white photo of an African",
-      "alt": "a black and white photo of an African American man with short",
+      "titulo": "Rizos blancos y barbilla alzada",
+      "alt": "Fotografía en blanco y negro de una persona de perfil con cabello rizado claro, gafas de sol oscuras y chaqueta de cuero, mirando hacia arriba.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -638,7 +638,7 @@
       "serie": "archivo",
       "orden": 21,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El plato metálico se queda flotando justo sobre las copas de los pinos, tan quieto que ni el desenfoque de la cámara logra emborronarle el borde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -652,8 +652,8 @@
         "generacion": "7ae7e0fc-edba-442f-9e94-a7a2751ed761",
         "variante": 2
       },
-      "titulo": "A blurry out of focus photograph taken from",
-      "alt": "A blurry out of focus photograph taken from quite far away by",
+      "titulo": "El disco entre los pinos",
+      "alt": "Fotografía borrosa de un objeto volador en forma de disco flotando sobre la copa de los árboles, con tono verdoso y aspecto antiguo.",
       "w": 1344,
       "h": 880,
       "anchos": [
@@ -669,7 +669,7 @@
       "serie": "archivo",
       "orden": 22,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva cuarenta años ajustando esa máquina y nadie le ha dicho para qué sirve; teme que la respuesta sea que sirve para que él siga ahí.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -683,8 +683,8 @@
         "generacion": "d49e7c63-25cc-4f5d-a500-0aae2cc0ec8b",
         "variante": 0
       },
-      "titulo": "A book cover for scifi in the style",
-      "alt": "a book cover for scifi in the style of colorful moebius daydr",
+      "titulo": "Turno en la máquina roja",
+      "alt": "Ilustración retrofuturista de una persona con traje amarillo y casco blanco operando un panel de control en una gran maquinaria roja llena de tubos.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -700,7 +700,7 @@
       "serie": "archivo",
       "orden": 23,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le arden en la espalda tantos hilos dorados bordados en la chaqueta que compiten con la hoguera de enfrente por iluminarle la noche entera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -714,8 +714,8 @@
         "generacion": "25f91447-8196-4d9b-be80-bdd5f845e0a5",
         "variante": 0
       },
-      "titulo": "A burning pyre with a character from The",
-      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "titulo": "El bordado frente al fuego",
+      "alt": "Hombre de espaldas con una chaqueta bordada en dorado, sentado junto a una fogata frente a un lago de noche, bajo un cielo estrellado.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -731,7 +731,7 @@
       "serie": "archivo",
       "orden": 24,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las charreteras doradas del uniforme le brillan más que el cañaveral entero que arde frente a él, con otro hombre sentado justo en medio de las llamas sin que el fuego lo toque.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -745,8 +745,8 @@
         "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569",
         "variante": 2
       },
-      "titulo": "A burning pyre with a character from The",
-      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "titulo": "Charreteras doradas ante el cañaveral",
+      "alt": "Hombre de espaldas con uniforme militar bordado en dorado, mirando un campo en llamas de noche, con otra persona sentada entre el fuego.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -762,7 +762,7 @@
       "serie": "archivo",
       "orden": 25,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta con las manos cruzadas sobre las rodillas, y la hoguera de al lado le pinta media cara de naranja mientras la otra mitad se le queda del color exacto de la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -776,8 +776,8 @@
         "generacion": "7bac29a0-6c49-4baf-8cfc-5bc938f46569",
         "variante": 3
       },
-      "titulo": "A burning pyre with a character from The",
-      "alt": "a burning pyre with a character from The Curiana watching fro",
+      "titulo": "Media cara de hoguera",
+      "alt": "Hombre sentado con uniforme militar oscuro bordado en dorado, junto a una fogata de noche frente a un lago, bajo un cielo estrellado.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -793,7 +793,7 @@
       "serie": "archivo",
       "orden": 26,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le nacen cables del cráneo en vez de pelo, y se enroscan tan apretados alrededor de la nuca que ni ella misma sabría por dónde empezar a peinarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -807,8 +807,8 @@
         "generacion": "d4901187-6a36-4d7b-bba6-cc8b3e65064c",
         "variante": 0
       },
-      "titulo": "A character with blue clothing standing next to",
-      "alt": "a character with blue clothing standing next to a blue backgr",
+      "titulo": "Cables en lugar de pelo",
+      "alt": "Ilustración de una figura humanoide azul con la cabeza cubierta de tubos y cables metálicos en lugar de cabello, sobre fondo azul.",
       "w": 1024,
       "h": 1120,
       "anchos": [
@@ -824,7 +824,7 @@
       "serie": "archivo",
       "orden": 27,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La canoa vacía se queda flotando junto a las casas de palafito sin que nadie la amarre, como si esperara a que bajen los rayos de sol a remarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -838,8 +838,8 @@
         "generacion": "e70f25ae-a584-4382-8393-a6b04b118125",
         "variante": 1
       },
-      "titulo": "A city of stilt houses submerged in crystal-clear",
-      "alt": "A city of stilt houses submerged in crystal-clear turquoise w",
+      "titulo": "Canoa vacía junto al palafito",
+      "alt": "Poblado de casas de madera sobre pilotes con techos de paja, sobre un mar turquesa transparente, con una canoa de madera flotando cerca bajo un cielo con rayos de sol entre las nubes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -855,7 +855,7 @@
       "serie": "archivo",
       "orden": 28,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se ríe con los ojos cerrados y el pelo rizado se le abre alrededor de la cara como una corona que no le cabe entera en el encuadre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -869,8 +869,8 @@
         "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c",
         "variante": 0
       },
-      "titulo": "A close-up of a face and hair lying",
-      "alt": "a close-up of a face and hair lying on the subjects back with",
+      "titulo": "Sonrisa tendida al sol",
+      "alt": "Primer plano del rostro de una persona joven con los ojos cerrados y una sonrisa amplia, cabello rizado oscuro extendido alrededor, fondo azul.",
       "w": 1184,
       "h": 1008,
       "anchos": [
@@ -886,7 +886,7 @@
       "serie": "archivo",
       "orden": 29,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz dorada le cae solo sobre media cara mientras el resto se le pierde en la sombra, y aun así la sonrisa se le nota entera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -900,8 +900,8 @@
         "generacion": "5c5da1a4-e8f6-4f6b-9305-68f6418a107c",
         "variante": 3
       },
-      "titulo": "A close-up of a face and hair lying",
-      "alt": "a close-up of a face and hair lying on the subjects back with",
+      "titulo": "Sonrisa entre la penumbra dorada",
+      "alt": "Primer plano del rostro de una persona con los ojos cerrados y sonriendo, iluminado por una luz cálida sobre fondo oscuro, cabello rizado alrededor.",
       "w": 1184,
       "h": 1008,
       "anchos": [
@@ -917,7 +917,7 @@
       "serie": "archivo",
       "orden": 30,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos capas —una roja, una dorada— cuelgan inmóviles del barandal de piedra mientras el mar de abajo no deja de moverse ni un segundo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -931,8 +931,8 @@
         "generacion": "8b1eff8b-86b7-4b05-87d2-a1b055543ab8",
         "variante": 0
       },
-      "titulo": "A couple in medieval costumes are standing on",
-      "alt": "a couple in medieval costumes are standing on a balcony looki",
+      "titulo": "Capas inmóviles ante el mar",
+      "alt": "Dos personas con vestimenta medieval, una con capa roja y otra con manto dorado, de pie en un balcón de piedra frente al mar bajo un cielo nublado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -948,7 +948,7 @@
       "serie": "archivo",
       "orden": 31,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le brotan líneas de código luminoso por toda la piel, como si el agua azul en la que flota le hubiera filtrado el alfabeto entero de una máquina.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -962,8 +962,8 @@
         "generacion": "5334f21b-36ce-4cce-a069-8989cb3f8098",
         "variante": 1
       },
-      "titulo": "A ethereal portrait of an androgynous entity with",
-      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "titulo": "El alfabeto bajo el agua",
+      "alt": "Retrato de una persona bajo el agua, con el rostro cubierto de patrones de luz digital brillante, en tonos azules y verdes.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -979,7 +979,7 @@
       "serie": "archivo",
       "orden": 32,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le brillan los ojos de un azul tan encendido que hasta las líneas doradas que le cruzan la frente parecen apagadas a su lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -993,8 +993,8 @@
         "generacion": "6bcda6b9-8da9-4d20-a4ff-1f09899e4763",
         "variante": 0
       },
-      "titulo": "A ethereal portrait of an androgynous entity with",
-      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "titulo": "Ojos que apagan el oro",
+      "alt": "Primer plano del rostro de una persona con ojos azules brillantes y marcas doradas luminosas en la frente y las mejillas, fondo con líneas onduladas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1010,7 +1010,7 @@
       "serie": "archivo",
       "orden": 33,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por la única rendija que deja el velo se le asoma una torre roja entera con su ciudad alrededor, y ni así se le mueve un pliegue de la capucha.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1024,8 +1024,8 @@
         "generacion": "c6c72ecd-c49a-4c0b-8fcf-224ad2d05de2",
         "variante": 3
       },
-      "titulo": "A ethereal portrait of an androgynous entity with",
-      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "titulo": "Ciudad tras la capucha",
+      "alt": "Perfil de una persona con una capucha oscura con textura de código digital, con una ciudad iluminada y una torre roja de fondo al atardecer.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1041,7 +1041,7 @@
       "serie": "archivo",
       "orden": 34,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El aro de luz que la rodea gira tan despacio que se alcanzan a leer las cifras antes de que vuelvan a pasar por el mismo punto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1055,8 +1055,8 @@
         "generacion": "d366181b-f041-4ec7-ac65-af4065487095",
         "variante": 3
       },
-      "titulo": "A ethereal portrait of an androgynous entity with",
-      "alt": "A ethereal portrait of an androgynous entity with Mediterrane",
+      "titulo": "El aro de cifras",
+      "alt": "Retrato de una persona con un halo circular de luz y patrones digitales alrededor de la cabeza, vestida de negro, fondo oscuro con tonos azules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1072,7 +1072,7 @@
       "serie": "archivo",
       "orden": 35,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La barca vuelve cada noche a la misma orilla malva, siempre vacía, y en el pueblo hace años que dejaron de preguntar quién la empuja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1086,8 +1086,8 @@
         "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c",
         "variante": 1
       },
-      "titulo": "A fishing boat at the distance in a",
-      "alt": "a fishing boat at the distance in a panoramic view of the sea",
+      "titulo": "La barca que volvió sola",
+      "alt": "Barca de madera azul varada en una orilla de arena violácea, con olas rompiendo alrededor, bajo un cielo azul oscuro con grandes nubes blancas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -1103,7 +1103,7 @@
       "serie": "archivo",
       "orden": 36,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ola rompe tan alto en primer plano que por un instante tapa el barco entero, y un segundo después ahí sigue, azul y de pie sobre el agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1117,8 +1117,8 @@
         "generacion": "6557c402-89eb-49ca-9b63-c27e46c8bc5c",
         "variante": 3
       },
-      "titulo": "A fishing boat at the distance in a",
-      "alt": "a fishing boat at the distance in a panoramic view of the sea",
+      "titulo": "Proa azul entre la espuma",
+      "alt": "Barco de pesca azul y blanco navegando entre olas grandes de un mar turquesa agitado, bajo un cielo tormentoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -1134,7 +1134,7 @@
       "serie": "archivo",
       "orden": 37,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola pluma azul le corona el sombrero y le llega más alto que las palmas del fondo, mientras se apoya en el bastón como si llevara parado desde antes de que naciera el pantano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1148,8 +1148,8 @@
         "generacion": "a96d2253-9451-4208-99d7-e19f177d6b8b",
         "variante": 3
       },
-      "titulo": "A full-body portrait of a Caqueto native American",
-      "alt": "A full-body portrait of a Caqueto native American from the 16",
+      "titulo": "Pluma azul sobre el pantano",
+      "alt": "Retrato de cuerpo entero de un hombre indígena con sombrero de plumas, túnica azul y naranja, sosteniendo un bastón, de pie junto a un pantano con palmeras.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -1164,7 +1164,7 @@
       "serie": "archivo",
       "orden": 38,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Clava la mirada en el horizonte con la lanza en alto, y las olas revientan justo detrás tan fuerte que parecen ir a mojarle las plumas rojas sin tocarlo a él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1178,8 +1178,8 @@
         "generacion": "f617711a-b983-48d4-a347-c3c4ec56ff68",
         "variante": 2
       },
-      "titulo": "A full-body portrait of a Caqueto native American",
-      "alt": "A full-body portrait of a Caqueto native American from the 16",
+      "titulo": "Lanza contra el oleaje",
+      "alt": "Retrato de cuerpo entero de un hombre indígena con tocado de plumas rojas, sosteniendo una lanza, de pie sobre rocas frente al mar con olas rompiendo, luz dorada.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -1194,7 +1194,7 @@
       "serie": "archivo",
       "orden": 39,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El tiburón cruza justo por debajo del sol, y por un segundo el agua entera se le vuelve del mismo oro que lleva encima el arrecife.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1208,8 +1208,8 @@
         "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606",
         "variante": 0
       },
-      "titulo": "A golden shark swimming under the rock among",
-      "alt": "A golden shark swimming under the rock among a reef filled wi",
+      "titulo": "El tiburón y el oro",
+      "alt": "Tiburón nadando bajo el agua junto a un arrecife de coral, con la luz del sol filtrándose en tonos dorados desde la superficie.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -1225,7 +1225,7 @@
       "serie": "archivo",
       "orden": 40,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El coral naranja arde con la fuerza de mil fósforos encendidos a la vez, y el tiburón cruza el incendio entero sin que se le chamusque una sola escama.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1239,8 +1239,8 @@
         "generacion": "1115a773-6645-47e6-a7c4-e31cb2d5a606",
         "variante": 1
       },
-      "titulo": "A golden shark swimming under the rock among",
-      "alt": "A golden shark swimming under the rock among a reef filled wi",
+      "titulo": "El incendio del arrecife",
+      "alt": "Un tiburón nada bajo el agua junto a corales blandos de color naranja brillante, con luz azul oscura filtrándose desde la superficie.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -1256,7 +1256,7 @@
       "serie": "archivo",
       "orden": 41,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva un collar de perlas y sonríe tan fuerte que apaga las lámparas de la cantina, mientras media mesa de hombres espera su turno para hablar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1270,8 +1270,8 @@
         "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e",
         "variante": 0
       },
-      "titulo": "A group of men and women siting around",
-      "alt": "a group of men and women siting around outside of a coffee Vi",
+      "titulo": "El collar en la cantina",
+      "alt": "Fotografía en sepia de una mujer sonriente con collar de perlas sentada junto a una mesa, rodeada de varios hombres en un bar.",
       "w": 1280,
       "h": 944,
       "anchos": [
@@ -1287,7 +1287,7 @@
       "serie": "archivo",
       "orden": 42,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una planta enorme se asoma por detrás solo para escuchar la conversación, y ríe tan fuerte el hombre de la derecha que hace temblar las hojas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1301,8 +1301,8 @@
         "generacion": "061277f0-5cb7-45f9-a66c-f117a1595d1e",
         "variante": 3
       },
-      "titulo": "A group of men and women siting around",
-      "alt": "a group of men and women siting around outside of a coffee Vi",
+      "titulo": "Las hojas que escuchan",
+      "alt": "Fotografía en sepia de una mujer sonriente en el centro de un grupo de cuatro hombres sentados a una mesa, con plantas de fondo.",
       "w": 1280,
       "h": 944,
       "anchos": [
@@ -1318,7 +1318,7 @@
       "serie": "archivo",
       "orden": 43,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las fichas de dominó llevan tantas partidas sobre la misma mesa que ya se les borraron los puntos negros, y el sombrero blanco del centro no se ha movido ni un centímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1332,8 +1332,8 @@
         "generacion": "04bcbef9-0177-4de4-92d8-ca3a3445b4d8",
         "variante": 2
       },
-      "titulo": "A group of men siting around outside of",
-      "alt": "a group of men siting around outside of a cafe in Caracas in",
+      "titulo": "El dominó de la mesa",
+      "alt": "Fotografía en sepia de un grupo de hombres con sombreros sentados alrededor de una mesa con fichas de dominó.",
       "w": 1280,
       "h": 944,
       "anchos": [
@@ -1349,7 +1349,7 @@
       "serie": "archivo",
       "orden": 44,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las hojas de arriba crecieron tan grandes que hacen de techo, y los cuatro sombreros de paja no logran taparles ni la mitad de la cara al sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1363,8 +1363,8 @@
         "generacion": "9815e5d2-2b89-440f-833d-366bb70c7e03",
         "variante": 2
       },
-      "titulo": "A group of men siting around outside of",
-      "alt": "a group of men siting around outside of a cafe in Caracas in",
+      "titulo": "El techo de hojas",
+      "alt": "Fotografía en blanco y negro de cuatro hombres con sombrero sentados a una mesa redonda en un patio, bajo hojas grandes de una planta.",
       "w": 1280,
       "h": 944,
       "anchos": [
@@ -1380,7 +1380,7 @@
       "serie": "archivo",
       "orden": 45,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El viento le alborota el cabello en todas direcciones a la vez, y la guacamaya se le clava en el hombro con las garras tan firmes que no hace falta perchero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1394,8 +1394,8 @@
         "generacion": "5c858b86-ec77-433c-8a4a-486e2d03f9ae",
         "variante": 0
       },
-      "titulo": "A illustration of a man with a parrot",
-      "alt": "a illustration of a man with a parrot standing on his shoulde",
+      "titulo": "El viento y la guacamaya",
+      "alt": "Ilustración de un hombre de perfil con cabello largo ondulado y una guacamaya azul y blanca posada en su hombro, sobre fondo claro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -1411,7 +1411,7 @@
       "serie": "archivo",
       "orden": 46,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene a la guacamaya negra sobre un palo con la misma mano que no ha soltado desde que aprendió a caminar, y el ave todavía no conoce el cielo abierto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1425,8 +1425,8 @@
         "generacion": "ae72417a-d556-4f47-9614-550e9d4dd4ac",
         "variante": 3
       },
-      "titulo": "A illustration of a man with a parrot",
-      "alt": "a illustration of a man with a parrot in the style of dark cr",
+      "titulo": "El ave sobre la mano",
+      "alt": "Pintura de un hombre de rostro serio sosteniendo una guacamaya negra posada en un palo, sobre fondo marrón texturizado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -1442,7 +1442,7 @@
       "serie": "archivo",
       "orden": 47,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada ola carga un ascua entera del atardecer y la arrastra mar adentro, sin que el agua fría alcance jamás a apagarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1456,8 +1456,8 @@
         "generacion": "6d883756-8501-4b16-a9ef-18cf96d57b87",
         "variante": 0
       },
-      "titulo": "A image showing the water lines at the",
-      "alt": "a image showing the water lines at the sunset in the style of",
+      "titulo": "El ascua en el oleaje",
+      "alt": "Primer plano de la superficie del mar con olas pequeñas que reflejan la luz naranja y roja de un atardecer.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1473,7 +1473,7 @@
       "serie": "archivo",
       "orden": 48,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya la mano en la madera como si fuera solo una puerta, sin saber que el ojo del otro lado no ha parpadeado ni una sola vez desde que se abrió el agujero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1487,8 +1487,8 @@
         "generacion": "276c80ab-9a72-4019-972b-2bd45a8200e0",
         "variante": 0
       },
-      "titulo": "A man opening a portal to an alternate",
-      "alt": "A man opening a portal to an alternate psychedelic dimension",
+      "titulo": "El ojo en la puerta",
+      "alt": "Un hombre de traje toca con la mano una pared de tablones de madera con un agujero del que sobresale un ojo grande, junto a un muro de piedra.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1504,7 +1504,7 @@
       "serie": "archivo",
       "orden": 49,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El visor le tapa los ojos, pero no evita que las mil estrellas bordadas en la túnica sigan brillando por su cuenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1518,8 +1518,8 @@
         "generacion": "3a64d32a-0bcb-40e0-b674-bd194df89f53",
         "variante": 1
       },
-      "titulo": "A man wearing a colorful outfit and surrounded",
-      "alt": "a man wearing a colorful outfit and surrounded by stars in th",
+      "titulo": "La túnica de mil estrellas",
+      "alt": "Ilustración de un hombre con visor futurista y una túnica de colores estampada con estrellas, de pie sobre un fondo azul oscuro lleno de estrellas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1535,7 +1535,7 @@
       "serie": "archivo",
       "orden": 50,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Extiende el puño y la guacamaya se queda tan quieta encima que sus plumas rojas se confunden con las mangas de la túnica del mismo color.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1549,8 +1549,8 @@
         "generacion": "082e0a75-c718-406f-8012-bbb48b4e52ef",
         "variante": 1
       },
-      "titulo": "A man wearing a red shirt is holding",
-      "alt": "a man wearing a red shirt is holding an parrot in the style o",
+      "titulo": "La guacamaya del puño",
+      "alt": "Pintura de un hombre con túnica rosa sosteniendo una guacamaya roja sobre el puño, con una bolsa de cuero al hombro y sandalias con diseño geométrico.",
       "w": 800,
       "h": 1385,
       "anchos": [
@@ -1565,7 +1565,7 @@
       "serie": "archivo",
       "orden": 51,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un cometa rojo y azul le atraviesa la cara justo a la altura de los ojos y ya no termina de cruzar: se queda ahí clavado como una cicatriz de luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1579,8 +1579,8 @@
         "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc",
         "variante": 0
       },
-      "titulo": "A man with a blue glowing eye floating",
-      "alt": "A man with a blue glowing eye floating in space with orange a",
+      "titulo": "El cometa en la mirada",
+      "alt": "Rostro de un hombre calvo cruzado por franjas de luz roja, naranja y azul a la altura de los ojos, sobre fondo oscuro con estrellas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1596,7 +1596,7 @@
       "serie": "archivo",
       "orden": 52,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En el centro de la frente lleva engastada una piedra azul tan fría que todavía se le ve humear una estrella por dentro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1610,8 +1610,8 @@
         "generacion": "0af09855-af7a-4b4a-b313-9680609fa9fc",
         "variante": 3
       },
-      "titulo": "A man with a blue glowing eye floating",
-      "alt": "A man with a blue glowing eye floating in space with orange a",
+      "titulo": "La piedra de la frente",
+      "alt": "Ilustración de un rostro con textura tallada en tonos verde azulado y naranja, con una piedra azul circular en el centro de la frente.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1627,7 +1627,7 @@
       "serie": "archivo",
       "orden": 53,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Mira hacia arriba y la única estrella del cielo se le acerca tanto que le tiñe los ojos del mismo azul, sin que ninguna otra se anime a acercarse igual.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1641,8 +1641,8 @@
         "generacion": "3f654dde-14cf-428a-aa72-363c3972aa3a",
         "variante": 2
       },
-      "titulo": "A man with a blue glowing eye orange",
-      "alt": "A man with a blue glowing eye orange skin and a starry sky ba",
+      "titulo": "La estrella sobre la cabeza",
+      "alt": "Rostro de un hombre mirando hacia arriba con los ojos iluminados de azul, bajo una estrella brillante en un cielo nocturno, con tonos naranja y turquesa en la piel.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1658,7 +1658,7 @@
       "serie": "archivo",
       "orden": 54,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El atardecer no terminó de caer del cielo: se le resbaló por la mejilla y ahí sigue escurriendo, naranja arriba y azul abajo, sin llegar nunca al cuello.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1672,8 +1672,8 @@
         "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559",
         "variante": 0
       },
-      "titulo": "A mans face with an eye that glows",
-      "alt": "A mans face with an eye that glows like the night sky close-u",
+      "titulo": "El atardecer en la mejilla",
+      "alt": "Primer plano del ojo y la mejilla de una persona iluminados con un degradado de naranja y azul, sobre fondo oscuro con una estrella brillante.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1689,7 +1689,7 @@
       "serie": "archivo",
       "orden": 55,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Medio rostro se quedó en la Tierra y el otro medio ya se fue a la galaxia, y solo el ojo azul del centro no ha decidido a cuál lado pertenece.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1703,8 +1703,8 @@
         "generacion": "ec48ae3b-06b9-4d88-8a78-2df745c52559",
         "variante": 3
       },
-      "titulo": "A mans face with an eye that glows",
-      "alt": "A mans face with an eye that glows like the night sky close-u",
+      "titulo": "Medio rostro, media galaxia",
+      "alt": "Rostro dividido a la mitad: un lado con piel texturizada y el otro con la imagen de una galaxia, con un ojo azul brillante en el centro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -1720,7 +1720,7 @@
       "serie": "archivo",
       "orden": 56,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El mar le sube por la espalda sin romper nunca en espuma, y el otro sostiene la espada tan floja que ya se le olvidó para qué sirve un filo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1734,8 +1734,8 @@
         "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a",
         "variante": 0
       },
-      "titulo": "A movie still of two men standing next",
-      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "titulo": "El mar a sus espaldas",
+      "alt": "Dos hombres de cabello largo y ropa oscura de pie frente al mar al atardecer; el de atrás sostiene una espada.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -1751,7 +1751,7 @@
       "serie": "archivo",
       "orden": 57,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La hoguera lleva tres días enteros ardiendo a un paso de ellos y todavía no logra chamuscarles ni un hilo de la capa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1765,8 +1765,8 @@
         "generacion": "8c9060ba-2e8d-4fee-b754-3ffac025733a",
         "variante": 1
       },
-      "titulo": "A movie still of two men standing next",
-      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "titulo": "La hoguera que no quema",
+      "alt": "Dos hombres de pie de noche junto a una hoguera encendida; el de atrás sostiene una espada, el de adelante lleva una capa oscura con cuello bordado.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -1782,7 +1782,7 @@
       "serie": "archivo",
       "orden": 58,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar bordado que lleva al cuello guarda más calor que la hoguera entera que arde a un paso de su hombro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1796,8 +1796,8 @@
         "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
         "variante": 1
       },
-      "titulo": "A movie still of two men standing next",
-      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "titulo": "El bordado junto al fuego",
+      "alt": "Primer plano de un hombre de cabello largo con cuello bordado, con una hoguera encendida detrás y otro hombre con una lanza al fondo.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -1813,7 +1813,7 @@
       "serie": "archivo",
       "orden": 59,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Empuña él mismo la espada mientras una línea de fuego arde justo donde termina el mar, y la marea lleva años intentando llegar hasta ahí para apagarla sin conseguirlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1827,8 +1827,8 @@
         "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
         "variante": 2
       },
-      "titulo": "A movie still of two men standing next",
-      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "titulo": "El horizonte en llamas",
+      "alt": "Un hombre de cabello largo sostiene una espada frente al mar, con una franja de fuego ardiendo en el horizonte al atardecer.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -1844,7 +1844,7 @@
       "serie": "archivo",
       "orden": 60,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se planta justo entre el mar y la hoguera, y ninguno de los dos ha logrado en todos estos años quedarse con él, ni el agua ni las llamas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1858,8 +1858,8 @@
         "generacion": "ebe8d497-30cb-4977-b5ec-abd2ef99e25a",
         "variante": 3
       },
-      "titulo": "A movie still of two men standing next",
-      "alt": "a movie still of two men standing next to an exploding bonfir",
+      "titulo": "El mar y la hoguera",
+      "alt": "Dos hombres de pie frente al mar al atardecer, con una gran hoguera ardiendo detrás de ellos; el de atrás sostiene una lanza.",
       "w": 1400,
       "h": 768,
       "anchos": [
@@ -1875,7 +1875,7 @@
       "serie": "archivo",
       "orden": 61,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada hombre de la fila carga el mismo haz de paja al hombro desde el día en que aprendió a caminar, y ya se le volvió oro en las manos de tanto cargarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1889,8 +1889,8 @@
         "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
         "variante": 0
       },
-      "titulo": "A newspaper press image of venezuelan farmers in",
-      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "titulo": "Los haces de paja",
+      "alt": "Ilustración coloreada de una fila de hombres con sombrero cargando haces de paja al hombro, frente a un muro de ladrillo.",
       "w": 1376,
       "h": 864,
       "anchos": [
@@ -1906,7 +1906,7 @@
       "serie": "archivo",
       "orden": 62,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al final de la fila espera un burro tan paciente que ya le echó raíces a las patas, mientras el perro es el único que no lleva sombrero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1920,8 +1920,8 @@
         "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
         "variante": 1
       },
-      "titulo": "A newspaper press image of venezuelan farmers in",
-      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "titulo": "El burro paciente",
+      "alt": "Ilustración coloreada de una fila de hombres con distintos sombreros y ropa, cargando papeles y bultos, con un burro y un perro junto a ellos.",
       "w": 1376,
       "h": 864,
       "anchos": [
@@ -1937,7 +1937,7 @@
       "serie": "archivo",
       "orden": 63,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los caballos arrastran el mismo carromato entre la caña desde hace cien cosechas, y las ruedas todavía no se han gastado ni un centímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1951,8 +1951,8 @@
         "generacion": "fc93100c-d8f5-4ecb-a265-900778e7219c",
         "variante": 2
       },
-      "titulo": "A newspaper press image of venezuelan farmers in",
-      "alt": "a newspaper press image of venezuelan farmers in 1836 for the",
+      "titulo": "Los caballos entre la caña",
+      "alt": "Pintura en tonos sepia de varios caballos tirando de un carro entre plantaciones de caña, con hombres a caballo y de pie sobre el carro.",
       "w": 1376,
       "h": 864,
       "anchos": [
@@ -1968,7 +1968,7 @@
       "serie": "archivo",
       "orden": 64,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El penacho rojo encabeza la carga de lanzas, y el polvo que levantan los pies lleva trescientos años sin volver a tocar el suelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -1982,8 +1982,8 @@
         "generacion": "05209ceb-7716-4755-9e61-88bc03beffb1",
         "variante": 0
       },
-      "titulo": "A painting of soldiers in uniform fighting in",
-      "alt": "a painting of soldiers in uniform fighting in the style of vi",
+      "titulo": "El penacho de la batalla",
+      "alt": "Pintura de guerreros con lanzas y tocados de plumas en pleno combate, con caballos y una nube de polvo en un paisaje abierto bajo un cielo dorado.",
       "w": 1400,
       "h": 679,
       "anchos": [
@@ -1999,7 +1999,7 @@
       "serie": "archivo",
       "orden": 65,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El casco blanco de la estación se curva sobre el valle como un párpado entreabierto, y por su ventana redonda cabe un planeta entero antes de que la luna termine de salir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2013,8 +2013,8 @@
         "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65",
         "variante": 0
       },
-      "titulo": "A painting shows the inside view of a",
-      "alt": "A painting shows the inside view of a space station in orbit",
+      "titulo": "El ojo blanco del valle",
+      "alt": "Vista nocturna de un valle con un pueblo y colinas verdes desde el interior curvo de una estación espacial blanca, con una ventana circular que muestra un planeta y una luna creciente en el cielo morado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -2030,7 +2030,7 @@
       "serie": "archivo",
       "orden": 66,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Desde la terraza curva cuelgan macetas verdes mientras tres lunas y un cometa cruzan el cielo morado sobre la laguna azul del valle, y nadie adentro se asoma a mirarlas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2044,8 +2044,8 @@
         "generacion": "e38b9d5d-d662-4997-bc76-ee88c73e1e65",
         "variante": 1
       },
-      "titulo": "A painting shows the inside view of a",
-      "alt": "A painting shows the inside view of a space station in orbit",
+      "titulo": "Terraza curva bajo tres lunas",
+      "alt": "Vista de un valle verde con una laguna azul y un pueblo, observado desde una terraza curva de una estructura futurista blanca con plantas en macetas, bajo un cielo morado con varias lunas y una estrella fugaz.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -2061,7 +2061,7 @@
       "serie": "archivo",
       "orden": 67,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta el brazo en la proa de la canoa y el ave roja que cruza el cielo parece detenerse un instante a escuchar lo que grita.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2075,8 +2075,8 @@
         "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607",
         "variante": 0
       },
-      "titulo": "A panoramic view of the Amazon rainforest featuring",
-      "alt": "A panoramic view of the Amazon rainforest featuring native in",
+      "titulo": "Brazo alzado en la canoa",
+      "alt": "Dos hombres reman una canoa de madera por un río entre chozas de techo de paja, con árboles tropicales, un ave roja en vuelo y animales cerca de las viviendas, en luz cálida de atardecer.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2092,7 +2092,7 @@
       "serie": "archivo",
       "orden": 68,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Techos cónicos se repiten río arriba tantas veces que el conteo se pierde antes de que la última canoa llegue a la aldea.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2106,8 +2106,8 @@
         "generacion": "2e6dce78-b8b9-4852-ac99-979ab2ef9607",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest featuring",
-      "alt": "A panoramic view of the Amazon rainforest featuring native in",
+      "titulo": "El río de techos cónicos",
+      "alt": "Vista aérea de una aldea con numerosas chozas de techo cónico de paja junto a un río, con varias canoas de madera navegando y transportando personas, rodeada de selva tropical densa.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2123,7 +2123,7 @@
       "serie": "archivo",
       "orden": 69,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se yergue sobre la canoa y hunde la pértiga hasta el fondo del río, y la montaña entera parece inclinarse un grado para verlo pasar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2137,8 +2137,8 @@
         "generacion": "0a8104a1-956e-4d87-bd75-20474b190df3",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Pértiga sobre el agua verde",
+      "alt": "Valle boscoso con montañas al fondo, un río central con dos canoas de madera, una de ellas impulsada con pértiga por una persona de pie, chozas de techo de paja en ambas orillas y animales cerca de ellas.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2154,7 +2154,7 @@
       "serie": "archivo",
       "orden": 70,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una fila de canoas angostas cruza el río en fila india tan larga que la última todavía no ha salido de la aldea cuando la primera ya llegó al otro extremo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2168,8 +2168,8 @@
         "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
         "variante": 0
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El desfile de canoas angostas",
+      "alt": "Aldea con chozas de techo de paja a ambas orillas de un río, varias canoas de madera con remeros navegando en fila, rodeada de selva tropical bajo un cielo nublado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2185,7 +2185,7 @@
       "serie": "archivo",
       "orden": 71,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz cae tan dorada sobre el río que los techos de paja y el agua terminan siendo del mismo metal.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2199,8 +2199,8 @@
         "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Oro sobre el agua verde",
+      "alt": "Aldea de chozas de techo de paja junto a un río con canoas de madera, bajo una luz dorada de atardecer con nubes densas reflejadas en el agua verde-azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2216,7 +2216,7 @@
       "serie": "archivo",
       "orden": 72,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tantas canoas convergen al centro del río que por un instante el agua entera parece un solo cauce hecho de proas apuntando hacia el mismo punto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2230,8 +2230,8 @@
         "generacion": "0ae726c5-c8b8-4955-bc92-1e9d80526aa5",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El cruce de tantas canoas",
+      "alt": "Aldea con chozas de techo cónico de paja a ambos lados de un río, con numerosas canoas de madera con remeros convergiendo hacia el centro, rodeada de palmeras y selva tropical densa, en colores vivos.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2247,7 +2247,7 @@
       "serie": "archivo",
       "orden": 73,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se planta de pie en el agua turquesa y clava la pértiga tan hondo que el mar entero se queda quieto esperando a que la saque.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2261,8 +2261,8 @@
         "generacion": "0b4d111c-ca9e-42ee-850d-c307e741f20f",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "De pie sobre el mar",
+      "alt": "Dos hombres en una bahía de agua turquesa, uno remando una canoa de madera y otro de pie con una pértiga en el agua poco profunda, con palmeras, chozas de paja y montañas al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2278,7 +2278,7 @@
       "serie": "archivo",
       "orden": 74,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La montaña se dobla entera dentro del agua quieta, y el pueblo de techos cónicos parece flotar dos veces, una en la orilla y otra bocabajo en el río.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2292,8 +2292,8 @@
         "generacion": "367d86c3-7841-476a-8189-7989062c6bfa",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Montaña doblada en el agua",
+      "alt": "Paisaje de un lago rodeado de montañas con reflejo especular, un pueblo de chozas de techo cónico en la orilla, canoas de madera y animales cerca del agua, en estilo de pintura clásica de paisaje.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2309,7 +2309,7 @@
       "serie": "archivo",
       "orden": 75,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El azul de la noche se traga la selva entera, menos los techos de paja que guardan la última luz para guiar de vuelta a las canoas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2323,8 +2323,8 @@
         "generacion": "367d86c3-7841-476a-8189-7989062c6bfa",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Canoas que buscan la luz",
+      "alt": "Escena nocturna en tonos azules de un río con varias canoas de madera con remeros, dirigiéndose hacia chozas de techo de paja iluminadas, entre palmeras en silueta.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2340,7 +2340,7 @@
       "serie": "archivo",
       "orden": 76,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Río abajo el verde de la selva se sale de la orilla y se mete en el agua, y el cauce tiene que doblarse dos veces para no ahogarse en tanto color.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2354,8 +2354,8 @@
         "generacion": "708bc812-8883-4007-b4f8-058897fa7860",
         "variante": 0
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El verde desbordado del río",
+      "alt": "Vista de una aldea de chozas de techo de paja a lo largo de un río sinuoso, con varias canoas de madera, rodeada de selva tropical densa bajo un cielo azul con nubes.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2371,7 +2371,7 @@
       "serie": "archivo",
       "orden": 77,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los techos de paja se alinean orilla arriba tantas veces que uno pierde la cuenta antes de que el río termine de doblar la curva.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2385,8 +2385,8 @@
         "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Los techos que nunca acaban",
+      "alt": "Aldea con una larga fila de chozas de techo de paja a lo largo de un río curvo entre selva tropical densa, con canoas de madera navegando, en luz cálida de tarde.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2402,7 +2402,7 @@
       "serie": "archivo",
       "orden": 78,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se aprietan tanto las chozas contra el agua que las canoas piden permiso para pasar entre techo y techo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2416,8 +2416,8 @@
         "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "La aldea que se amontona",
+      "alt": "Aldea densa de chozas de techo de paja agrupadas junto a un río, con canoas de madera navegando entre ellas, rodeada de selva tropical bajo cielo despejado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2433,7 +2433,7 @@
       "serie": "archivo",
       "orden": 79,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Desde tan alto la copa de los árboles se cierra sobre el río como una tapa verde, y solo el brillo del agua entre las canoas deja ver que abajo sigue habiendo un mundo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2447,8 +2447,8 @@
         "generacion": "77621c9a-6c05-4ab4-818a-94bbc015c0d9",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El río desde lo alto",
+      "alt": "Vista elevada de una aldea de chozas de techo de paja junto a un río serpenteante, rodeada de densa selva tropical, con canoas de madera y aves en vuelo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2464,7 +2464,7 @@
       "serie": "archivo",
       "orden": 80,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol se hunde tan despacio detrás de los techos de paja que a los remeros les da tiempo de cruzar el río dos veces antes de que se apague del todo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2478,8 +2478,8 @@
         "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
         "variante": 0
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El oro que se apaga",
+      "alt": "Escena de atardecer con chozas de techo de paja en silueta junto a un río, canoas de madera con remeros en primer plano, bajo un cielo dorado reflejado en el agua.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2495,7 +2495,7 @@
       "serie": "archivo",
       "orden": 81,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Toda choza queda copiada tan exacta en el agua oscura que de noche la aldea tiene el doble de techos que de día.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2509,8 +2509,8 @@
         "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "La noche copia las chozas",
+      "alt": "Vista nocturna en tonos azules de una aldea de chozas de techo de paja junto a un río, con canoas de madera y remeros, reflejos en el agua oscura.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2526,7 +2526,7 @@
       "serie": "archivo",
       "orden": 82,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El río dobla el codo y la aldea entera lo sigue, choza tras choza, hasta agotar la última palmera de la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2540,8 +2540,8 @@
         "generacion": "7fa7aa1a-555b-4a04-bacb-ed3a26faaabe",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El río dobla su codo",
+      "alt": "Aldea de chozas de techo de paja a lo largo de un recodo de un río, con palmeras y canoas de madera con remeros, bajo un cielo azul despejado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2557,7 +2557,7 @@
       "serie": "archivo",
       "orden": 83,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un cono blanco se alza el doble de alto que las demás chozas, y las figuras diminutas se apiñan a su alrededor como si toda la aldea cupiera en ese único triángulo de tela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2571,8 +2571,8 @@
         "generacion": "9a3a4809-b373-4b39-999e-4b6cb904ca8b",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El pico blanco entre techos",
+      "alt": "Vista isométrica en estilo de pixel art de una aldea junto a un río, con chozas de techo marrón, una gran estructura cónica blanca, personas diminutas vestidas de blanco y canoas.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2588,7 +2588,7 @@
       "serie": "archivo",
       "orden": 84,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Brotan las chozas entre los árboles como si el bosque las hubiera sembrado sin orden, y la neblina tarda toda la mañana en decidir cuál dejar ver primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2602,8 +2602,8 @@
         "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
         "variante": 0
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Chozas que brotan del bosque",
+      "alt": "Vista aérea de una selva densa con chozas de techo de paja dispersas entre los árboles junto a un río, bajo una atmósfera con neblina.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2619,7 +2619,7 @@
       "serie": "archivo",
       "orden": 85,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La canoa larga lleva tantos remeros a bordo que hacen falta las montañas del fondo para tener suficiente horizonte donde mirar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2633,8 +2633,8 @@
         "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Canoa larga contra el monte",
+      "alt": "Vista panorámica de un río con una aldea de chozas de techo de paja, una canoa larga con varios remeros, montañas al fondo, bajo un cielo con nubes.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2650,7 +2650,7 @@
       "serie": "archivo",
       "orden": 86,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre las chozas los árboles crecen tan altos que hay que bajar hasta el río y mirar de reojo para encontrar dónde vive la aldea.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2664,8 +2664,8 @@
         "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Árboles que esconden las chozas",
+      "alt": "Aldea de chozas de techo de paja parcialmente oculta entre árboles altos de la selva, junto a un río con canoas de madera, en tonos verdes oscuros.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2681,7 +2681,7 @@
       "serie": "archivo",
       "orden": 87,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cientos de figuras diminutas vestidas de blanco se aprietan junto a las chozas hasta que el suelo entero de la aldea desaparece bajo ellas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2695,8 +2695,8 @@
         "generacion": "bce6a3ab-b605-4f6b-bd92-80c311b32c49",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El enjambre de figuras blancas",
+      "alt": "Vista isométrica en estilo de pixel art de una aldea con numerosas personas diminutas vestidas de blanco reunidas junto a chozas de techo marrón y un río.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2712,7 +2712,7 @@
       "serie": "archivo",
       "orden": 88,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La niebla se traga las colinas del fondo y solo deja libre la franja de chozas junto al río, como si el resto del mundo todavía no hubiera despertado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2726,8 +2726,8 @@
         "generacion": "ef803288-afc1-4ece-8615-40c839eb7926",
         "variante": 1
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Niebla que guarda el río",
+      "alt": "Vista panorámica en tonos verdes apagados de una aldea de chozas de techo de paja junto a un río que serpentea entre selva densa, con colinas neblinosas al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2743,7 +2743,7 @@
       "serie": "archivo",
       "orden": 89,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se curva tanto la laguna alrededor de la aldea que las chozas de una orilla alcanzan a ver su reflejo saludando desde la otra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2757,8 +2757,8 @@
         "generacion": "ef803288-afc1-4ece-8615-40c839eb7926",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "Laguna que abraza la aldea",
+      "alt": "Vista de una laguna verde rodeada de chozas de techo de paja y selva tropical, con canoas de madera, nenúfares en el agua y cielo despejado con nubes.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2774,7 +2774,7 @@
       "serie": "archivo",
       "orden": 90,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Treinta remos golpean el río a la vez frente a la hilera de techos de paja, y ninguno rompe el compás aunque las canoas se crucen sin chocar nunca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2788,8 +2788,8 @@
         "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8",
         "variante": 2
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El desfile de las canoas",
+      "alt": "Vista aérea de una aldea con techos cónicos de paja junto a un río ancho, con varias canoas cargadas de remeros navegando entre la selva verde bajo un cielo verdoso en el horizonte.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2805,7 +2805,7 @@
       "serie": "archivo",
       "orden": 91,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos veces dobla el río antes de llegar a las chozas doradas, y en cada vuelta la canoa que lo sigue gana un remero más.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2819,8 +2819,8 @@
         "generacion": "f53f213f-18c1-4718-9feb-57cffa7861b8",
         "variante": 3
       },
-      "titulo": "A panoramic view of the Amazon rainforest in",
-      "alt": "A panoramic view of the Amazon rainforest in the 16th century",
+      "titulo": "El recodo de las chozas",
+      "alt": "Vista panorámica de una aldea de chozas con techo de paja junto a un río sinuoso, con una canoa con varios pasajeros en primer plano, selva verde y cielo azul con nubes.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -2836,7 +2836,7 @@
       "serie": "archivo",
       "orden": 92,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le crecen dos cajas de metal con diales y cables sobre la cabeza, tan pesadas que los guantes de hule se cierran solos para no salir flotando.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2850,8 +2850,8 @@
         "generacion": "e49fedc8-ee64-4814-ad49-74120091ae72",
         "variante": 0
       },
-      "titulo": "A photo of the first person virtual reality",
-      "alt": "A photo of the first person virtual reality headset designed",
+      "titulo": "El casco de circuitos",
+      "alt": "Hombre con traje azul de mangas largas y guantes negros de hule, con un aparatoso casco de realidad virtual compuesto por cajas metálicas, diales y cables, sobre fondo negro.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -2866,7 +2866,7 @@
       "serie": "archivo",
       "orden": 93,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pelo se le enrosca en rizos tan tupidos que le gana terreno al cuadro entero, mientras la luz dorada solo se queda a vivir en la sonrisa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2880,8 +2880,8 @@
         "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2",
         "variante": 2
       },
-      "titulo": "A photograph of an attractive woman lying on",
-      "alt": "a photograph of an attractive woman lying on her back from ab",
+      "titulo": "El pelo que se derrama",
+      "alt": "Mujer de cabello oscuro y rizado recostada boca arriba con los ojos cerrados y una amplia sonrisa, iluminada por una luz dorada, con un top verde a cuadros y fondo rojo con textura floral.",
       "w": 1184,
       "h": 1008,
       "anchos": [
@@ -2897,7 +2897,7 @@
       "serie": "archivo",
       "orden": 94,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ríe con los ojos cerrados y el pelo abierto en abanico sobre la tela azul, como si la carcajada necesitara todo ese espacio para caber.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2911,8 +2911,8 @@
         "generacion": "fbb795d0-0760-4c67-b43e-5508666e8ec2",
         "variante": 3
       },
-      "titulo": "A photograph of an attractive woman lying on",
-      "alt": "a photograph of an attractive woman lying on her back from ab",
+      "titulo": "Carcajada sobre fondo azul",
+      "alt": "Mujer de cabello oscuro recostada boca arriba, riendo con los ojos cerrados, con el pelo extendido a los lados, vistiendo un top de tirantes finos sobre un fondo azul texturizado.",
       "w": 1184,
       "h": 1008,
       "anchos": [
@@ -2928,7 +2928,7 @@
       "serie": "archivo",
       "orden": 95,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tres figuras de capa roja cruzan el puente de tablas sueltas mientras el cielo entero gira despacio sobre sus cabezas, como si el remolino llevara siglos sin decidirse a caer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2942,8 +2942,8 @@
         "generacion": "9cbb9964-a368-4cde-970d-8f20beadf2c0",
         "variante": 0
       },
-      "titulo": "A photograph of an underwater stilte",
-      "alt": "a photograph of an underwater stilte",
+      "titulo": "El remolino del cielo",
+      "alt": "Aldea de casas de paja sobre pilotes conectadas por puentes de madera sobre agua turquesa, con varias figuras envueltas en capas rojas cruzando los puentes, bajo un remolino azul en espiral en el cielo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -2959,7 +2959,7 @@
       "serie": "archivo",
       "orden": 96,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Con una mano sostiene el fuego y con la otra el hielo, y los cuernos le crecen tanto que dividen el cielo en la mitad que arde y la mitad que congela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -2973,8 +2973,8 @@
         "generacion": "449bdf69-59b3-402c-b3b6-2923f36ad57a",
         "variante": 3
       },
-      "titulo": "A poster for the movie the last angel",
-      "alt": "a poster for the movie the last angel in the style of jeff ea",
+      "titulo": "Cuernos de fuego y hielo",
+      "alt": "Figura con cuernos y brazos extendidos rodeada de llamas anaranjadas de un lado y de una luz azul helada del otro, con figuras más pequeñas alrededor, en una ilustración de fantasía oscura.",
       "w": 1024,
       "h": 1040,
       "anchos": [
@@ -2990,7 +2990,7 @@
       "serie": "archivo",
       "orden": 97,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta la palma hacia el triángulo anaranjado que flota sobre las colinas, y lleva tanto tiempo sosteniéndolo con la mirada que ya ni la túnica roja se le mueve con el viento.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3004,8 +3004,8 @@
         "generacion": "e27d9c25-0f19-4e92-8d52-0144c326feea",
         "variante": 2
       },
-      "titulo": "A scientific manuscript from the renaissance",
-      "alt": "A scientific manuscript from the renaissance",
+      "titulo": "El triángulo que flota",
+      "alt": "Joven de cabello rizado y túnica roja sentado sobre un muro de piedra, con la mano extendida hacia un triángulo anaranjado brillante que flota en el cielo, con un paisaje de colinas al fondo.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -3020,7 +3020,7 @@
       "serie": "archivo",
       "orden": 98,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Nadie recuerda quién la subió a esa roca, pero el cielo lleva ardiendo desde entonces y la piedra sigue fría al tacto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3034,8 +3034,8 @@
         "generacion": "15f9872a-951f-457d-b950-b8e00183ecd5",
         "variante": 0
       },
-      "titulo": "A statue in desert in the style of",
-      "alt": "a statue in desert in the style of bold saturation innovator",
+      "titulo": "El que sostiene el incendio",
+      "alt": "Estatua de un hombre desnudo, de piedra azulada, erguida sobre una roca en un desierto, recortada contra un cielo de nubes rojas y naranjas.",
       "w": 800,
       "h": 1131,
       "anchos": [
@@ -3050,7 +3050,7 @@
       "serie": "archivo",
       "orden": 99,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El trono de roca roja carga con un cuerpo que ya se oxidó entero en verde, y las nubes arden anaranjadas alrededor sin subirle la temperatura ni un grado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3064,8 +3064,8 @@
         "generacion": "0ab1e22d-f52e-44b3-8060-6c8a9f684585",
         "variante": 2
       },
-      "titulo": "A statue in stone is sitting in the",
-      "alt": "a statue in stone is sitting in the desert next to colorful c",
+      "titulo": "El dios verde entre nubes",
+      "alt": "Estatua de bronce verde de una figura masculina barbada y musculosa, sentada sobre un trono de piedra en un peñasco rocoso, bajo un cielo de nubes anaranjadas y rosadas al atardecer.",
       "w": 800,
       "h": 1131,
       "anchos": [
@@ -3080,7 +3080,7 @@
       "serie": "archivo",
       "orden": 100,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las nubes rosadas se apilan detrás como si fueran a sepultar la montaña entera, pero la estatua verde no se inmuta y sigue sentada con la niebla a los pies.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3094,8 +3094,8 @@
         "generacion": "7e10606b-a9cd-4055-bf2f-a50b2153052c",
         "variante": 0
       },
-      "titulo": "A statue in stone is sitting in the",
-      "alt": "a statue in stone is sitting in the desert next to colorful c",
+      "titulo": "El centinela verde",
+      "alt": "Estatua de piedra verde de una figura barbada sentada sobre un pedestal tallado en la cima de una montaña rocosa cubierta de niebla, bajo un cielo de nubes rosadas y rojas.",
       "w": 800,
       "h": 1131,
       "anchos": [
@@ -3110,7 +3110,7 @@
       "serie": "archivo",
       "orden": 101,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se cierran las hojas de palma como cortinas en las cuatro esquinas, y toda la luz del cielo tiene que colarse por el único hueco donde el río dobla hacia el horizonte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3124,8 +3124,8 @@
         "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
         "variante": 0
       },
-      "titulo": "A stunning panoramic view of the Amazon rainforest",
-      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "titulo": "Rayos sobre el río verde",
+      "alt": "Vista panorámica de un río serpenteante entre la selva amazónica densa, enmarcada por hojas de palma oscuras en las esquinas superiores, con haces de luz dorada cayendo sobre el horizonte.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -3141,7 +3141,7 @@
       "serie": "archivo",
       "orden": 102,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos jaguares se apostan cada uno en su esquina de la selva y ninguno pestañea, como si vigilaran que el reflejo de la luna no se le escape al río.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3155,8 +3155,8 @@
         "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
         "variante": 1
       },
-      "titulo": "A stunning panoramic view of the Amazon rainforest",
-      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "titulo": "La luna entre dos jaguares",
+      "alt": "Vista panorámica nocturna de un río entre la selva amazónica bajo una luna llena y un cielo azul oscuro con nubes, con dos felinos manchados apostados en las esquinas inferiores del primer plano.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -3172,7 +3172,7 @@
       "serie": "archivo",
       "orden": 103,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Abre tanto las alas el ave negra que le tapa medio horizonte anaranjado a los tucanes, y ellos se quedan con la otra mitad desde la rama de al lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3186,8 +3186,8 @@
         "generacion": "68b7c25c-ec68-413c-932f-6e336a1ed561",
         "variante": 2
       },
-      "titulo": "A stunning panoramic view of the Amazon rainforest",
-      "alt": "A stunning panoramic view of the Amazon rainforest dense with",
+      "titulo": "El ave sobre el río",
+      "alt": "Vista panorámica de un río entre la selva amazónica al atardecer, con un ave negra volando en primer plano y dos tucanes posados en una rama a la derecha, bajo un cielo anaranjado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -3203,7 +3203,7 @@
       "serie": "archivo",
       "orden": 104,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La aldea entera se vació hacia la orilla del río y solo un remero se quedó en el agua, remando despacio para no interrumpir a nadie.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3217,8 +3217,8 @@
         "generacion": "6935c284-0eb1-42c3-aa2c-78a800a04ec8",
         "variante": 2
       },
-      "titulo": "A wide highly realistic painting-style scene of the",
-      "alt": "A wide highly realistic painting-style scene of the Amazon ra",
+      "titulo": "La multitud junto al río",
+      "alt": "Escena de una aldea junto a un río verde con una gran multitud de personas reunidas frente a chozas de paja, un hombre remando en canoa en primer plano, bajo una luz dorada de atardecer.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -3234,7 +3234,7 @@
       "serie": "archivo",
       "orden": 105,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tanto tiempo lleva girando el remolino azul sobre el pasto anaranjado que los que bailan en corro ya solo saben moverse en esa misma dirección.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3248,8 +3248,8 @@
         "generacion": "38c61c86-4737-4ece-82c1-715643ce963a",
         "variante": 2
       },
-      "titulo": "A witches covenant dances around in",
-      "alt": "a witches covenant dances around in",
+      "titulo": "La ronda bajo el remolino",
+      "alt": "Grupo de figuras con túnicas verdiazules y tocados con cuernos bailando en círculo sobre pasto anaranjado, bajo un gran remolino azul oscuro que gira en el cielo nocturno.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3265,7 +3265,7 @@
       "serie": "archivo",
       "orden": 106,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna se apaga entera detrás de un círculo negro y las capas pálidas de los que caminan por la arena son lo único que sigue brillando.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3279,8 +3279,8 @@
         "generacion": "adf8f0b4-3989-4bcf-95d8-d935b8a529e5",
         "variante": 3
       },
-      "titulo": "A witches covenant dances around in",
-      "alt": "a witches covenant dances around in",
+      "titulo": "La luna negra del desierto",
+      "alt": "Varias figuras envueltas en túnicas blancas caminan por el desierto con las manos extendidas entre sí, bajo un cielo estrellado con una forma circular oscura y una gran roca a un lado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3296,7 +3296,7 @@
       "serie": "archivo",
       "orden": 107,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se doblan los árboles negros hacia adentro hasta cerrar un círculo perfecto alrededor del corro, y solo una estrella se asoma por el hueco que dejan las copas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3310,8 +3310,8 @@
         "generacion": "0b1de8a5-db0e-4dd7-b6b4-0a9f307576cb",
         "variante": 0
       },
-      "titulo": "A witches covenant dances around in circles with",
-      "alt": "a witches covenant dances around in circles with the main wit",
+      "titulo": "El círculo de árboles negros",
+      "alt": "Ilustración de varias figuras con túnicas largas reunidas en un claro circular rodeado de árboles oscuros y retorcidos con follaje pálido, bajo un cielo nocturno con una sola estrella visible.",
       "w": 2048,
       "h": 2048,
       "anchos": [
@@ -3328,7 +3328,7 @@
       "serie": "archivo",
       "orden": 108,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El círculo azul cuelga tan redondo en el cielo que parece pintado con compás, y las capas negras alargan su sombra hasta la duna siguiente.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3342,8 +3342,8 @@
         "generacion": "9662a3ab-0a0d-44f4-94b5-3dcb2ce8f061",
         "variante": 2
       },
-      "titulo": "A witches covenant dances around in circles with",
-      "alt": "a witches covenant dances around in circles with the main wit",
+      "titulo": "Capas negras bajo el círculo",
+      "alt": "Grupo de figuras con túnicas y capuchas negras caminando en fila sobre dunas de arena anaranjada, bajo un gran círculo azul pálido en un cielo oscuro y estrellado, con una roca a la derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3359,7 +3359,7 @@
       "serie": "archivo",
       "orden": 109,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Todo alrededor del auto rojo se deshace en líneas de velocidad dentro del túnel azul, menos el piloto, que no ha parpadeado desde que entró.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3373,8 +3373,8 @@
         "generacion": "4a09ab60-bcd9-4b8f-a93e-820962717430",
         "variante": 0
       },
-      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
-      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "titulo": "El rojo dentro del vórtice",
+      "alt": "Vehículo rojo en forma de nave con un piloto visible en la cabina, atravesando a toda velocidad un túnel espiral azul con estelas de luz y desenfoque de movimiento.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -3390,7 +3390,7 @@
       "serie": "archivo",
       "orden": 110,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nave alargada vuela tan pegada a las rocas rojas que su propia sombra llega al portal verde antes que el casco, apurada por entrar primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3404,8 +3404,8 @@
         "generacion": "c374e7ab-e3ea-438e-828b-81ad3952de4f",
         "variante": 0
       },
-      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
-      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "titulo": "Rumbo al portal verde",
+      "alt": "Ilustración de una nave espacial alargada de color beige volando sobre un terreno rocoso rojizo, dirigiéndose hacia un portal luminoso en un cielo verde con estrellas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -3421,7 +3421,7 @@
       "serie": "archivo",
       "orden": 111,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cae en picada la nave oscura y deja detrás una decena de estelas rojas, tantas que el azul del fondo apenas se le nota entre líneas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3435,8 +3435,8 @@
         "generacion": "e0394adf-b46b-4d1e-8a0c-c25091d57622",
         "variante": 1
       },
-      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
-      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "titulo": "Estelas rojas sobre azul",
+      "alt": "Nave espacial oscura descendiendo en picada con varias estelas de luz roja detrás, sobre un fondo azul con gotas de agua visibles en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -3452,7 +3452,7 @@
       "serie": "archivo",
       "orden": 112,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El casco no se le mueve un milímetro mientras cabalga el torpedo en medio de una explosión verde que dispara sus chispas hacia los cuatro bordes de la imagen.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3466,8 +3466,8 @@
         "generacion": "e1f55ea6-93a3-4f95-a9e2-413949e85049",
         "variante": 2
       },
-      "titulo": "A4bUp4 Spaceship going through a Spacial Wo",
-      "alt": "a4bUp4 Spaceship going through a Spacial Wo",
+      "titulo": "Jinete del torpedo verde",
+      "alt": "Persona con casco montada sobre un vehículo con forma de torpedo, en medio de una explosión de partículas verdes y blancas que se dispersan en todas direcciones.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -3483,7 +3483,7 @@
       "serie": "archivo",
       "orden": 113,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva tantos collares superpuestos en el pecho que parece que cada camello de la fila detrás le regaló una vuelta antes de perderse en la duna.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3497,8 +3497,8 @@
         "generacion": "2c100109-7f0d-4256-9c55-acb78e864f8e",
         "variante": 3
       },
-      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
-      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "titulo": "Rostro y camellos al fondo",
+      "alt": "Retrato de una persona con capucha azul oscuro y varios collares superpuestos, mirando de frente, con una fila de camellos caminando desenfocada en las dunas del desierto detrás, bajo un cielo azul.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -3514,7 +3514,7 @@
       "serie": "archivo",
       "orden": 114,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un disco metálico enorme viaja amarrado al primer camello y le devuelve tanta luz al atardecer que el resto de la caravana avanza guiándose por su brillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3528,8 +3528,8 @@
         "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8",
         "variante": 1
       },
-      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
-      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "titulo": "El disco de la caravana",
+      "alt": "Grupo de personas con túnicas anaranjadas y turbantes montadas en camellos, cruzando dunas de arena roja al atardecer, con un objeto redondo y metálico atado a la montura del primer camello.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3545,7 +3545,7 @@
       "serie": "archivo",
       "orden": 115,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Justo cuando el cielo se pone azul oscuro, el camello de adelante gira la cabeza hacia quien mira, y ningún jinete detrás se atreve a taparle la vista.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3559,8 +3559,8 @@
         "generacion": "956e1767-4741-44d4-89bc-f50d4a73cef8",
         "variante": 3
       },
-      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
-      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "titulo": "Turbantes contra el cielo azul",
+      "alt": "Tres jinetes con turbantes y túnicas oscuras y anaranjadas montados en camellos sobre dunas de arena, con un objeto redondo atado a la montura del primero, bajo un cielo azul oscuro al atardecer.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3576,7 +3576,7 @@
       "serie": "archivo",
       "orden": 116,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El velo de plata del jinete que abre la fila guarda tanto sol de mediodía que todavía alumbra cuando ya cayó la noche sobre las dunas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3590,8 +3590,8 @@
         "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529",
         "variante": 0
       },
-      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
-      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "titulo": "El velo de plata",
+      "alt": "Tres jinetes envueltos en telas plateada, naranja y bordada cabalgan camellos adornados con cuentas sobre dunas doradas, bajo un cielo azul oscuro al atardecer.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3607,7 +3607,7 @@
       "serie": "archivo",
       "orden": 117,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruza las dunas envuelto en una tela tan blanca que ninguna tormenta de arena en el camino logró mancharla, y detrás de él la fila entera de camellos guarda el mismo silencio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3621,8 +3621,8 @@
         "generacion": "cf75e38b-5704-411c-8a1f-a863b0b91529",
         "variante": 2
       },
-      "titulo": "Album Cover of a Desert Caravan Tuareg Nomad",
-      "alt": "Album Cover of a Desert Caravan Tuareg Nomad Family in single",
+      "titulo": "El manto blanco del guía",
+      "alt": "Una fila de camellos con jinetes cubiertos de telas blanca y naranja avanza por dunas doradas bajo un cielo azul con nubes, con arneses de cuentas de colores.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3638,7 +3638,7 @@
       "serie": "archivo",
       "orden": 118,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un hilo de luz de arcoíris le atraviesa la cara de sien a sien, y desde esa noche ve el mundo partido en siete colores exactos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3652,8 +3652,8 @@
         "generacion": "b273ea04-25d3-486c-bb6f-b9815b7c47b0",
         "variante": 2
       },
-      "titulo": "Alternative rock album cover art with Latin american",
-      "alt": "alternative rock album cover art with Latin american boy with",
+      "titulo": "El destello entre los ojos",
+      "alt": "Retrato nocturno granulado de un joven de cabello oscuro y rizado con un destello de luz de colores cruzándole los ojos, con una segunda persona en sombra detrás, bajo un cielo con una estrella.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3669,7 +3669,7 @@
       "serie": "archivo",
       "orden": 119,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los anillos naranjas detrás de su cabeza cuentan los años que ha vivido dos veces, una de frente y otra de perfil, azul y amarillo a la vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3683,8 +3683,8 @@
         "generacion": "d1218760-3e2d-43e1-a458-fb84bd3a6ab8",
         "variante": 2
       },
-      "titulo": "Alternative rock album cover art with Latin american",
-      "alt": "alternative rock album cover art with Latin american boy with",
+      "titulo": "Doble rostro en anillos",
+      "alt": "Retrato de doble exposición de un joven de cabello rizado en tonos azul y amarillo, con un segundo perfil superpuesto a la izquierda, sobre un fondo de círculos concéntricos naranjas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3700,7 +3700,7 @@
       "serie": "archivo",
       "orden": 120,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El espejo de marco dorado le copia la espalda con tanta fidelidad que, si se diera vuelta, encontraría ahí a alguien que lleva años esperándolo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3714,8 +3714,8 @@
         "generacion": "bbb5bc58-7cdf-44d9-ac96-f428e2dd3adb",
         "variante": 0
       },
-      "titulo": "Alternative rock album cover with Latin american boy",
-      "alt": "alternative rock album cover with Latin american boy with an",
+      "titulo": "El espejo que la sigue",
+      "alt": "Joven de cabello oscuro y rizado de pie en una habitación en penumbra con luz azul verdosa, frente a un espejo de marco dorado que refleja su espalda, con cuadros colgados en la pared.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3731,7 +3731,7 @@
       "serie": "archivo",
       "orden": 121,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sube el humo del cigarrillo tan despacio entre las flores bordadas de la blusa que la sombra de la palma en la ventana no alcanza a moverse mientras tanto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3745,8 +3745,8 @@
         "generacion": "47a3c46f-8cc6-464d-ad5d-d29a2d82f8de",
         "variante": 3
       },
-      "titulo": "An asian girl holding a cigarette in a",
-      "alt": "an asian girl holding a cigarette in a chair in the style of",
+      "titulo": "El humo entre flores oscuras",
+      "alt": "Mujer joven de cabello negro corto sentada en un sillón de madera tallada, con blusa de flores oscuras, sosteniendo un cigarrillo encendido, frente a una ventana con sombra de hojas de palma.",
       "w": 1024,
       "h": 1184,
       "anchos": [
@@ -3762,7 +3762,7 @@
       "serie": "archivo",
       "orden": 122,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El gato blanco se puso sombrero de flores y saco azul para tomar el té, y desde entonces ninguna taza de la casa se atreve a hacer ruido contra el plato.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3776,8 +3776,8 @@
         "generacion": "a8c27f5c-4331-4d56-b487-7bea6fc85c07",
         "variante": 3
       },
-      "titulo": "An Oil painting of a surreal world a",
-      "alt": "An Oil painting of a surreal world a white rabbit with red ey",
+      "titulo": "Sombrero floreado del gato",
+      "alt": "Pintura al óleo de un gato blanco antropomorfizado con sombrero de copa floreado y saco azul, sentado a una mesa con una taza de té de porcelana y un plato con tapa plateada.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3793,7 +3793,7 @@
       "serie": "archivo",
       "orden": 123,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los cables le nacen del cráneo como pelo eléctrico y arden en naranja por las cuencas vacías, con corriente suficiente para iluminar una ciudad entera si alguien se atreviera a tocarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3807,8 +3807,8 @@
         "generacion": "174e70bc-915f-4c5c-b5f9-1ec96a105387",
         "variante": 0
       },
-      "titulo": "An oil painting of an artificial creature with",
-      "alt": "an oil painting of an artificial creature with blue clothing",
+      "titulo": "Cráneo de cables encendidos",
+      "alt": "Pintura de una criatura biomecánica con cráneo blanco, cables saliendo de la cabeza y cuencas de los ojos con luz naranja brillante, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1120,
       "anchos": [
@@ -3824,7 +3824,7 @@
       "serie": "archivo",
       "orden": 124,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los signos incrustados en la piedra cambian de orden cuando nadie mira, y por eso nadie ha terminado nunca de leer el collar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3838,8 +3838,8 @@
         "generacion": "ac0acb64-7a6a-458a-af42-41163c998f79",
         "variante": 3
       },
-      "titulo": "Ancient Arawak Symbol of Buchibe",
-      "alt": "Ancient Arawak Symbol of Buchibe",
+      "titulo": "El collar que se lee solo",
+      "alt": "Amuleto de piedra verde oscura en forma de herradura, con espirales en los extremos y signos geométricos color hueso incrustados, sobre fondo azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3855,7 +3855,7 @@
       "serie": "archivo",
       "orden": 125,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El trazo blanco que dibuja el perfil con penacho no se levanta del papel ni una sola vez, de la corona hasta la última pluma.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3869,8 +3869,8 @@
         "generacion": "0f6a3f01-25a0-465e-9407-371700aff702",
         "variante": 0
       },
-      "titulo": "Ancient Mayan Symbol of Buchibe",
-      "alt": "Ancient Mayan Symbol of Buchibe",
+      "titulo": "El perfil de Buchibé",
+      "alt": "Logotipo con el texto 'Buchibé' en letras blancas manuscritas y, debajo, la ilustración en línea blanca del perfil de un rostro con tocado de plumas, sobre fondo azul marino.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3886,7 +3886,7 @@
       "serie": "archivo",
       "orden": 126,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Con el maletín bien sujeto y las gafas redondas sin resbalarle del hocico, el capibara luce el saco floreado como si llevara ahí dentro todo un río.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3900,8 +3900,8 @@
         "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
         "variante": 1
       },
-      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
-      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "titulo": "El capibara del maletín",
+      "alt": "Retrato de un capibara con cuerpo humano vestido con saco floreado turquesa, camisa blanca y gafas redondas, sosteniendo un maletín oscuro, sobre fondo azul liso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3917,7 +3917,7 @@
       "serie": "archivo",
       "orden": 127,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sentado en la piedra más alta del cerro, el capibara se guarda el atardecer entero detrás de los lentes oscuros y no piensa devolverlo hasta que amanezca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3931,8 +3931,8 @@
         "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
         "variante": 2
       },
-      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
-      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "titulo": "Capibara al filo del monte",
+      "alt": "Capibara con cuerpo humano vestido con saco verde azulado y gafas de sol, sentado sobre una roca frente a montañas nocturnas con franjas horizontales rosadas y moradas, sosteniendo un maletín.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3948,7 +3948,7 @@
       "serie": "archivo",
       "orden": 128,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De pie contra un cielo con apenas un puñado de estrellas, el capibara sostiene el maletín con la misma calma con que sostendría una junta directiva de otro planeta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3962,8 +3962,8 @@
         "generacion": "3eee0cc1-7036-4a1d-abb8-fe9dbd0bde8f",
         "variante": 3
       },
-      "titulo": "Anthropomorfic capybara in a funky 70s attire from",
-      "alt": "Anthropomorfic capybara in a funky 70s attire from out of spa",
+      "titulo": "Capibara bajo pocas estrellas",
+      "alt": "Capibara con cuerpo humano vestido con blazer color vino y gafas de montura roja, de pie frente a un cielo nocturno con estrellas dispersas, sosteniendo un maletín oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -3979,7 +3979,7 @@
       "serie": "archivo",
       "orden": 129,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El saco morado con dibujos de paisley le sienta al capibara con la autoridad de alguien que ha cerrado más tratos sentado que de pie.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -3993,8 +3993,8 @@
         "generacion": "c77d28f5-80cd-400c-a21c-6417815935c0",
         "variante": 3
       },
-      "titulo": "Anthropomorfic capybara in a funky 70s attire with",
-      "alt": "Anthropomorfic capybara in a funky 70s attire with grovvy gla",
+      "titulo": "Capibara de saco morado",
+      "alt": "Capibara con cuerpo humano vestido con blazer estampado morado y camisa con dibujos, gafas de sol, sentado con una mano apoyada sobre una superficie oscura, fondo verde azulado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4010,7 +4010,7 @@
       "serie": "archivo",
       "orden": 130,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se turnan el arco del violín y el cuerno dorado los ángeles, entre nube y nube, y ninguno para de tocar aunque las alas se les llenen de niebla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4024,8 +4024,8 @@
         "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c",
         "variante": 2
       },
-      "titulo": "Artwork cover featuring an orchestra",
-      "alt": "artwork cover featuring an orchestra",
+      "titulo": "Ángeles con violín y cuerno",
+      "alt": "Pintura clásica en tonos sepia de varios ángeles con alas tocando violín, violonchelo y un instrumento de viento entre nubes.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4041,7 +4041,7 @@
       "serie": "archivo",
       "orden": 131,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arpa dorada suena tan fuerte entre las nubes que las alas de los ángeles que tocan violín se les abren solas, sin que ellos lo pidan.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4055,8 +4055,8 @@
         "generacion": "5a42a435-d5cf-4360-802f-8b013732ab9c",
         "variante": 3
       },
-      "titulo": "Artwork cover featuring an orchestra",
-      "alt": "artwork cover featuring an orchestra",
+      "titulo": "Cuerdas doradas entre nubes",
+      "alt": "Pintura clásica de ángeles alados tocando violín, un arpa dorada y un instrumento de viento entre nubes, en tonos dorados y rojizos con un fragmento de cielo azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4072,7 +4072,7 @@
       "serie": "archivo",
       "orden": 132,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El círculo negro se enrolla sobre sí mismo tantas veces que ya no encuentra la salida, y en el centro exacto deja apenas el hueco justo para una palabra dorada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4086,8 +4086,8 @@
         "generacion": "bd400d8d-2d50-420b-9486-27ac98513ae1",
         "variante": 3
       },
-      "titulo": "Award winning logo design for Curian",
-      "alt": "Award winning logo design for Curian",
+      "titulo": "Espiral de la sintonía",
+      "alt": "Logotipo circular formado por anillos negros concéntricos sobre fondo gris claro, con la palabra 'Curiana' en letras doradas en el centro y 'Radio' en negro en la esquina inferior izquierda.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -4103,7 +4103,7 @@
       "serie": "archivo",
       "orden": 133,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El brazo del hombre apunta al sol y el sol le devuelve el gesto con rayos tan largos que le llegan hasta los escalones donde tiene los pies.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4117,8 +4117,8 @@
         "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
         "variante": 0
       },
-      "titulo": "Aztec Ritual",
-      "alt": "Aztec Ritual",
+      "titulo": "El sol que responde",
+      "alt": "Grabado coloreado a mano de dos figuras en un templo escalonado, una con tocado de plumas y otra señalando un gran sol con rostro humano en el cielo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4134,7 +4134,7 @@
       "serie": "archivo",
       "orden": 134,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pirámide de piedra se construyó tan alta para poder mirar al sol de frente que ahora las nubes bajas le pasan por debajo de los escalones.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4148,8 +4148,8 @@
         "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
         "variante": 1
       },
-      "titulo": "Aztec Ritual",
-      "alt": "Aztec Ritual",
+      "titulo": "Templo frente al sol",
+      "alt": "Grabado coloreado a mano de un templo escalonado con varias figuras con tocados de plumas frente a un gran sol con rostro humano en el cielo, en tonos amarillo, azul y rojo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4165,7 +4165,7 @@
       "serie": "archivo",
       "orden": 135,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre los dos hombres arde un fuego tan pequeño que cabe en una olla, pero el sol de arriba se agacha igual para calentarse las manos con él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4179,8 +4179,8 @@
         "generacion": "7ca5a234-02ee-43a5-a578-25db560d10a1",
         "variante": 3
       },
-      "titulo": "Aztec Ritual",
-      "alt": "Aztec Ritual",
+      "titulo": "Fuego entre dos tocados",
+      "alt": "Grabado coloreado a mano de dos figuras, una con corona y vestido verde y otra con tocado de plumas, de pie junto a un brasero con fuego, bajo un gran sol con rostro humano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4196,7 +4196,7 @@
       "serie": "archivo",
       "orden": 136,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pájaro se paró justo en la flor más alta del nopal, y desde ahí su cresta roja compite con las espinas por ver quién pincha más fuerte el cielo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4210,8 +4210,8 @@
         "generacion": "054efa4b-83ab-4a07-b154-fcd2ef38b3a7",
         "variante": 3
       },
-      "titulo": "Belorus benthicus perched on the top of cactus",
-      "alt": "belorus benthicus perched on the top of cactus in the style o",
+      "titulo": "Corona roja sobre espinas",
+      "alt": "Fotografía de un ave con cresta roja y anaranjada, pecho moteado y pico oscuro, posada sobre un nopal con flores anaranjadas, con fondo verde desenfocado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4227,7 +4227,7 @@
       "serie": "archivo",
       "orden": 137,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los botones dorados del uniforme brillan más que la luna llena que tiene enfrente, y el barco de tres mástiles no se atreve a zarpar mientras él siga mirando.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4241,8 +4241,8 @@
         "generacion": "79d21059-fc90-4232-85cd-034190ca90b2",
         "variante": 2
       },
-      "titulo": "Birds Eye View of Simn Bolvar in his",
-      "alt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+      "titulo": "El uniforme frente al mar",
+      "alt": "Ilustración de un hombre con uniforme militar oscuro de pie en una playa tropical de noche, mirando hacia un barco de vela con tres mástiles sobre el mar iluminado por la luna llena, con palmeras alrededor.",
       "w": 768,
       "h": 512,
       "anchos": [
@@ -4257,7 +4257,7 @@
       "serie": "archivo",
       "orden": 138,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las olas rompen contra las rocas con la misma insistencia con que él mira el barco, y ni la luna llena que tienen encima logra que ninguno de los dos ceda primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4271,8 +4271,8 @@
         "generacion": "f25b94cb-6c1c-4589-82d8-fbd36b9b9e64",
         "variante": 0
       },
-      "titulo": "Birds Eye View of Simn Bolvar in his",
-      "alt": "Birds Eye View of Simn Bolvar in his night clothes walking on",
+      "titulo": "La espera bajo la luna",
+      "alt": "Ilustración de un hombre con uniforme militar oscuro visto de perfil en una costa rocosa de noche, con un barco de vela de tres mástiles sobre el mar bajo una luna llena y cielo estrellado.",
       "w": 1400,
       "h": 933,
       "anchos": [
@@ -4288,7 +4288,7 @@
       "serie": "archivo",
       "orden": 139,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Echa la cabeza tan atrás que la luz le resbala por el cuello entero antes de encontrarle la cara escondida detrás de los lentes redondos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4302,8 +4302,8 @@
         "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db",
         "variante": 0
       },
-      "titulo": "Black and white photo of an albino african",
-      "alt": "black and white photo of an albino african man with short hai",
+      "titulo": "El cuello hacia la luz",
+      "alt": "Fotografía en blanco y negro de un hombre de cabello corto y claro, con gafas de sol redondas, cabeza inclinada hacia atrás, torso desnudo con una cadena fina, sobre fondo negro con iluminación lateral.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4319,7 +4319,7 @@
       "serie": "archivo",
       "orden": 140,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva dos cadenas al cuello y ninguna pesa lo que pesan las marcas que tiene en el hombro, justo ahí donde la luz decide no entrar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4333,8 +4333,8 @@
         "generacion": "2336f400-2771-4c6b-b5a1-14b860cb47db",
         "variante": 3
       },
-      "titulo": "Black and white photo of an albino african",
-      "alt": "black and white photo of an albino african man with short hai",
+      "titulo": "Perfil de cadenas dobles",
+      "alt": "Fotografía en blanco y negro de un hombre de cabello corto y claro, con gafas de sol, visto de perfil con la cabeza hacia arriba, cadenas al cuello y marcas visibles en el hombro, sobre fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4350,7 +4350,7 @@
       "serie": "archivo",
       "orden": 141,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cabello rizado y decolorado le pesa tan poco que se le levanta solo contra el fondo gris, mientras las cadenas del cuello sí se quedan quietas por él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4364,8 +4364,8 @@
         "generacion": "97ee7a87-27e9-461f-a72a-582039698f83",
         "variante": 3
       },
-      "titulo": "Black and white photography of young black man",
-      "alt": "black and white photography of young black man with short cur",
+      "titulo": "Rizos claros contra el gris",
+      "alt": "Fotografía en blanco y negro de un joven de cabello rizado claro y gafas de sol redondas, mirando hacia arriba, con varias cadenas al cuello, torso desnudo, sobre fondo gris de estudio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4381,7 +4381,7 @@
       "serie": "archivo",
       "orden": 142,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva tres cadenas de oro superpuestas al cuello y ninguna se mueve un milímetro aunque el fondo verde entero vibre a su alrededor.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4395,8 +4395,8 @@
         "generacion": "da806bcd-b383-4779-b92f-78ac33cf1a54",
         "variante": 0
       },
-      "titulo": "Black woman with short blonde hair side view",
-      "alt": "black woman with short blonde hair side view black t shirt an",
+      "titulo": "Cadenas de oro en verde",
+      "alt": "Retrato de perfil de una mujer de cabello corto rizado decolorado en rubio, con varios collares dorados superpuestos sobre una camiseta negra, sobre fondo verde, con luz cálida sobre el rostro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4412,7 +4412,7 @@
       "serie": "archivo",
       "orden": 143,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ocho círculos rojos se le quedan clavados en el lomo amarillo, girando lento como ojos que nunca terminan de despertar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4426,8 +4426,8 @@
         "generacion": "c6cc4308-0a06-427a-9f0e-17652ea0769d",
         "variante": 1
       },
-      "titulo": "Blue chivo arawak chaman pixel art s",
-      "alt": "Blue chivo arawak chaman pixel art s",
+      "titulo": "Bestia de círculos rojos",
+      "alt": "Ilustración de estilo folclórico de un animal con cabeza azul y cuernos, cuerpo amarillo con textura de líneas y círculos rojos concéntricos, patas azules con pezuñas rojas, sobre fondo negro.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -4443,7 +4443,7 @@
       "serie": "archivo",
       "orden": 144,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le crecen siete ojos azules en la cara y todos miran para el mismo lado a la vez, sin que ninguno pestañee primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4457,8 +4457,8 @@
         "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3",
         "variante": 1
       },
-      "titulo": "Blue chivo arawak chaman pixel art s",
-      "alt": "Blue chivo arawak chaman pixel art s",
+      "titulo": "Rostro de los siete ojos",
+      "alt": "Ilustración de estilo folclórico de un rostro azul con múltiples ojos concéntricos dispuestos en el rostro, fondo amarillo, cuello rojo, cabello y ropa con textura de líneas negras.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -4474,7 +4474,7 @@
       "serie": "archivo",
       "orden": 145,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La corona le dispara veinte puñales de tela roja y azul hacia todos los puntos del cielo, y con la garra abierta parece que fuera a atrapar el que se le escape.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4488,8 +4488,8 @@
         "generacion": "fef0cd6f-265e-485d-98d0-6ed4810556f3",
         "variante": 2
       },
-      "titulo": "Blue chivo arawak chaman pixel art s",
-      "alt": "Blue chivo arawak chaman pixel art s",
+      "titulo": "El dios de las dagas",
+      "alt": "Ilustración de estilo folclórico de una criatura con rostro verdoso de tres ojos y colmillos, tocado radial de picos rojos y azules, cuerpo escamoso, con una garra extendida, fondo amarillo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -4505,7 +4505,7 @@
       "serie": "archivo",
       "orden": 146,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol se cae entero sobre el agua y las olas lo parten en quinientos pedazos de naranja sin que ninguno se hunda.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4519,8 +4519,8 @@
         "generacion": "9b658c20-a0a5-4f49-b4b0-cbe3beb2b39e",
         "variante": 0
       },
-      "titulo": "Blue orange and yellow lines in water at",
-      "alt": "blue orange and yellow lines in water at sunset in the style",
+      "titulo": "Sol partido en el agua",
+      "alt": "Fotografía de cerca de la superficie del agua con ondas, reflejando luz de atardecer en tonos naranja y amarillo sobre agua de tono púrpura azulado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -4536,7 +4536,7 @@
       "serie": "archivo",
       "orden": 147,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cuerno se le desenfoca en el aire como si la niebla misma no terminara de decidir si es de verdad.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4550,8 +4550,8 @@
         "generacion": "dd18d582-6646-4235-a676-0fc241cf7365",
         "variante": 2
       },
-      "titulo": "Blurry surreal photograph of a white unicorn galloping",
-      "alt": "Blurry surreal photograph of a white unicorn galloping in a d",
+      "titulo": "El unicornio en la niebla",
+      "alt": "Fotografía borrosa de la cabeza de un unicornio blanco con crin larga y cuerno en espiral, sobre fondo verde azulado difuminado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4567,7 +4567,7 @@
       "serie": "archivo",
       "orden": 148,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "A la derecha el bosque entero se le enrosca en un remolino de troncos, y el unicornio sigue caminando como si no fuera con él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4581,8 +4581,8 @@
         "generacion": "7cba75b2-d685-47b8-b31f-ba0779090720",
         "variante": 0
       },
-      "titulo": "Blurry surreal wide photo of a white unicorn",
-      "alt": "Blurry surreal wide photo of a white unicorn galloping in a d",
+      "titulo": "El unicornio y el remolino",
+      "alt": "Fotografía de un unicornio blanco caminando entre árboles oscuros en un bosque, con desenfoque de movimiento en los troncos y un efecto de remolino circular a la derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4598,7 +4598,7 @@
       "serie": "archivo",
       "orden": 149,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola canoa de madera flota vacía entre los palafitos, y el agua está tan clara que parece que el pueblo entero también tuviera reflejo por debajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4612,8 +4612,8 @@
         "generacion": "6c23226c-2d63-426e-a047-a7ff61b9bf4a",
         "variante": 2
       },
-      "titulo": "Booming market in stilt city over crystal-clear turquoise",
-      "alt": "Booming market in stilt city over crystal-clear turquoise wat",
+      "titulo": "Canoa entre palafitos",
+      "alt": "Fotografía de un pueblo de casas de madera sobre pilotes con techos de paja, construido sobre un canal de agua turquesa transparente, con una canoa de madera vacía flotando cerca, bajo cielo azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -4629,7 +4629,7 @@
       "serie": "archivo",
       "orden": 150,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El manto púrpura le cae hasta las botas y no roza el suelo ni una vez, aunque detrás el caballo agite la cabeza contra las riendas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4643,8 +4643,8 @@
         "generacion": "8622bb83-1a57-4bc7-85c7-b7a2531db86b",
         "variante": 1
       },
-      "titulo": "Both men are dressed in medieval costume in",
-      "alt": "both men are dressed in medieval costume in the style of movi",
+      "titulo": "Manto púrpura ante el castillo",
+      "alt": "Fotografía de dos hombres vestidos con atuendo medieval, uno con manto púrpura y cota de malla de pie junto a un caballo montado por otro hombre con capa verde, frente a un castillo de piedra.",
       "w": 1360,
       "h": 880,
       "anchos": [
@@ -4660,7 +4660,7 @@
       "serie": "archivo",
       "orden": 151,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cigarro se le apaga despacio entre los labios y el humo sube derecho hasta perderse en las plumas rojas y blancas del tocado, sin que el viento lo tuerza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4674,8 +4674,8 @@
         "generacion": "05511883-87be-47a2-af4f-422dfaaee9bd",
         "variante": 0
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "Humo bajo la corona",
+      "alt": "Retrato de un hombre con tocado de plumas rojas y blancas, fumando un cigarro enrollado a mano, con una vara de bambú al fondo, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4691,7 +4691,7 @@
       "serie": "archivo",
       "orden": 152,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un guantelete de metal le cubre el antebrazo por debajo de la capa amarilla, y agarra la lanza como si el hierro llevara ahí toda la vida, aunque nadie se lo forjó.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4705,8 +4705,8 @@
         "generacion": "14606671-5fe6-4f28-b50a-c5fb3ae1ddfd",
         "variante": 3
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "Guantelete bajo la capa amarilla",
+      "alt": "Retrato de cuerpo entero de un hombre con tocado de plumas, capa amarilla y faja roja, sosteniendo una lanza y con un guantelete de metal en el antebrazo, sobre fondo de cielo azul y verde.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4722,7 +4722,7 @@
       "serie": "archivo",
       "orden": 153,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Del tocado de plumas rojas le cuelga una sola tela blanca hasta el hombro, y no se mueve aunque él gire la cabeza entera para mirar el horizonte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4736,8 +4736,8 @@
         "generacion": "22d6874b-3c5b-412a-8427-28f51258a856",
         "variante": 1
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "La tela blanca del tocado",
+      "alt": "Retrato de un hombre con tocado de plumas rojas y una tela blanca colgante, capa amarilla y lanza de madera, sobre fondo azul con siluetas de árboles oscuros.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4753,7 +4753,7 @@
       "serie": "archivo",
       "orden": 154,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola pluma blanca se le levanta recta encima de la cabeza, más alta que el resto del tocado, como si quisiera tocar el azul del cielo antes que él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4767,8 +4767,8 @@
         "generacion": "22d6874b-3c5b-412a-8427-28f51258a856",
         "variante": 3
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "La pluma que se yergue",
+      "alt": "Retrato de un hombre con tocado de plumas, una pluma blanca sobresaliendo hacia arriba, collar de cuentas azules, iluminación cálida sobre fondo azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4784,7 +4784,7 @@
       "serie": "archivo",
       "orden": 155,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene contra los labios una pipa de cuenco blanco tallado, y el humo que suelta se enreda derecho en las plumas azules y rojas sin deshacerse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4798,8 +4798,8 @@
         "generacion": "52ff9540-8b71-442f-999c-3a252d46d30b",
         "variante": 2
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "La pipa de cuenco blanco",
+      "alt": "Retrato de un hombre con tocado de plumas rojas y bandas azules y blancas, sosteniendo una pipa junto a los labios, collar de cuentas, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4815,7 +4815,7 @@
       "serie": "archivo",
       "orden": 156,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sombrero de paja de ala ancha le tapa media frente, y la capa clara le cae hasta las botas sin que una sola arruga la desordene.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4829,8 +4829,8 @@
         "generacion": "6d81203d-f4db-48f3-8362-dc02a669518c",
         "variante": 3
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "El sombrero de ala ancha",
+      "alt": "Retrato de cuerpo entero de un hombre con sombrero de paja de ala ancha adornado con una pluma, capa color crema sobre túnica bordada y botas claras, de pie sobre pasto al atardecer.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4846,7 +4846,7 @@
       "serie": "archivo",
       "orden": 157,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Debajo de la capa entreabierta el vientre queda al descubierto, y detrás de él el horizonte entero arde en una franja amarilla que no se apaga ni de noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4860,8 +4860,8 @@
         "generacion": "6f2101fe-8fe8-4add-a4a2-efc25fb1cd95",
         "variante": 1
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "La línea de horizonte ardiente",
+      "alt": "Retrato de cuerpo entero de un hombre con sombrero de paja, capa abierta que muestra el torso y taparrabo blanco, sosteniendo una lanza, de pie sobre fondo de cielo azul con una franja amarilla brillante en el horizonte.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4877,7 +4877,7 @@
       "serie": "archivo",
       "orden": 158,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos rayas de pintura azul le bajan por la cara desde la frente hasta la mandíbula, tan derechas que parecen trazadas con una regla y no con un dedo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4891,8 +4891,8 @@
         "generacion": "8a9ca760-0b5c-4c52-ac64-b7df1e7f418d",
         "variante": 2
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "Rayas azules sobre la piel",
+      "alt": "Retrato de un hombre con tocado de plumas rojas y amarillas, pintura facial en rayas azules, capa amarilla y collar con adorno de concha, sobre fondo azul oscuro.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -4907,7 +4907,7 @@
       "serie": "archivo",
       "orden": 159,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Del collar más largo le cuelga un solo colgante de hueso tallado justo sobre el pecho, y pesa lo bastante para que ni el viento del retrato lo balancee.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4921,8 +4921,8 @@
         "generacion": "9a8ef513-4b66-4f26-b64c-e1cc6feeefb2",
         "variante": 0
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "El colgante de hueso",
+      "alt": "Retrato de un hombre con tocado de plumas, cabello largo trenzado, varios collares de cuentas con un colgante de hueso, iluminación cálida sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4938,7 +4938,7 @@
       "serie": "archivo",
       "orden": 160,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola raya azul le parte la cara al centro, de la frente a la nariz, tan exacta que separa el rostro en dos mitades idénticas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4952,8 +4952,8 @@
         "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666",
         "variante": 0
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "Raya al centro del rostro",
+      "alt": "Retrato de un hombre con tocado de plumas amarillas y naranjas, pintura facial en una línea azul vertical sobre el rostro, capa clara y collares con colgante de concha, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -4969,7 +4969,7 @@
       "serie": "archivo",
       "orden": 161,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva una flecha entera amarrada al hombro con una cuerda, y el sombrero puntiagudo se le eleva tanto que compite en altura con el asta de la propia flecha.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -4983,8 +4983,8 @@
         "generacion": "9f12fb2a-865d-4cf3-8470-7ec360361666",
         "variante": 3
       },
-      "titulo": "Buchibe the last Manaure of the Caquetios Son",
-      "alt": "Buchibe the last Manaure of the Caquetios Son of Earth Native",
+      "titulo": "Flecha atada al hombro",
+      "alt": "Retrato de cuerpo entero de un hombre con sombrero cónico, capa amarilla con bordado azul, una flecha atada al hombro con una cuerda, y collares de cuentas, sobre fondo de cielo azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5000,7 +5000,7 @@
       "serie": "archivo",
       "orden": 162,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos haces de luz atraviesan la nave de punta a punta y siguen de largo hacia las estrellas, mientras la Tierra entera cabe detrás como si fuera solo otro adorno de la cubierta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5014,8 +5014,8 @@
         "generacion": "6450fa89-dc6c-40b3-955d-48f95eb13340",
         "variante": 0
       },
-      "titulo": "C Beams glittering in the dark in deep",
-      "alt": "C Beams glittering in the dark in deep space near the Tannhau",
+      "titulo": "La nave contra la Tierra",
+      "alt": "Ilustración de una enorme nave espacial futurista iluminada en tonos azules y verdes, con haces de luz atravesando la escena y el planeta Tierra visible al fondo entre las estrellas.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -5030,7 +5030,7 @@
       "serie": "archivo",
       "orden": 163,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El volcán se pinta de rojo hasta la base y tiñe el mar de abajo con el mismo color, como si la lava ya hubiera llegado al agua sin que nadie la viera correr.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5044,8 +5044,8 @@
         "generacion": "0df2e34e-44a6-4bbf-b1c4-5c7269da9804",
         "variante": 0
       },
-      "titulo": "Cachicamo diciendole al morrocoy conchuo",
-      "alt": "cachicamo diciendole al morrocoy conchuo",
+      "titulo": "Montaña roja sobre el mar",
+      "alt": "Pintura de un volcán de color rojo intenso rodeado de nubes blancas, bajo un cielo verde oscuro, con el mar en tonos verdes y azules en primer plano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5061,7 +5061,7 @@
       "serie": "archivo",
       "orden": 164,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se vuelve brasa el cielo entero, de un naranja tan denso que el agua de abajo se lo bebe y lo devuelve intacto sin apagar ni un tono.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5075,8 +5075,8 @@
         "generacion": "4cf50304-c39e-4cb0-944c-aae41383cc24",
         "variante": 0
       },
-      "titulo": "Cachicamo diciendole al morrocoy conchuo",
-      "alt": "cachicamo diciendole al morrocoy conchuo",
+      "titulo": "Manglares contra el cielo rojo",
+      "alt": "Pintura de un atardecer con el cielo en tonos naranja y rojo intenso, nubes iluminadas, siluetas de manglares en el horizonte y el reflejo del sol sobre el agua.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5092,7 +5092,7 @@
       "serie": "archivo",
       "orden": 165,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al fondo, la refinería entera sigue ardiendo con tres llamas que no se apagan hace años, mientras la persona cruza la calle en un solo trazo borroso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5106,8 +5106,8 @@
         "generacion": "6c27f1b0-1687-49bd-82c5-17befd1d10a3",
         "variante": 1
       },
-      "titulo": "Character walking in the street in Paraguan with",
-      "alt": "character walking in the street in Paraguan with an oil refin",
+      "titulo": "Llamas de refinería al fondo",
+      "alt": "Fotografía borrosa por movimiento de una persona caminando en primer plano vestida de rojo, con una refinería petrolera iluminada y con llamas al fondo, bajo un cielo brumoso al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5123,7 +5123,7 @@
       "serie": "archivo",
       "orden": 166,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina solo por el centro de la calle empedrada, y a los lados las puertas azules y las motos aparcadas se quedan quietas, como si esperaran a que él pase para volver a moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5137,8 +5137,8 @@
         "generacion": "32b747d9-25c4-4b65-a621-8f7a2d575d15",
         "variante": 0
       },
-      "titulo": "Character walking in the street Slice of life",
-      "alt": "character walking in the street Slice of life in Paraguan",
+      "titulo": "La calle de puertas azules",
+      "alt": "Fotografía de una persona caminando por una calle empedrada de un pueblo colonial, con casas blancas de techos de tejas rojas, puertas azules, motocicletas estacionadas y plantas en macetas, al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5182,7 +5182,7 @@
       "serie": "archivo",
       "orden": 168,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "A la punta más larga del caracol solo le faltan tres centímetros y noventa atardeceres para ensartar el sol rojo que tiene enfrente.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5196,8 +5196,8 @@
         "generacion": "2e8f16ba-5e70-402d-a3f2-17fee4edebad",
         "variante": 3
       },
-      "titulo": "Cinematic M",
-      "alt": "Cinematic M",
+      "titulo": "Espina que apunta al sol",
+      "alt": "Concha marina puntiaguda de tonos rosados y blancos sobre arena clara, con un sol rojo en el horizonte y cielo en tonos cálidos.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -5213,7 +5213,7 @@
       "serie": "archivo",
       "orden": 169,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los surcos de este caracol atesoran mar azul entero, y el sol tuvo que teñirse de naranja para no perder el concurso de brillo contra la concha.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5227,8 +5227,8 @@
         "generacion": "3f6aebe8-561e-4e69-a4c6-ee352e6c6c41",
         "variante": 0
       },
-      "titulo": "Cinematic M",
-      "alt": "Cinematic M",
+      "titulo": "Concha de acero al atardecer",
+      "alt": "Concha marina alargada con reflejos azules metálicos sobre superficie blanca, cielo y mar azul intenso y un sol naranja brillante en el horizonte.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -5244,7 +5244,7 @@
       "serie": "archivo",
       "orden": 170,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le cruzan el caparazón vetas tan rojas que parecen la marca de la última ola, aunque la espuma blanca todavía se frena a dos pasos de distancia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5258,8 +5258,8 @@
         "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d",
         "variante": 0
       },
-      "titulo": "Cinematic M",
-      "alt": "Cinematic M",
+      "titulo": "Concha que espera la ola",
+      "alt": "Concha marina blanca con vetas rojas y textura rugosa sobre arena, con olas de espuma blanca cerca y un sol rojo pequeño en un cielo oscuro.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -5275,7 +5275,7 @@
       "serie": "archivo",
       "orden": 171,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cielo ya le robó casi todo el color a la concha, y solo el sol, reducido a una moneda roja, se niega a dejarla del todo a oscuras.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5289,8 +5289,8 @@
         "generacion": "8d56dec9-c3d2-4f9f-a1ad-5423c1abb78d",
         "variante": 3
       },
-      "titulo": "Cinematic M",
-      "alt": "Cinematic M",
+      "titulo": "Silueta con espinas al anochecer",
+      "alt": "Concha marina oscura con reflejos rosados y espinas puntiagudas sobre arena blanca, cielo azul oscuro con un sol rojo pequeño cerca del horizonte.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -5306,7 +5306,7 @@
       "serie": "archivo",
       "orden": 172,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Diez mil puntos dorados y turquesas le cubren la piel entera, y cada uno se enciende un instante antes de que el aire le llegue a los labios entreabiertos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5320,8 +5320,8 @@
         "generacion": "ee43ad82-05b0-4cd3-8683-dd06bdbd106b",
         "variante": 0
       },
-      "titulo": "Close-up po",
-      "alt": "Close-up po",
+      "titulo": "El rostro de mil puntos",
+      "alt": "Retrato de un rostro femenino cubierto por una textura de puntos dorados y turquesas, con ojos claros y labios entreabiertos, sobre fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5337,7 +5337,7 @@
       "serie": "archivo",
       "orden": 173,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mitad derecha de esta cara arde en cobre y la izquierda se le queda fría en turquesa, sin que ninguna logre cruzar la nariz para ganarle terreno a la otra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5351,8 +5351,8 @@
         "generacion": "184d0463-dd38-4ea9-82f0-fa146d883b05",
         "variante": 3
       },
-      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
-      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "titulo": "Rostro partido en dos luces",
+      "alt": "Retrato de un rostro femenino con textura de puntos digitales, la mitad derecha iluminada en tonos cobrizos y la izquierda en tonos turquesas, con ojos azules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5368,7 +5368,7 @@
       "serie": "archivo",
       "orden": 174,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una red verde le cubre toda la cara menos los ojos azules, que la atraviesan sin dejarle ni un solo punto de luz a medio camino.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5382,8 +5382,8 @@
         "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
         "variante": 0
       },
-      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
-      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "titulo": "Mirada que perfora la malla",
+      "alt": "Retrato de un rostro femenino con textura de malla digital verde y turquesa, ojos azules intensos y mechones de cabello oscuro visibles a un lado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5399,7 +5399,7 @@
       "serie": "archivo",
       "orden": 175,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Unas cortinas de cuentas azules le tapan medio rostro, y aun así consigue mirar derecho a través de cada una sin mover el cuello ni una vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5413,8 +5413,8 @@
         "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
         "variante": 1
       },
-      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
-      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "titulo": "Cortinas de cuentas azules",
+      "alt": "Retrato de un rostro femenino con textura de malla dorada y turquesa, ojos azules, parcialmente cubierto por franjas de sombra y luces azules desenfocadas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5430,7 +5430,7 @@
       "serie": "archivo",
       "orden": 176,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Medio rostro y un hombro entero ya se los devora una tela azul, pero el ojo que queda del lado de la luz alcanza a contar cada punto dorado de su propio iris.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5444,8 +5444,8 @@
         "generacion": "bbbcefd5-013e-4ff0-9156-801abcef6128",
         "variante": 3
       },
-      "titulo": "Close-up portrait cinematic lighting of an androgynous digita",
-      "alt": "Close-up portrait cinematic lighting of an androgynous digita",
+      "titulo": "Medio rostro en sombra azul",
+      "alt": "Retrato de un rostro femenino con textura de malla dorada y verde, mitad del rostro iluminada y mitad cubierta por tela azul oscura, ojos claros.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5461,7 +5461,7 @@
       "serie": "archivo",
       "orden": 177,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El rayo parte el cielo justo detrás de la isla de palmeras, y el hombre del turbante ya perdió la cuenta de los mil relámpagos que no lo han alcanzado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5475,8 +5475,8 @@
         "generacion": "126fa0e0-7b25-4468-91c0-53d4ae46ee94",
         "variante": 0
       },
-      "titulo": "Coastal waters of Guinea-Bissau late autumn of 1467",
-      "alt": "Coastal waters of Guinea-Bissau late autumn of 1467 during th",
+      "titulo": "El remero bajo el rayo",
+      "alt": "Hombre con turbante visto de espaldas sobre una embarcación, remando en un mar agitado durante una tormenta, con un rayo cayendo cerca de una isla con palmeras al fondo, en tonos verdosos oscuros.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -5492,7 +5492,7 @@
       "serie": "archivo",
       "orden": 178,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada pincelada es un día; los del lado claro se recuerdan mal y los del azul uno por uno, pero nadie sabe dónde cambió la cuenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5506,8 +5506,8 @@
         "generacion": "27e6053b-67c9-49d4-9f2e-1361212f413d",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Donde el azul empieza a contar",
+      "alt": "Pintura abstracta de pinceladas pequeñas dispuestas en arcos, que pasan de tonos crema y ocre a la izquierda a azul cobalto intenso a la derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5523,7 +5523,7 @@
       "serie": "archivo",
       "orden": 179,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Justo donde el rojo se convierte en azul cae algo invisible, y las ondas que suelta tardan toda una vida en llegar a las cuatro esquinas del cuadro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5537,8 +5537,8 @@
         "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
         "variante": 0
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Estanque partido en dos climas",
+      "alt": "Textura abstracta de líneas onduladas finas en degradado de rojo en la esquina superior izquierda a azul en la esquina inferior derecha, con un patrón de ondas concéntricas en el centro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5554,7 +5554,7 @@
       "serie": "archivo",
       "orden": 180,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Miles de líneas salen del centro blanco, y a cada una le toca decidir si se pinta de rojo hacia la izquierda o de azul hacia la derecha.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5568,8 +5568,8 @@
         "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
         "variante": 1
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Ojo que reparte colores",
+      "alt": "Textura abstracta con un centro claro luminoso del que irradian líneas finas hacia un lado rojo y otro azul, en un patrón circular.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5585,7 +5585,7 @@
       "serie": "archivo",
       "orden": 181,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre el rojo de la izquierda y el azul de la derecha se abre una franja pálida en diagonal, y ahí se queda, indecisa, sin acercarse del todo a ningún borde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5599,8 +5599,8 @@
         "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Franja que no elige bando",
+      "alt": "Textura abstracta de franjas diagonales borrosas, rojas y naranjas a la izquierda, azules a la derecha, separadas por una banda pálida central.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5616,7 +5616,7 @@
       "serie": "archivo",
       "orden": 182,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El naranja llega ondulando desde la izquierda como si viniera ardiendo, y se apaga solo, línea por línea, en la espuma blanca que ocupa todo el borde derecho.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5630,8 +5630,8 @@
         "generacion": "343ba58e-faa2-4504-b72f-60978f802834",
         "variante": 3
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Fuego apagado en espuma",
+      "alt": "Textura abstracta de líneas onduladas en degradado de naranja intenso a la izquierda hacia blanco a la derecha, con un pequeño destello azul en la esquina superior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -5647,7 +5647,7 @@
       "serie": "archivo",
       "orden": 183,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sin cambiar ni una sola curva, las líneas onduladas que forman la duna dorada de la izquierda cruzan el cuadro entero y del otro lado ya son mar azul.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5661,8 +5661,8 @@
         "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Duna que se vuelve mar",
+      "alt": "Textura abstracta de líneas onduladas diagonales, doradas y anaranjadas a la izquierda, azules a la derecha, con un brillo central luminoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5678,7 +5678,7 @@
       "serie": "archivo",
       "orden": 184,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los brochazos horizontales dividen el lienzo justo donde el cielo rosado decide hacerse agua azul, y ninguno se atreve a cruzar esa línea.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5692,8 +5692,8 @@
         "generacion": "464708df-ee3d-490d-9ab5-e707a28b6e3f",
         "variante": 3
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Horizonte pintado a brochazos",
+      "alt": "Pintura abstracta de campo de color con franjas horizontales, tonos rosados y dorados en la parte superior y azules en la parte inferior, con textura de pinceladas visibles.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5709,7 +5709,7 @@
       "serie": "archivo",
       "orden": 185,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Arriba, la tela azul índigo se deshilacha en diagonal hasta volverse hilo dorado abajo, dejando ver, hebra por hebra, la costura exacta del cambio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5723,8 +5723,8 @@
         "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
         "variante": 0
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Costura entre noche y oro",
+      "alt": "Textura abstracta de trazos diagonales gruesos, azul índigo en la parte superior izquierda y dorado en la parte inferior derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5740,7 +5740,7 @@
       "serie": "archivo",
       "orden": 186,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El resplandor durazno del centro se hunde bajo las ondas azules que lo rodean, y en la esquina inferior derecha ya no queda ni rastro de luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5754,8 +5754,8 @@
         "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
         "variante": 1
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Sol hundido entre las ondas",
+      "alt": "Textura abstracta de ondas azules alrededor de un resplandor central color durazno, con una zona oscura en la esquina inferior derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5771,7 +5771,7 @@
       "serie": "archivo",
       "orden": 187,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por donde el sol roza la cresta oscura de la montaña se sueltan franjas de arcoíris enteras, y el cielo azul de arriba ni se anima a bajar hasta el filo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5785,8 +5785,8 @@
         "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "La cordillera que suelta arcoíris",
+      "alt": "Textura abstracta con la silueta oscura de una cordillera en la parte inferior, cielo azul arriba y franjas de colores similares a un arcoíris cerca del horizonte.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5802,7 +5802,7 @@
       "serie": "archivo",
       "orden": 188,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al cruzarse dos franjas naranjas del cuadriculado, la tela deja de fingir que es tela y se enciende en un círculo entero de brasa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5816,8 +5816,8 @@
         "generacion": "469b42e7-7b52-41a8-a249-55378e84cc3f",
         "variante": 3
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Tartán que arde por dentro",
+      "alt": "Textura abstracta con patrón de cuadros tipo tartán en azul oscuro y franjas diagonales naranjas y rojas, con un punto de luz circular anaranjado en el centro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5833,7 +5833,7 @@
       "serie": "archivo",
       "orden": 189,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los anillos azules nacen del centro anaranjado y se agrandan sin parar, y todavía ninguno se ha decidido a tocar el borde del cuadro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5847,8 +5847,8 @@
         "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
         "variante": 0
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Anillos que no paran",
+      "alt": "Textura abstracta de anillos concéntricos azules que rodean un resplandor central anaranjado y rosado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5864,7 +5864,7 @@
       "serie": "archivo",
       "orden": 190,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Alternando naranja y azul como un código de barras, las franjas verticales pierden la cuenta justo en el centro y se emborronan todas juntas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5878,8 +5878,8 @@
         "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Código de barras del sol",
+      "alt": "Textura abstracta de franjas verticales alternadas en naranja y azul, con una zona central borrosa y más clara.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5895,7 +5895,7 @@
       "serie": "archivo",
       "orden": 191,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre una franja verde y naranja se posa, en capas, el cielo azul de arriba, que termina hundiéndose en un fondo tan oscuro que ya no se sabe si es agua o sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5909,8 +5909,8 @@
         "generacion": "86c7ea83-d335-41f1-80e3-c71d92cf16c8",
         "variante": 3
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Capas del horizonte revuelto",
+      "alt": "Textura abstracta de bandas horizontales onduladas, azul en la parte superior, verde y naranja en el medio, y oscura en la parte inferior.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5926,7 +5926,7 @@
       "serie": "archivo",
       "orden": 192,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una nube guarda brasas naranjas en el pecho en medio de la neblina azul, y el frío de alrededor todavía no ha logrado apagarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5940,8 +5940,8 @@
         "generacion": "96e5f65a-0c0c-455b-97f9-e85c35b05a81",
         "variante": 0
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "La nube que guarda brasas",
+      "alt": "Textura abstracta difusa con un resplandor anaranjado central rodeado de tonos azules, como niebla.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5957,7 +5957,7 @@
       "serie": "archivo",
       "orden": 193,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Justo en la frontera entre el cielo azul y el cielo naranja se detiene un círculo pálido, y ninguno de los dos lados logra ponerle encima su color.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -5971,8 +5971,8 @@
         "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
         "variante": 1
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "Luna que separa dos cielos",
+      "alt": "Textura abstracta dividida en dos mitades verticales, azul y morada a la izquierda, naranja a la derecha, con un círculo de luz pálida en el centro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -5988,7 +5988,7 @@
       "serie": "archivo",
       "orden": 194,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cielo se resiste a quedarse quieto y alguien lo arrastra hacia la derecha sin soltarlo, dejando nueve franjas doradas colgadas del aire como ropa tendida a media tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6002,8 +6002,8 @@
         "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
         "variante": 2
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "El atardecer en fuga",
+      "alt": "Franjas horizontales borrosas en tonos azules, blancos, dorados y naranjas, como un cielo o paisaje difuminado por movimiento, con una banda oscura en la parte inferior.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -6019,7 +6019,7 @@
       "serie": "archivo",
       "orden": 195,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El reflejo del sol no cabe entero en el agua, así que se reparte en miles de puntos redondos que se van enfriando de naranja a violeta antes de llegar a la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6033,8 +6033,8 @@
         "generacion": "ffc5595d-afd9-4ae1-9f36-f65585f5b49a",
         "variante": 3
       },
-      "titulo": "Color field painting in the style of uhd",
-      "alt": "color field painting in the style of uhd image interference p",
+      "titulo": "El sol repartido en gotas",
+      "alt": "Superficie de agua con textura de puntos de colores, tonos naranjas y dorados en la parte superior que se transforman en azules y violetas hacia abajo, como una trama de semitono.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -6050,7 +6050,7 @@
       "serie": "archivo",
       "orden": 196,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre sus pechos crece una planta de hojas anchas: soltó su última hoja hace veintitrés años, el día en que se acercaron el primer milímetro, y desde entonces ninguno se ha movido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6064,8 +6064,8 @@
         "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
         "variante": 0
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "La planta que los separa",
+      "alt": "Retrato de una mujer y un hombre de piel oscura, de perfil y frente a frente, vestidos con ropa estampada en dorado y naranja sobre fondo azul oscuro, con una planta de hojas verdes entre ellos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6081,7 +6081,7 @@
       "serie": "archivo",
       "orden": 197,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se pintan la piel del mismo bote de azul desde hace tantos años que ya no queda pintura para diferenciar dónde termina la cara de uno y empieza la del otro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6095,8 +6095,8 @@
         "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
         "variante": 1
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Idéntico azul en dos caras",
+      "alt": "Retrato de una mujer de cabello negro corto y un hombre calvo, ambos con la piel pintada de azul oscuro, frente contra frente sobre fondo verde azulado, con ropa estampada en dorado y hojas verdes.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6112,7 +6112,7 @@
       "serie": "archivo",
       "orden": 198,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El corazón que lleva bordado en el pecho ha sido remendado con hilo de oro tantas veces que ya pesa más que la camisa entera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6126,8 +6126,8 @@
         "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
         "variante": 2
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "El corazón bordado en oro",
+      "alt": "Retrato de una mujer de piel clara y cabello oscuro junto a un hombre de piel muy oscura, sobre fondo azul, él con una prenda azul y un gran corazón dorado bordado en el pecho.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6143,7 +6143,7 @@
       "serie": "archivo",
       "orden": 199,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El trébol dorado que le cuelga del oído ya perdió medio brillo de tanto rozar la mejilla del hombre que tiene enfrente, con los ojos cerrados los dos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6157,8 +6157,8 @@
         "generacion": "5a2a1012-7480-4130-a3da-3362e29ed940",
         "variante": 3
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "El trébol que le cuelga",
+      "alt": "Retrato de una mujer de piel azulada con arete en forma de trébol y labios rojos, junto a un hombre de piel oscura, ambos con los ojos cerrados y frente contra frente, con ropa estampada en dorado sobre fondo verde oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6174,7 +6174,7 @@
       "serie": "archivo",
       "orden": 200,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las flores azules les crecieron de la noche a la mañana hasta la altura de la clavícula, y la semana que viene les va a tapar el beso que todavía no se dan.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6188,8 +6188,8 @@
         "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d",
         "variante": 0
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Flores azules hasta el pecho",
+      "alt": "Retrato de una mujer y un hombre de piel oscura con peinados afro, ella con vestido floral amarillo y azul y arete de perla, él con camisa amarilla estampada, sobre fondo azul oscuro con flores azules en primer plano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6205,7 +6205,7 @@
       "serie": "archivo",
       "orden": 201,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de ellos la selva está hecha de puntos de pintura pura, tantos que hace falta una estación seca entera para contarlos todos sin perder la cuenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6219,8 +6219,8 @@
         "generacion": "7616fd8f-ad05-4e04-a7c2-c5c9b9bd7b5d",
         "variante": 3
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Selva a punto de estallar",
+      "alt": "Retrato de una mujer de piel azulada con flores en el cabello y un hombre de piel morena, ambos rodeados de hojas de palma y flores moradas y naranjas, en un estilo de puntos de colores muy saturados.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6236,7 +6236,7 @@
       "serie": "archivo",
       "orden": 202,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Llevan bordado en el pecho el mismo árbol dorado, una rama por cada año que llevan parados a esta distancia exacta el uno del otro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6250,8 +6250,8 @@
         "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
         "variante": 0
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "El árbol que llevan dentro",
+      "alt": "Retrato pintado de una mujer y un hombre de piel clara, ambos con un emblema dorado en forma de árbol bordado en el pecho de su ropa azul, sobre fondo verde azulado con textura de pintura al óleo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6267,7 +6267,7 @@
       "serie": "archivo",
       "orden": 203,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pintura se agrietó en todas partes menos en los dos corazones dorados que llevan bordados en el pecho, como si el tiempo no se atreviera a tocar esa parte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6281,8 +6281,8 @@
         "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
         "variante": 1
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Dos corazones del mismo oro",
+      "alt": "Retrato de una mujer y un hombre de piel oscura con aretes dorados, ambos con un corazón dorado bordado en el pecho sobre ropa azul, con textura de pintura agrietada y envejecida sobre fondo verde azulado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6298,7 +6298,7 @@
       "serie": "archivo",
       "orden": 204,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "No ha parpadeado desde que pintaron la pared de atrás, y en ese tiempo la pintura ya se descascaró dos veces mientras sus ojos siguen igual de blancos y abiertos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6312,8 +6312,8 @@
         "generacion": "8591efc0-c4ca-41e1-9afa-de090185ee3b",
         "variante": 3
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Los ojos que no parpadean",
+      "alt": "Retrato de un hombre de piel azul oscura con los ojos completamente blancos y brillantes, vestido con una túnica azul con cuello dorado, junto a una mujer de piel oscura con arete dorado y túnica blanca con bordes dorados, sobre fondo verde azulado texturizado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6329,7 +6329,7 @@
       "serie": "archivo",
       "orden": 205,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La rama dorada bordada en el vestido de ella lleva diez años creciendo hacia el cuello de él, y le faltan tres hojas para alcanzar el primer corazón pequeño.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6343,8 +6343,8 @@
         "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340",
         "variante": 0
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "Rama de oro contra corazones",
+      "alt": "Retrato de una mujer de piel clara y cabello oscuro con vestido azul de ramas doradas, junto a un hombre de piel azulada con prenda azul y cuello dorado decorado con pequeños corazones, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6360,7 +6360,7 @@
       "serie": "archivo",
       "orden": 206,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El vestido de ella tiene sembrados tantos corazones diminutos que ya son más que los latidos que han compartido de pie, sin moverse, en esta misma pose.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6374,8 +6374,8 @@
         "generacion": "ae1161b5-41c5-4754-b1dc-05d1e87fa340",
         "variante": 3
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "El vestido sembrado de corazones",
+      "alt": "Retrato de una mujer de piel clara y cabello rubio claro con vestido azul cubierto de pequeños corazones dorados, junto a un hombre de piel muy oscura con cuello dorado decorado también con corazones, sobre fondo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6391,7 +6391,7 @@
       "serie": "archivo",
       "orden": 207,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los labios se juntan con tanta fuerza que los puntos de color de una cara se mezclan con los de la otra, y ya solo queda una forma con dos narices.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6405,8 +6405,8 @@
         "generacion": "d56fb0ea-6841-4d6c-91ae-7ea18ef9adfb",
         "variante": 1
       },
-      "titulo": "Cover art with Two people looking at each",
-      "alt": "Cover art with Two people looking at each other with tenderne",
+      "titulo": "El beso que los funde",
+      "alt": "Dos rostros besándose de cerca, representados con manchas y puntos de color azul, dorado y morado sobre un fondo morado, en un estilo pictórico difuminado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6422,7 +6422,7 @@
       "serie": "archivo",
       "orden": 208,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La calavera flota sobre el tablero de cuadros del cielo con los ojos fijos en la torre del reloj desde hace tanto que ya le quemó dos agujeros azules al fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6436,8 +6436,8 @@
         "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761",
         "variante": 1
       },
-      "titulo": "Cover of time travelers 7 in the sty",
-      "alt": "cover of time travelers 7 in the sty",
+      "titulo": "La calavera vigila el reloj",
+      "alt": "Paisaje psicodélico con una calavera gigante de ojos azules flotando sobre un cielo a cuadros, un sol en espiral de colores, dos figuras con armadura caminando sobre un suelo de rayas de colores hacia una torre de reloj.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6453,7 +6453,7 @@
       "serie": "archivo",
       "orden": 209,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "A la montaña le tomó mil años terminar de tallarse la cara, y al caminante que se acerca por la arena de colores todavía le faltan tres pasos para verla abrir los ojos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6467,8 +6467,8 @@
         "generacion": "302a7fe7-2fe3-4e3f-a735-60304e714761",
         "variante": 3
       },
-      "titulo": "Cover of time travelers 7 in the sty",
-      "alt": "cover of time travelers 7 in the sty",
+      "titulo": "Rostro tallado en la montaña",
+      "alt": "Paisaje psicodélico con un rostro humano tallado en una formación rocosa a la derecha, un remolino rosado y azul en el cielo a la izquierda, y una figura solitaria caminando sobre un suelo de rayas de colores.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6484,7 +6484,7 @@
       "serie": "archivo",
       "orden": 210,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La escalera tallada en la roca sube hacia la torre del reloj, y el que la sube lleva caminando desde que la luna de allá arriba todavía era redonda y no un remolino.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6498,8 +6498,8 @@
         "generacion": "9d149f76-bc15-4c35-999d-a52019a7f4d3",
         "variante": 0
       },
-      "titulo": "Cover of time travelers 7 in the sty",
-      "alt": "cover of time travelers 7 in the sty",
+      "titulo": "La escalera hacia el reloj",
+      "alt": "Paisaje psicodélico con una torre de reloj ornamentada a la derecha, un remolino azul en forma de luna a la izquierda, una escalera tallada en la roca y una figura pequeña caminando sobre un suelo de rayas de colores.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6515,7 +6515,7 @@
       "serie": "archivo",
       "orden": 211,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El reloj cuelga del cielo en vez del sol, y hace tanto ruido al marcar la hora que sus anillos de colores todavía siguen temblando en el aire.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6529,8 +6529,8 @@
         "generacion": "e48ca045-fc47-45f1-9b66-2c02f99638f2",
         "variante": 1
       },
-      "titulo": "Cover of time travelers 7 in the sty",
-      "alt": "cover of time travelers 7 in the sty",
+      "titulo": "El reloj hecho de sol",
+      "alt": "Paisaje psicodélico con un hombre de traje visto de espaldas parado sobre un suelo de rayas onduladas en blanco y negro, frente a un gran reloj rodeado de anillos de colores en el cielo, junto a una torre ornamentada.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6546,7 +6546,7 @@
       "serie": "archivo",
       "orden": 212,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de él gira un mecanismo de relojes tan grande que ninguno de sus engranajes coincide en la hora, y él lleva años sin voltear a comprobarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6560,8 +6560,8 @@
         "generacion": "0e4afe5c-395b-4d44-940d-ea89fcbfa9f7",
         "variante": 0
       },
-      "titulo": "Cover of time travelers 7 in the style",
-      "alt": "cover of time travelers 7 in the style of bruce pennington co",
+      "titulo": "El relojero de la esfera",
+      "alt": "Hombre calvo con túnica rosa y gafas oscuras, sosteniendo un bastón, de pie sobre un camino bordeado de esferas oscuras, dentro de una cúpula de cristal con un enorme mecanismo de relojes dorado detrás y una ciudad al atardecer al fondo.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6577,7 +6577,7 @@
       "serie": "archivo",
       "orden": 213,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El vestido naranja se le pega al cuerpo con un viento que sube directo de la curva del planeta, y lleva media vida intentando doblarlo hasta darle la forma del horizonte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6591,8 +6591,8 @@
         "generacion": "9e7f44fc-1cdf-41ab-8995-78f74351b74c",
         "variante": 1
       },
-      "titulo": "Cover of time travelers 7 in the style",
-      "alt": "cover of time travelers 7 in the style of bruce pennington co",
+      "titulo": "Vestido naranja sobre el mundo",
+      "alt": "Mujer de cabello oscuro y vestido naranja de pie sobre un peñasco, mirando hacia una ciudad futurista con cúpulas y torres, con la curva de un planeta visible bajo sus pies, en tonos dorados y verdes.",
       "w": 1152,
       "h": 1024,
       "anchos": [
@@ -6608,7 +6608,7 @@
       "serie": "archivo",
       "orden": 214,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina por un pasillo tallado con símbolos antiguos hacia una sola estrella azul al fondo, y lleva tantos años acercándose que la estrella todavía no crece ni un poco.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6622,8 +6622,8 @@
         "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad",
         "variante": 1
       },
-      "titulo": "Cryochamber where intergalactic trav",
-      "alt": "cryochamber where intergalactic trav",
+      "titulo": "El pasillo hacia la estrella",
+      "alt": "Interior de un túnel curvo y ornamentado con relieves tallados y luces doradas, iluminado con luz cálida, con una persona de pie al fondo cerca de una abertura ovalada donde se ve un punto de luz azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -6639,7 +6639,7 @@
       "serie": "archivo",
       "orden": 215,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz que entra por la abertura circular del fondo es tan fuerte que todo lo tallado en las paredes solo existe porque a ella se le ocurrió iluminarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6653,8 +6653,8 @@
         "generacion": "ba42f980-c2bd-48ac-a6a6-7d6950aa4cad",
         "variante": 3
       },
-      "titulo": "Cryochamber where intergalactic trav",
-      "alt": "cryochamber where intergalactic trav",
+      "titulo": "La salida hecha de luz",
+      "alt": "Interior de un túnel curvo con relieves tallados, iluminado en tonos azules, con una silueta de pie al fondo cerca de una abertura circular muy iluminada.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -6670,7 +6670,7 @@
       "serie": "archivo",
       "orden": 216,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuenta cada panel amarillo encendido a lo largo del pasillo metálico, y pierde la cuenta justo donde el túnel oscuro se traga la última luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6684,8 +6684,8 @@
         "generacion": "80bc2cc7-99ed-4f08-800c-47331f938989",
         "variante": 0
       },
-      "titulo": "Cryochamber where intergalactic travelers enter cryosleep",
-      "alt": "cryochamber where intergalactic travelers enter cryosleep",
+      "titulo": "El traje azul del pasillo",
+      "alt": "Persona con traje espacial azul caminando por una pasarela dentro de un túnel metálico acanalado, iluminado en tonos azules con paneles amarillos brillantes a los lados, hacia una abertura oscura al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6701,7 +6701,7 @@
       "serie": "archivo",
       "orden": 217,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La palabra encendida en la pantalla lleva tanto tiempo repitiéndose que ya se borró de las notas de papel de donde la copiaron a mano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6715,8 +6715,8 @@
         "generacion": "6cfce9ea-3392-4f26-b8ca-57745e7d25e6",
         "variante": 0
       },
-      "titulo": "Cs65c 8bit halftone screen with the word P",
-      "alt": "cs65c 8bit halftone screen with the word P",
+      "titulo": "Diez dedos y una palabra",
+      "alt": "Ilustración de estilo cómic con dos manos escribiendo en un teclado antiguo, frente a una pantalla que muestra la palabra PROMPT en letras pixeladas anaranjadas, con hojas de papel con anotaciones a un lado, en tonos verdes y ocres.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6732,7 +6732,7 @@
       "serie": "archivo",
       "orden": 218,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ojo enorme que flota arriba no ha parpadeado desde que las siluetas de abajo se quedaron paradas, y no lo va a hacer hasta que la última de ellas mire para otro lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6746,8 +6746,8 @@
         "generacion": "45c70d99-40b0-4f92-b873-623759998d5b",
         "variante": 0
       },
-      "titulo": "Cyberpunk eye shape starship with a",
-      "alt": "cyberpunk eye shape starship with a",
+      "titulo": "El ojo que flota",
+      "alt": "Forma ovalada gigante con un solo ojo naranja y negro flotando en un cielo brumoso, sobre un grupo de siluetas oscuras de pie en un terreno ondulado y desértico.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6763,7 +6763,7 @@
       "serie": "archivo",
       "orden": 219,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El delineado le nace en el párpado y no para hasta la sien, tres centímetros de más que lleva puestos con la misma calma con que otros llevan puesto un nombre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6777,8 +6777,8 @@
         "generacion": "f2ca84df-f697-476f-bcc2-e52bb7c12678",
         "variante": 3
       },
-      "titulo": "Cydney parker photo by michael odet in the",
-      "alt": "cydney parker photo by michael odet in the style of polaroid",
+      "titulo": "El trazo hasta la sien",
+      "alt": "Retrato tipo polaroid de una mujer joven de cabello corto oscuro y despeinado, con delineado negro pronunciado, labios rojos, una prenda negra transparente al cuello y una chaqueta de cuero, sobre fondo amarillo cálido.",
       "w": 1024,
       "h": 1184,
       "anchos": [
@@ -6794,7 +6794,7 @@
       "serie": "archivo",
       "orden": 220,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El agua bajo la canoa es tan transparente que el remero cuenta los peces dos veces: una vez nadando y otra en su sombra sobre la arena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6808,8 +6808,8 @@
         "generacion": "62ca7a63-2099-4e5b-a1a5-c45f74865cb9",
         "variante": 0
       },
-      "titulo": "Daily life in a stilt houses submerged in",
-      "alt": "daily life in a stilt houses submerged in crystal-clear turqu",
+      "titulo": "El canal entre palafitos",
+      "alt": "Un hombre rema en una canoa de madera por un canal de agua turquesa y transparente, entre casas de palafito con techos de paja, bajo un cielo azul despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -6825,7 +6825,7 @@
       "serie": "archivo",
       "orden": 221,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los tres llevan tanto tiempo mirando el vidrio verde que ya no distinguen si observan la ciudad o si la ciudad, allá abajo, los observa a ellos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6839,8 +6839,8 @@
         "generacion": "5c4f4208-dcc0-421e-8886-8df789e88846",
         "variante": 3
       },
-      "titulo": "Day in the corporate office postcard in the",
-      "alt": "Day in the corporate office postcard in the style of 1990s ar",
+      "titulo": "Tres siluetas ante la ciudad",
+      "alt": "Tres personas en siluetas oscuras, vestidas de traje, de espaldas frente a un ventanal curvo con vista panorámica de una ciudad extensa, bajo un cielo con nubes, en tonos verdiazules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6856,7 +6856,7 @@
       "serie": "archivo",
       "orden": 222,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las paredes desaparecen bajo tantas hojas pegadas unas sobre otras que ya nadie sabe de qué color se pintaron, y solo la nevera blanca del fondo guarda un rectángulo libre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6870,8 +6870,8 @@
         "generacion": "08b14f56-e25a-4e20-85f8-210af594582f",
         "variante": 2
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "El cuarto forrado de papeles",
+      "alt": "Interior de una oficina angosta con las paredes cubiertas de papeles y afiches, computadoras sobre un mesón a la izquierda, una nevera blanca al fondo y piso de baldosas bajo luces fluorescentes.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6887,7 +6887,7 @@
       "serie": "archivo",
       "orden": 223,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pared de ladrillo sostiene más papeles clavados que ladrillos visibles le quedan, mientras la silla negra gira sola hacia la ventana esperando que alguien entre antes de que se apague la luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6901,8 +6901,8 @@
         "generacion": "08b14f56-e25a-4e20-85f8-210af594582f",
         "variante": 3
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "Escritorio junto al ladrillo",
+      "alt": "Oficina vacía con una pared de ladrillo cubierta de papeles a la derecha, un escritorio de madera con silla negra, ventana con persianas verticales y piso de terrazo verde.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6918,7 +6918,7 @@
       "serie": "archivo",
       "orden": 224,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Firma papel tras papel sobre el mostrador beige sin levantar la vista, mientras la planta de la esquina crece tan derecha que parece llevar ahí desde la inauguración del edificio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6932,8 +6932,8 @@
         "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac",
         "variante": 2
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "Firma en el mostrador beige",
+      "alt": "Una mujer con uniforme rosado está sentada detrás de un mostrador de recepción escribiendo en unos papeles, con una planta cerca y oficinas al fondo bajo luces fluorescentes.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6949,7 +6949,7 @@
       "serie": "archivo",
       "orden": 225,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cuatro sillas moradas rodean el escritorio de caoba sin que nadie las haya movido en años, mientras la ciudad entera se extiende bajo el vidrio esperando una reunión que no llega.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6963,8 +6963,8 @@
         "generacion": "b9dc5818-2b1f-41e0-964a-7b54c7961bac",
         "variante": 3
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "Despacho morado sobre la ciudad",
+      "alt": "Oficina ejecutiva con sillas de cuero morado alrededor de un escritorio de madera, un florero con flores, y ventanales con vista panorámica de una ciudad, sobre piso alfombrado morado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -6980,7 +6980,7 @@
       "serie": "archivo",
       "orden": 226,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los papeles cubren el piso turquesa como una alfombra que nadie ha barrido en cinco cambios de sistema operativo, mientras las pantallas viejas siguen encendidas mirando hacia la nada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -6994,8 +6994,8 @@
         "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33",
         "variante": 2
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "Caos turquesa de pantallas viejas",
+      "alt": "Cuarto desordenado de paredes turquesa con varios monitores antiguos de tubo, equipos electrónicos apilados, un archivador rojo y papeles esparcidos por todo el piso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -7011,7 +7011,7 @@
       "serie": "archivo",
       "orden": 227,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El único mueble del cuarto es esta silla roja, y el sol entra tan oblicuo por la puerta de vidrio que le dibuja una sombra el doble de larga que ella misma.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7025,8 +7025,8 @@
         "generacion": "e4436906-ebe6-453b-a3e0-a48335cf4e33",
         "variante": 3
       },
-      "titulo": "Day in the office room postcard in the",
-      "alt": "Day in the office room postcard in the style of 1990s arawak",
+      "titulo": "Sillón rojo bajo la luz",
+      "alt": "Un sillón de oficina rojo vacío en la esquina de un cuarto, iluminado por luz solar diagonal que entra por una puerta de vidrio, con un letrero pequeño en la pared junto a él.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -7042,7 +7042,7 @@
       "serie": "archivo",
       "orden": 228,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La planta cuelga tan cargada de hojas sobre los cubículos que dos personas trabajan a la sombra de sus ramas sin haber sembrado nada ellas mismas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7056,8 +7056,8 @@
         "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1",
         "variante": 0
       },
-      "titulo": "Day inside the corporate office room busy cubicles",
-      "alt": "Day inside the corporate office room busy cubicles postcard i",
+      "titulo": "Cubículos bajo la planta verde",
+      "alt": "Oficina de paredes verdes con cubículos, dos personas sentadas frente a monitores de computadora y otra persona caminando al fondo, con una planta colgante sobre los escritorios y luz de ventana con rejas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7073,7 +7073,7 @@
       "serie": "archivo",
       "orden": 229,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Trabaja de espaldas a la puerta con dos pantallas encendidas frente a él, y detrás las carpetas se apilan en una torre tan firme que ya hace las veces de pared.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7087,8 +7087,8 @@
         "generacion": "1a592b03-be42-49bd-82a9-0d463ab5a1d1",
         "variante": 1
       },
-      "titulo": "Day inside the corporate office room busy cubicles",
-      "alt": "Day inside the corporate office room busy cubicles postcard i",
+      "titulo": "De espaldas ante dos pantallas",
+      "alt": "Un hombre con suéter gris está sentado de espaldas frente a dos monitores de computadora en un escritorio de oficina, rodeado de estantes con archivos y carpetas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7104,7 +7104,7 @@
       "serie": "archivo",
       "orden": 230,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la espalda tan mojada de sudor y salitre que el sol le dibuja encima el mismo brillo del mar que tiene enfrente, y ya no se sabe cuál de los dos moja al otro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7118,8 +7118,8 @@
         "generacion": "277187c6-95dc-4281-bafa-7ef194ed707c",
         "variante": 0
       },
-      "titulo": "Day with the fishermen postcard in the style",
-      "alt": "Day with the fishermen postcard in the style of 1500s precolo",
+      "titulo": "Hacia la isla de palmas",
+      "alt": "Un hombre visto de espaldas, sin camisa, está sentado en la proa de una embarcación mirando hacia el mar abierto, con una isla de palmeras a lo lejos bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7135,7 +7135,7 @@
       "serie": "archivo",
       "orden": 231,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Reman los cuatro exactamente al mismo compás, y la estela que dejan sobre el agua verde queda tan recta que parece trazada con regla desde la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7149,8 +7149,8 @@
         "generacion": "2ced6dad-12b0-4b9e-9425-bb964b738866",
         "variante": 3
       },
-      "titulo": "Day with the fishermen postcard in the style",
-      "alt": "Day with the fishermen postcard in the style of 1500 arawak s",
+      "titulo": "Los cuatro del bote verde",
+      "alt": "Vista aérea de un bote de madera con cuatro hombres vestidos de blanco y gorras remando sobre un mar de color verde turquesa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7166,7 +7166,7 @@
       "serie": "archivo",
       "orden": 232,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las olas rompen en una línea blanca tan larga que parece un cordón que amarra la isla de palmeras a la orilla, y el bote diminuto cruza justo por el nudo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7180,8 +7180,8 @@
         "generacion": "10246a99-6fd3-4016-b0de-bb5444638f35",
         "variante": 0
       },
-      "titulo": "DCxg a fishing b",
-      "alt": "dCxg a fishing b",
+      "titulo": "La isla frente al oleaje",
+      "alt": "Paisaje costero con una pequeña isla de palmeras, olas rompiendo en la orilla, montañas al fondo y un pequeño bote con dos personas navegando cerca de la playa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7197,7 +7197,7 @@
       "serie": "archivo",
       "orden": 233,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol se rompe en tantos pedazos sobre el agua que la barca navega envuelta en su propio enjambre de chispas, dejando atrás una estela de espuma blanca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7211,8 +7211,8 @@
         "generacion": "97fb414d-b33b-446c-90e3-027c379e551d",
         "variante": 1
       },
-      "titulo": "DCxg a fishing boat at the distance in",
-      "alt": "dCxg a fishing boat at the distance in a",
+      "titulo": "El bote entre las chispas",
+      "alt": "Silueta de un bote de pesca navegando sobre un mar con reflejos brillantes del sol, bajo un cielo con nubes blancas, y espuma de olas en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7228,7 +7228,7 @@
       "serie": "archivo",
       "orden": 234,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mesa azul del primer plano queda vacía menos por un vaso, mientras el bote de pescadores se recorta diminuto justo en el centro del marco de paja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7242,8 +7242,8 @@
         "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961",
         "variante": 0
       },
-      "titulo": "DCxg a fishing boat at the distance in",
-      "alt": "dCxg a fishing boat at the distance in a",
+      "titulo": "Mesa azul frente al bote",
+      "alt": "Vista desde una palapa de techo de paja hacia el mar, con un bote de pescadores en el horizonte, sillas de madera y una mesa azul con un vaso en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7259,7 +7259,7 @@
       "serie": "archivo",
       "orden": 235,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La costa se difumina tan lejos en la neblina que el bote navega sin saber ya si todavía tiene tierra detrás o si ya la dejó atrás hace rato.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7273,8 +7273,8 @@
         "generacion": "a69cc905-9709-4c78-a1fd-368ee4250961",
         "variante": 2
       },
-      "titulo": "DCxg a fishing boat at the distance in",
-      "alt": "dCxg a fishing boat at the distance in a",
+      "titulo": "El bote en la neblina",
+      "alt": "Un pequeño bote de pesca navega solo sobre un mar en calma, con una costa lejana y difusa al fondo bajo un cielo nublado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7290,7 +7290,7 @@
       "serie": "archivo",
       "orden": 236,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Corren en fila justo por la orilla donde el agua toca la arena, y el sol de frente los recorta tan negros que ya son puro contorno en movimiento.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7304,8 +7304,8 @@
         "generacion": "06e5aaf4-1ea3-44bc-91d7-920d3452e256",
         "variante": 2
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "Corredores contra el sol",
+      "alt": "Siluetas oscuras de varias personas corriendo por la orilla de una playa a contraluz, con el mar al fondo bajo un cielo brillante y neblinoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7321,7 +7321,7 @@
       "serie": "archivo",
       "orden": 237,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene dos puertas azules idénticas una junto a la otra, y ninguna de las dos se usa tanto como la lancha varada en la arena de al lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7335,8 +7335,8 @@
         "generacion": "0a30f04e-78a6-4e5c-985f-655ab739c62e",
         "variante": 1
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "Las dos puertas azules",
+      "alt": "Casa pequeña de paredes blancas y azules con techo de tejas y dos puertas azules, rodeada de arbustos verdes, con una lancha varada cerca y el mar al fondo, bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7352,7 +7352,7 @@
       "serie": "archivo",
       "orden": 238,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Baja por el sendero de tierra entre las piedras blancas, y la ola que rompe al final es tan alta que lo deja del tamaño de una de esas piedras.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7366,8 +7366,8 @@
         "generacion": "12647c4e-64ee-4a2a-b1fc-7220bf795702",
         "variante": 3
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "Sendero entre piedras blancas",
+      "alt": "Un sendero de tierra entre piedras blancas desciende hacia el mar, donde rompen grandes olas, con una persona de pie al final del camino bajo un cielo violeta de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7383,7 +7383,7 @@
       "serie": "archivo",
       "orden": 239,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nube blanca ocupa más cielo que las tres casas de paja ocupan tierra, y aun así ninguna de las puertas azules se ha movido para mirarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7397,8 +7397,8 @@
         "generacion": "1778e0f7-553c-4eb0-abe9-92a4a8a27ac0",
         "variante": 1
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "Tres casas frente al mar",
+      "alt": "Tres casas con techo de paja y puertas azules junto a un camino de tierra, frente al mar, bajo un cielo con grandes nubes blancas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7414,7 +7414,7 @@
       "serie": "archivo",
       "orden": 240,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La lente curva tanto el horizonte que el lago rosado se le enrosca completo detrás de la cabeza, con todo y bote, antes de volver a enderezarse en los bordes.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7428,8 +7428,8 @@
         "generacion": "267dff55-a75d-43b5-a521-9127be73c960",
         "variante": 2
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "Turbante blanco, lago rosado",
+      "alt": "Retrato en gran angular de una mujer con un pañuelo blanco en la cabeza, mirando de frente a la cámara, con un lago de agua rosada y un bote pequeño al fondo, bajo un cielo azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7445,7 +7445,7 @@
       "serie": "archivo",
       "orden": 241,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El piano suena tan cerca del arco abierto al mar que las notas salen directo hacia el agua sin pasar antes por ninguna de las mesas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7459,8 +7459,8 @@
         "generacion": "3eb12ea5-29dd-43e1-b5c0-1f62e7305e63",
         "variante": 2
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "El piano frente al mar",
+      "alt": "Fotografía en tono sepia de varias personas sentadas en mesas bajo un arco abierto hacia el mar, con una hoja de palmera colgando y una persona tocando un piano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7476,7 +7476,7 @@
       "serie": "archivo",
       "orden": 242,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las flores amarillas cubren tanto terreno frente a la casa que los dos que están sentados junto a la puerta parecen esperar en medio de un campo entero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7490,8 +7490,8 @@
         "generacion": "42234bf1-fca8-41a9-aaf3-c5757bd8962f",
         "variante": 1
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "La casa entre flores amarillas",
+      "alt": "Casa pequeña de techo de metal corrugado rodeada de arbustos verdes y un campo de flores silvestres amarillas, con dos personas sentadas cerca de la puerta, bajo un cielo azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7507,7 +7507,7 @@
       "serie": "archivo",
       "orden": 243,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pared azul se oscurece tanto con la última luz que el techo de tejas rojas es lo único que todavía se distingue del cielo que se le está poniendo encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7521,8 +7521,8 @@
         "generacion": "4b72baa4-7c2a-485f-94ea-f30001c0b93d",
         "variante": 3
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "La casa azul al anochecer",
+      "alt": "Casa de paredes azules y blancas con techo de tejas, vista al anochecer con un cielo rojizo y morado, el mar visible a lo lejos y cables eléctricos cruzando la escena.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7538,7 +7538,7 @@
       "serie": "archivo",
       "orden": 244,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El bote de madera lleva apoyado en la pared turquesa tanto tiempo que los arbustos le crecieron por dentro, y hace rato dejó de esperar la marea.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7552,8 +7552,8 @@
         "generacion": "a9a6e656-d988-4694-b663-a849d0dbe38c",
         "variante": 0
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "El bote que echó raíces",
+      "alt": "Casa de paredes turquesas con techo de paja y puerta azul, con un bote de madera lleno de arbustos apoyado en la fachada, bajo un cielo azul despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7569,7 +7569,7 @@
       "serie": "archivo",
       "orden": 245,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Empedrado de nubes iguales, el cielo ocupa las tres cuartas partes de la fotografía y dobla la calle entera dentro de su curva de vidrio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7583,8 +7583,8 @@
         "generacion": "cd08ef79-71af-4bae-b9b9-0df22acdc92a",
         "variante": 0
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "El cielo empedrado de nubes",
+      "alt": "Fotografía en gran angular de una calle de pueblo con casas de piedra, un carro estacionado y una persona caminando, bajo un cielo cubierto de nubes pequeñas y dispersas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7600,7 +7600,7 @@
       "serie": "archivo",
       "orden": 246,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El canal se parte en tres brazos de agua que devuelven el sol como espejos rotos, y el pantano verde no deja ver dónde empieza la tierra firme.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7614,8 +7614,8 @@
         "generacion": "cf10e7cb-7eaa-46a1-83ed-e648871ae987",
         "variante": 0
       },
-      "titulo": "DCxg httpss.mj.r",
-      "alt": "dCxg httpss.mj.r",
+      "titulo": "El delta de espejos",
+      "alt": "Vista aérea de un pantano con canales de agua brillante serpenteando entre vegetación verde y tierra rojiza, bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7631,7 +7631,7 @@
       "serie": "archivo",
       "orden": 247,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Reparten el pescado en cestas de mimbre los hombres de sombrero blanco, y la noche se traga cada bulto apenas se aparta de la luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7645,8 +7645,8 @@
         "generacion": "a404bb2f-3472-4f1f-8f51-6013b90d28c3",
         "variante": 3
       },
-      "titulo": "DCxg Slice of li",
-      "alt": "dCxg Slice of li",
+      "titulo": "El reparto del pescado",
+      "alt": "Fotografía nocturna en blanco y negro de varios hombres con sombrero y camisa blanca clasificando pescado en grandes cestas de mimbre.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7662,7 +7662,7 @@
       "serie": "archivo",
       "orden": 248,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El árbol se dobla entero hacia la playa, como si llevara cien años señalando el camino al carro blanco que baja solo por la carretera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7676,8 +7676,8 @@
         "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed",
         "variante": 1
       },
-      "titulo": "DCxg Slice of li",
-      "alt": "dCxg Slice of li",
+      "titulo": "El camino hacia el mar",
+      "alt": "Fotografía antigua de una carretera de tierra con un árbol grande inclinado a la izquierda, un carro blanco circulando hacia el mar y casas pequeñas a la derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7693,7 +7693,7 @@
       "serie": "archivo",
       "orden": 249,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva el sombrero de paja calado hasta las cejas y deja la cerveza a medio terminar sobre el muro, mientras el bote se mece detrás de él como si esperara turno.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7707,8 +7707,8 @@
         "generacion": "c08c9837-9fbf-4d47-b2a3-322b62811eed",
         "variante": 2
       },
-      "titulo": "DCxg Slice of li",
-      "alt": "dCxg Slice of li",
+      "titulo": "El sombrero frente al mar",
+      "alt": "Fotografía antigua de un hombre con sombrero de paja sentado junto a un muro frente al mar, con una cerveza sobre la mesa y un bote de madera flotando detrás.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7724,7 +7724,7 @@
       "serie": "archivo",
       "orden": 250,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La moto atraviesa la orilla a tanta velocidad que la casa de zinc se vuelve un borrón detrás de él y el bote ni alcanza a moverse con la ola de aire.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7738,8 +7738,8 @@
         "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c",
         "variante": 1
       },
-      "titulo": "DCxg Slice of li",
-      "alt": "dCxg Slice of li",
+      "titulo": "El motociclista de la costa",
+      "alt": "Fotografía antigua de un hombre conduciendo una motocicleta por un camino costero, con una casa pequeña y un bote de madera al fondo junto al mar.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7755,7 +7755,7 @@
       "serie": "archivo",
       "orden": 251,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Contra el brillo del mar se recorta un grupo de cabezas en silueta, y al fondo las torres de la refinería queman su propia luz compitiendo con el sol de la tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7769,8 +7769,8 @@
         "generacion": "e1ea1286-b2d4-4f84-8c2b-62731fecc91c",
         "variante": 2
       },
-      "titulo": "DCxg Slice of li",
-      "alt": "dCxg Slice of li",
+      "titulo": "Las siluetas de la refinería",
+      "alt": "Fotografía en blanco y negro de personas en silueta sentadas de espaldas frente al mar, con un bote pequeño y torres industriales de una refinería en el horizonte.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -7786,7 +7786,7 @@
       "serie": "archivo",
       "orden": 252,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El rojo de la pintura le cubre la cara entera hasta la línea del cuello, donde el collar de piel se cierra con un solo diente blanco que cuelga como firma.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7800,8 +7800,8 @@
         "generacion": "0952c9b5-b16b-4ddf-b01f-d91c64f6f521",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El collar de piel",
+      "alt": "Retrato de un hombre con el rostro y el cuerpo pintados de rojo, aretes amarillos, un aro en el tabique nasal, collares de cuentas y un cuello de piel con un colgante blanco, sobre fondo gris.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7816,7 +7816,7 @@
       "serie": "archivo",
       "orden": 253,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se apilan las conchas collar sobre collar hasta rozarle la barbilla, y tres rayas negras le bajan por el cuello como si contaran los años que lleva usándolas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7830,8 +7830,8 @@
         "generacion": "50375359-3845-4c4d-b256-7de30465167b",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El collar de conchas apiladas",
+      "alt": "Retrato de un hombre con cabello largo y oscuro, aro en el tabique nasal, aretes de concha, rayas oscuras pintadas en el cuello y varios collares apilados de conchas blancas, sobre fondo claro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7846,7 +7846,7 @@
       "serie": "archivo",
       "orden": 254,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos colmillos de metal le atraviesan el tabique al mismo tiempo, y la luz naranja le quema la piel hasta hacerla parecer brasa encendida.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7860,8 +7860,8 @@
         "generacion": "5b4b01a8-3923-4680-a79f-c6804743d68c",
         "variante": 3
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "Los dos colmillos del tabique",
+      "alt": "Retrato de un hombre con flequillo corto, dos aros atravesados en el tabique nasal, aretes de concha y collares de cuentas, bajo una luz cálida de tono naranja.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7876,7 +7876,7 @@
       "serie": "archivo",
       "orden": 255,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola mecha de canas le cruza el pelo negro, y la tela roja bordada le cubre apenas un hombro mientras el otro se queda desnudo bajo la sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7890,8 +7890,8 @@
         "generacion": "7009380c-fb82-483b-b891-3d3fdb1ee0e0",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El perfil de tela roja",
+      "alt": "Retrato de perfil de un hombre con cabello oscuro y una mecha canosa, arete blanco ovalado, aro dorado en el tabique nasal, collares de cuentas y una tela roja bordada sobre un hombro, contra fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7906,7 +7906,7 @@
       "serie": "archivo",
       "orden": 256,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le nace la pluma justo en la coronilla, y el collar de cuentas le cae por el pecho hasta rematar en una franja de conchas que casi le llega al ombligo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7920,8 +7920,8 @@
         "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "La pluma en la coronilla",
+      "alt": "Retrato de un hombre con un adorno de pluma en la cabeza, aro dorado en el tabique nasal, aretes de concha y un collar largo de cuentas oscuras rematado en conchas, sobre fondo dorado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7936,7 +7936,7 @@
       "serie": "archivo",
       "orden": 257,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arete de madera se le curva como un anzuelo entero colgado del lóbulo, y entre los collares le asoman plumas como si un ave se hubiera quedado atrapada ahí.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7950,8 +7950,8 @@
         "generacion": "a38d24f9-ef2a-4f0e-9679-8da59bdb498f",
         "variante": 2
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El gancho de madera",
+      "alt": "Retrato de un hombre con un arete de madera en forma de gancho, pintura roja en el rostro, aro dorado en el tabique nasal y varios collares de cuentas y conchas con plumas entre ellos.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7966,7 +7966,7 @@
       "serie": "archivo",
       "orden": 258,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El flequillo le corta la frente en línea perfecta, y dos aros dorados le atraviesan la nariz mientras los collares se apilan uno sobre otro hasta rozarle la barbilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -7980,8 +7980,8 @@
         "generacion": "c469a44e-2a09-45eb-901c-4b9099ff51d2",
         "variante": 2
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "Los dos aros dorados",
+      "alt": "Retrato de un hombre con flequillo recto, dos aros dorados en el tabique nasal, aretes de concha colgantes y varios collares de cuentas y conchas superpuestos, en tono cálido.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -7996,7 +7996,7 @@
       "serie": "archivo",
       "orden": 259,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apenas le alcanza la luz el filo de la nariz y el pómulo derecho, dejando el resto de la cara suelto en la oscuridad del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8010,8 +8010,8 @@
         "generacion": "cc75e988-f6c0-4d01-8b06-b85c83d2843d",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El brillo sobre el pómulo",
+      "alt": "Retrato de un hombre con cabello oscuro, aro dorado en el tabique nasal y collares de cuentas, iluminado de forma tenue contra un fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8026,7 +8026,7 @@
       "serie": "archivo",
       "orden": 260,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La manta a rayas rojas y negras le cubre un solo hombro y deja el otro desnudo, como si la tela hubiera decidido a mitad de camino no seguir cubriendo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8040,8 +8040,8 @@
         "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "La manta a rayas",
+      "alt": "Retrato de un hombre con cabello largo y oscuro, arete dorado, un collar de cuentas y conchas, y una manta a rayas rojas y negras cubriéndole un hombro, contra fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8056,7 +8056,7 @@
       "serie": "archivo",
       "orden": 261,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva un brazalete de cuentas idéntico en cada brazo, como un par de pulseras gemelas, mientras la estera tejida del fondo repite el mismo trenzado hasta el borde del retrato.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8070,8 +8070,8 @@
         "generacion": "cebda612-b095-40be-a7b3-dc836af2c29d",
         "variante": 2
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "Los brazaletes gemelos",
+      "alt": "Retrato de un hombre sentado con collares de cuentas superpuestos sobre una túnica tejida color crema, un arete de concha y brazaletes de cuentas en ambos brazos, frente a un fondo de estera tejida.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8086,7 +8086,7 @@
       "serie": "archivo",
       "orden": 262,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los collares se multiplican capa tras capa hasta que todos convergen en una sola piedra colgante, como si tanta cuenta solo existiera para sostener ese punto final.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8100,8 +8100,8 @@
         "generacion": "e8e9ea51-7291-4840-804c-196af43bf704",
         "variante": 2
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El colgante final",
+      "alt": "Retrato de un hombre con cabello largo, dos aros dorados en el tabique nasal, un arete colgante y varios collares de cuentas y conchas rematados en un colgante grande, sobre fondo verde oliva.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8116,7 +8116,7 @@
       "serie": "archivo",
       "orden": 263,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La vincha de cuentas le divide el pelo en una línea recta sobre la frente, y el azul del fondo hace que cada concha blanca del collar brille como si tuviera luz propia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8130,8 +8130,8 @@
         "generacion": "e8e9ea51-7291-4840-804c-196af43bf704",
         "variante": 3
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "La vincha sobre el pelo",
+      "alt": "Retrato de un hombre con una vincha de cuentas en la frente, aro dorado en el tabique nasal, un arete de concha y collares de cuentas oscuras y conchas blancas, sobre fondo azul oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8146,7 +8146,7 @@
       "serie": "archivo",
       "orden": 264,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar se ensancha hasta volverse un peto entero de cuentas que le cubre el pecho como si fuera una armadura tejida hilo por hilo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8160,8 +8160,8 @@
         "generacion": "eb39163d-402d-4dca-8640-ee9dbbf76c6e",
         "variante": 2
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El peto de cuentas",
+      "alt": "Retrato de un hombre de cabello corto con aro dorado en el tabique nasal y un amplio collar de cuentas que le cubre el pecho como un peto, sobre fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8176,7 +8176,7 @@
       "serie": "archivo",
       "orden": 265,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El manto tejido le nace en los hombros sembrado de conchas, como si el tejedor hubiera decidido coserle el mar entero encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8190,8 +8190,8 @@
         "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4",
         "variante": 1
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "El manto sembrado de conchas",
+      "alt": "Retrato de un hombre de cabello largo con arete colgante de cuentas y conchas, varios collares dorados y un manto tejido con conchas cosidas sobre los hombros, contra fondo oscuro verdoso.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8206,7 +8206,7 @@
       "serie": "archivo",
       "orden": 266,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arete de conchas le cuelga tan largo que le roza el hombro, y la vincha a rayas azules le cruza la frente como una segunda ceja pintada de tela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8220,8 +8220,8 @@
         "generacion": "fc90690d-4dd8-48ce-9d30-c7acdbf1e4d4",
         "variante": 3
       },
-      "titulo": "DE httpss.mj.r",
-      "alt": "DE httpss.mj.r",
+      "titulo": "La vincha de colores",
+      "alt": "Retrato de un hombre con una vincha de cuentas azules y blancas, piel con tono rojizo, aretes largos de concha y un collar de cuentas, con una prenda de piel sobre los hombros, contra fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8236,7 +8236,7 @@
       "serie": "archivo",
       "orden": 267,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las plumas se abren en abanico justo detrás de la sien y encienden de rojo y azul la única parte de la cabeza que la sombra no alcanza a cubrir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8250,8 +8250,8 @@
         "generacion": "02ff3e12-d4a6-404f-a962-5335fba9075f",
         "variante": 0
       },
-      "titulo": "DE Retrato de",
-      "alt": "DE Retrato de",
+      "titulo": "La corona de plumas encendidas",
+      "alt": "Retrato de un hombre con un tocado de plumas rojas y azules, vincha dorada, aro en el tabique nasal, collares dorados y brazaletes de cuentas, con el torso descubierto, contra fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -8267,7 +8267,7 @@
       "serie": "archivo",
       "orden": 268,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cresta de la ola se vuelve un vidrio verde justo antes de romper, y la espuma le dibuja una cortina blanca que dura menos de un segundo bajo la luz naranja del atardecer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8281,8 +8281,8 @@
         "generacion": "f1eac6ab-99e7-476b-b5bf-2bf3f133b35f",
         "variante": 0
       },
-      "titulo": "Did you know that acuatic dinosaurs also spawn",
-      "alt": "Did you know that acuatic dinosaurs also spawn eggs just like",
+      "titulo": "La ola de vidrio verde",
+      "alt": "Ilustración de una ola de mar rompiendo con espuma blanca, junto a un acantilado con palmeras y montañas al fondo, bajo un cielo de atardecer en tonos morados y naranjas.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -8298,7 +8298,7 @@
       "serie": "archivo",
       "orden": 269,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Abre la boca de frente a la cámara y enseña cada diente uno por uno, mientras las burbujas del buzo suben derechas como una cuenta hacia la superficie.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8312,8 +8312,8 @@
         "generacion": "5704380b-855d-4b39-bd6a-9d40c48e9487",
         "variante": 3
       },
-      "titulo": "Did you know that sharks also spawn eggs",
-      "alt": "Did you know that sharks also spawn eggs just like coral Befo",
+      "titulo": "La boca que cuenta burbujas",
+      "alt": "Cabeza de un tiburón vista de frente bajo el agua, con la boca abierta mostrando los dientes, en tonos azules y verdes, sobre un fondo de coral y con burbujas subiendo desde arriba.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -8329,7 +8329,7 @@
       "serie": "archivo",
       "orden": 270,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre el arrecife anaranjado que arde bajo sus aletas y el mismo incendio repetido en el reflejo de la superficie, nada raso sin chamuscarse ni una escama.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8343,8 +8343,8 @@
         "generacion": "81a5d6ea-edf0-4ce9-9400-ef48da928f77",
         "variante": 1
       },
-      "titulo": "Did you know that sharks also spawn eggs",
-      "alt": "Did you know that sharks also spawn eggs just like coral Befo",
+      "titulo": "El tiburón entre dos incendios",
+      "alt": "Un tiburón nadando cerca de la superficie del mar sobre un arrecife de coral anaranjado, con el agua azul oscuro y el reflejo del arrecife visible en la superficie.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -8360,7 +8360,7 @@
       "serie": "archivo",
       "orden": 271,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Flota a un palmo del agua sin mojarse nunca, con los pliegues color brasa tan tersos que el viento del atardecer los dobla como si fueran tela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8374,8 +8374,8 @@
         "generacion": "9abaf15c-ed1f-4c45-923f-686b94286024",
         "variante": 3
       },
-      "titulo": "Did you know that starfish and brittle stars",
-      "alt": "Did you know that starfish and brittle stars also spawn eggs",
+      "titulo": "La concha sin mojarse",
+      "alt": "Una forma parecida a una concha o estrella de mar, de color naranja y textura rugosa con pliegues claros, flotando en el aire sobre un lago al atardecer, con árboles en silueta al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -8391,7 +8391,7 @@
       "serie": "archivo",
       "orden": 272,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las manos desnudas golpean el cuero del tambor, y cada golpe suelta una chispa naranja que da la vuelta completa a la playa antes de apagarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8405,8 +8405,8 @@
         "generacion": "8477f66b-9307-4e87-ad90-df5f9886a342",
         "variante": 1
       },
-      "titulo": "DqCokGI Cinematic film photo close up of per",
-      "alt": "dqCokGI Cinematic film photo close up of per",
+      "titulo": "El tambor que suelta chispas",
+      "alt": "Un hombre con gorro rojo y camisa azul toca un tambor djembe sentado en una playa, rodeado de otras personas borrosas por el movimiento, con estelas de luz naranja y el mar y el cielo nublado al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -8422,7 +8422,7 @@
       "serie": "archivo",
       "orden": 273,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La esfera afelpada y azul del suelo queda a un roce de las faldas de rafia, y ninguno de los cuatro se atreve a tocarla primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8436,8 +8436,8 @@
         "generacion": "9793bbf9-e5e4-4d42-9c2e-51ed9b344c20",
         "variante": 0
       },
-      "titulo": "El regal este bolero lp remastered in the",
-      "alt": "el regal este bolero lp remastered in the style of playful h",
+      "titulo": "La esfera que nadie toca",
+      "alt": "Cuatro personas con máscaras y faldas de rafia de pie sobre un campo, vestidas en tonos ocres y rojizos, junto a una esfera de textura afelpada azul verdosa en primer plano, en una fotografía de tono envejecido.",
       "w": 1040,
       "h": 1024,
       "anchos": [
@@ -8453,7 +8453,7 @@
       "serie": "archivo",
       "orden": 274,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Toca el cuatro sentado en el centro exacto del tablero a cuadros, y el tablero gira tan despacio que los otros dos llevan media vida buscando ese mismo centro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8467,8 +8467,8 @@
         "generacion": "ec6f5647-fb21-46d6-937e-b32b1cb2b378",
         "variante": 3
       },
-      "titulo": "El regal este bolero lp remastered in the",
-      "alt": "el regal este bolero lp remastered in the style of playful h",
+      "titulo": "El centro del tablero",
+      "alt": "Pintura de tres hombres sobre un fondo de espiral a cuadros blancos y negros, uno sentado tocando un instrumento de cuerdas, con esferas de textura afelpada verde y roja flotando en la escena.",
       "w": 1040,
       "h": 1024,
       "anchos": [
@@ -8484,7 +8484,7 @@
       "serie": "archivo",
       "orden": 275,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajo los letreros de neón puntea el shamisen, y cada nota que suelta apaga una letra distinta del rótulo rosado antes de volver a encenderse sola.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8498,8 +8498,8 @@
         "generacion": "480ff122-2425-4608-aa86-2badaf7da22a",
         "variante": 2
       },
-      "titulo": "Elegant Jap",
-      "alt": "Elegant Jap",
+      "titulo": "La nota apaga el neón",
+      "alt": "Una mujer vestida con kimono tradicional toca un instrumento de cuerda japonés sentada en una calle nocturna iluminada por letreros de neón azules y rosados con caracteres japoneses.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -8515,7 +8515,7 @@
       "serie": "archivo",
       "orden": 276,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene el laúd contra el pecho como si fuera a caérsele el letrero rosado de encima, y camina tan despacio que las luces alcanzan a cambiar dos veces antes del siguiente paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8529,8 +8529,8 @@
         "generacion": "a3c612f9-25ed-4108-bdd8-c618f92ea7f7",
         "variante": 2
       },
-      "titulo": "Elegant Jap",
-      "alt": "Elegant Jap",
+      "titulo": "El laúd bajo las luces",
+      "alt": "Una mujer con kimono y maquillaje tradicional japonés sostiene un instrumento de cuerda de pie en una calle nocturna oscura, iluminada por un letrero de neón rosado con caracteres japoneses.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -8546,7 +8546,7 @@
       "serie": "archivo",
       "orden": 277,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El yelmo de plata le queda salpicado de sangre ajena, y grita tan fuerte en medio de la batalla que los que están detrás bajan la lanza sin darse cuenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8560,8 +8560,8 @@
         "generacion": "df7e0d6d-5f03-4ae1-9930-c92cfc4347f0",
         "variante": 2
       },
-      "titulo": "Epic battle between Aquiles and Prince Hector in",
-      "alt": "Epic battle between Aquiles and Prince Hector in front of the",
+      "titulo": "El yelmo salpicado de sangre",
+      "alt": "Primer plano de un guerrero con casco de metal manchado de sangre y gesto de furia, rodeado de otros soldados armados en una escena de batalla campal.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8577,7 +8577,7 @@
       "serie": "archivo",
       "orden": 278,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya la lanza en la baranda de piedra y mira hacia la bahía como si llevara dos mil años calculando el momento exacto de bajar hasta el agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8591,8 +8591,8 @@
         "generacion": "c451691a-ff3a-4a5d-987f-f116a6b67051",
         "variante": 2
       },
-      "titulo": "Eric clapton and claude jean in elvis presleys",
-      "alt": "eric clapton and claude jean in elvis presleys roman empire i",
+      "titulo": "La lanza sobre la baranda",
+      "alt": "Dos hombres vestidos con armadura y capa de estilo de la antigüedad clásica conversan de pie en una terraza con columnas, con vista a una bahía, un pueblo costero y colinas verdes al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -8608,7 +8608,7 @@
       "serie": "archivo",
       "orden": 279,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva puestos tantos collares de cuentas doradas que el cuello desaparece bajo ellos, mientras detrás le trenzan el cabello sin que mueva ni un músculo de la cara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8622,8 +8622,8 @@
         "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b",
         "variante": 1
       },
-      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
-      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "titulo": "El cuello bajo los collares",
+      "alt": "Una joven indígena con varios collares de cuentas doradas y aretes mira al frente en un interior iluminado con luz cálida, mientras otra persona detrás le trenza el cabello, con paredes de paja al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8639,7 +8639,7 @@
       "serie": "archivo",
       "orden": 280,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cinta de cuentas le cruza la frente de sien a sien sin ceder un milímetro, aunque a su lado le estén cerrando el último collar con manos apuradas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8653,8 +8653,8 @@
         "generacion": "5f57ec01-86a0-4b2c-a200-0e2a36f5a12b",
         "variante": 3
       },
-      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
-      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "titulo": "La cinta que no cede",
+      "alt": "Una joven indígena con una banda de cuentas en la frente y varios collares dorados mira al frente en un interior con luz cálida, mientras otra persona a su lado le ajusta un collar, con paredes de paja al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8670,7 +8670,7 @@
       "serie": "archivo",
       "orden": 281,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le colocan la tela roja sobre la cabeza a cuatro manos, dos por cada lado, y ninguna suelta hasta que queda exactamente recta sobre el peinado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8684,8 +8684,8 @@
         "generacion": "63694911-9983-4a89-af3b-079745a93293",
         "variante": 3
       },
-      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
-      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "titulo": "Tela roja a cuatro manos",
+      "alt": "Dos mujeres colocan una tela roja sobre la cabeza de una tercera mujer sentada, vestida con un top de rayas y collares de cuentas, en un interior de paredes de paja con cestas colgadas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8701,7 +8701,7 @@
       "serie": "archivo",
       "orden": 282,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una le trenza el cabello mechón por mechón mientras otra le acomoda el chal a rayas sobre los hombros, y las dos terminan a la vez sin haberse mirado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8715,8 +8715,8 @@
         "generacion": "7b2c2125-d97f-43b3-953f-790f9ed4e871",
         "variante": 0
       },
-      "titulo": "Escena de una princesa Caqueta con atuendo tradicional",
-      "alt": "Escena de una princesa Caqueta con atuendo tradicional nativo",
+      "titulo": "Dos manos un mismo instante",
+      "alt": "Tres mujeres en un interior de paja: una sentada con top de cuentas y chal a rayas, y otras dos detrás arreglándole el cabello y la ropa con luz cálida y tenue.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8761,7 +8761,7 @@
       "serie": "archivo",
       "orden": 284,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La hamaca cuelga atravesada en el marco de la puerta, y desde ella se ve el mar entero sin levantarse ni mecerla una sola vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8775,8 +8775,8 @@
         "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50",
         "variante": 0
       },
-      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
-      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "titulo": "Hamaca que enmarca el mar",
+      "alt": "Vista desde el interior de una casa hacia afuera por una puerta, con una hamaca colgada en primer plano y el mar visible al fondo bajo un cielo con nubes, en una fotografía de tono envejecido.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8792,7 +8792,7 @@
       "serie": "archivo",
       "orden": 285,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre las flores amarillas se queda quieto el caballo blanco tanto rato que las enredaderas empiezan a treparle por las patas sin que se aparte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8806,8 +8806,8 @@
         "generacion": "26c39d33-de94-469e-8251-ef52cdc46f50",
         "variante": 2
       },
-      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
-      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "titulo": "El caballo entre las flores",
+      "alt": "Un caballo blanco de pie entre plantas y flores amarillas en un jardín, con una hamaca y una casa de techo de tejas al fondo, en luz tenue de atardecer y tono de fotografía envejecida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8823,7 +8823,7 @@
       "serie": "archivo",
       "orden": 286,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las estrellas se amontonan justo encima del techo de tejas mientras la hamaca vacía se mece sola frente a la puerta, como si alguien acabara de soltarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8837,8 +8837,8 @@
         "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
         "variante": 1
       },
-      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
-      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "titulo": "La hamaca que se mece",
+      "alt": "Una casa rural pequeña de paredes claras y techo de tejas junto a un árbol solitario, bajo un cielo nocturno estrellado con nubes, con una hamaca colgada frente a la puerta, en tono de fotografía envejecida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8854,7 +8854,7 @@
       "serie": "archivo",
       "orden": 287,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cortina se abre justo lo necesario para que la bahía entera quepa entre las flores del balcón y la sombra de quien mira sin moverse del marco.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8868,8 +8868,8 @@
         "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
         "variante": 2
       },
-      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
-      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "titulo": "La bahía entre las flores",
+      "alt": "Vista desde un balcón con cortinas hacia un paisaje de colinas, un lago o bahía y cielo con nubes, con flores en primer plano y la silueta de una persona sentada a un lado, en tono de fotografía envejecida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8885,7 +8885,7 @@
       "serie": "archivo",
       "orden": 288,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Abierta de par en par, la puerta azul deja que la montaña entera quepa detrás del árbol sin que nadie se moleste nunca en cerrarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8899,8 +8899,8 @@
         "generacion": "6bb29086-869c-4e4c-b07a-da13069997e2",
         "variante": 3
       },
-      "titulo": "Ethereal vistas from paraguan with indigenous references goat",
-      "alt": "ethereal vistas from paraguan with indigenous references goat",
+      "titulo": "Puerta azul hacia la montaña",
+      "alt": "Una puerta azul abierta desde un interior oscuro hacia un paisaje de montañas con un árbol grande, y una hamaca visible a un lado, en tono de fotografía envejecida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -8916,7 +8916,7 @@
       "serie": "archivo",
       "orden": 289,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mano descansa sobre los mandos sin apretar ninguno, mientras en la pantalla de al lado la ciudad entera de luces sigue encendida abajo, como si esperara la orden.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8930,8 +8930,8 @@
         "generacion": "07ee67aa-4fa8-4a10-9838-95a596d47b8d",
         "variante": 0
       },
-      "titulo": "Extreme close up on retro analog control panel",
-      "alt": "extreme close up on retro analog control panel of Space freig",
+      "titulo": "La mano que espera",
+      "alt": "Interior de una cabina de mando con paneles de control analógicos, pantallas y luces, con una mano sobre los controles y una vista nocturna de luces de ciudad y un planeta a través de la ventana.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -8947,7 +8947,7 @@
       "serie": "archivo",
       "orden": 290,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El árbol deja caer sus flores rosadas sobre la banca donde los dos se sientan, y el carro negro estacionado lleva tantos años ahí que ya le brotan pétalos en el capó.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8961,8 +8961,8 @@
         "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9",
         "variante": 0
       },
-      "titulo": "Felix Vallottons painting slice of life in caracas",
-      "alt": "Felix Vallottons painting slice of life in caracas masterpiec",
+      "titulo": "El árbol sobre la banca",
+      "alt": "Pintura de una calle con casas coloniales azules y rosadas, un árbol con flores rosadas, dos personas sentadas en una banca y un automóvil antiguo negro estacionado cerca, con textura pictórica granulada.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -8977,7 +8977,7 @@
       "serie": "archivo",
       "orden": 291,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El papel tapiz verde repite su propio dibujo detrás de ella una y otra vez, hasta que el rojo de los labios queda como lo único en la habitación que no se repite.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -8991,8 +8991,8 @@
         "generacion": "ffd0fd28-bff3-49a1-9fbe-70984fa937a9",
         "variante": 3
       },
-      "titulo": "Felix Vallottons painting slice of life in caracas",
-      "alt": "Felix Vallottons painting slice of life in caracas masterpiec",
+      "titulo": "El rojo sin repetirse",
+      "alt": "Pintura de una mujer con vestido negro, labios rojos y aretes, vista detrás de la silueta oscura de un hombre con sombrero, sobre un fondo de papel tapiz verde con motivos decorativos.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9007,7 +9007,7 @@
       "serie": "archivo",
       "orden": 292,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta un brazo hacia la luna nueva mientras el fuego le sube por el manto color cobre, y nadie más se mueve hasta que la llama le toca el codo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9021,8 +9021,8 @@
         "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
         "variante": 0
       },
-      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
-      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "titulo": "El brazo hacia la luna",
+      "alt": "Un grupo de personas envueltas en mantos de color naranja y cobre de pie alrededor de una fogata en una playa de noche, con una luna creciente en el cielo y el mar y colinas oscuras al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9038,7 +9038,7 @@
       "serie": "archivo",
       "orden": 293,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El círculo completo rodea el fuego sin dejar un solo hueco entre manto y manto, mientras los árboles de ambos lados de la playa se inclinan igual de negros hacia el centro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9052,8 +9052,8 @@
         "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
         "variante": 1
       },
-      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
-      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "titulo": "El círculo sin huecos",
+      "alt": "Un grupo de personas envueltas en mantos anaranjados forma un círculo alrededor de una fogata en una playa de noche, con árboles en silueta a ambos lados, el mar al fondo y una luna creciente en el cielo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9069,7 +9069,7 @@
       "serie": "archivo",
       "orden": 294,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El fuego les llega más alto que la cintura y ninguno retrocede un paso, mientras la luna en cuarto menguante se queda justo encima como si vigilara el tamaño de las brasas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9083,8 +9083,8 @@
         "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
         "variante": 2
       },
-      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
-      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "titulo": "El fuego a la cintura",
+      "alt": "Un grupo de personas envueltas en mantos anaranjados alrededor de una fogata grande y brillante en una playa de noche, con el mar, colinas oscuras y una luna creciente en el cielo al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9100,7 +9100,7 @@
       "serie": "archivo",
       "orden": 295,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Siete cuerpos envueltos en blanco giran alrededor de la hoguera, y la luna llevaba tres noches acercándose tanto que el humo ya le toca el filo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9114,8 +9114,8 @@
         "generacion": "585c508a-d835-4699-82e5-8ef6d6ab4357",
         "variante": 3
       },
-      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
-      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "titulo": "Ronda de fuego y luna",
+      "alt": "Un grupo de personas con túnicas claras baila en círculo alrededor de una hoguera en una zona rocosa junto al mar, de noche, bajo una luna creciente y un cielo azul oscuro con estrellas, con montañas al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9131,7 +9131,7 @@
       "serie": "archivo",
       "orden": 296,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El fuego les llega a la cintura y ningún pie descalzo se quema, porque esa arena aprendió hace generaciones a enfriarse justo antes de que la pisen.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9145,8 +9145,8 @@
         "generacion": "fdc77c5a-4f15-40a6-837c-a31ae9a72be9",
         "variante": 2
       },
-      "titulo": "FHZLEW3f0w 35mm cinematic prehispanic scene a c",
-      "alt": "fHZLEW3f0w 35mm cinematic prehispanic scene a c",
+      "titulo": "Sombras encendidas en la orilla",
+      "alt": "Un grupo de personas con túnicas claras baila alrededor de una fogata en una franja de tierra junto al mar, de noche, con una luna creciente en el cielo azul oscuro y colinas oscuras alrededor.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9162,7 +9162,7 @@
       "serie": "archivo",
       "orden": 297,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las antenas de la estación cuelgan sobre el desierto rosado y proyectan una sombra tan larga que a esa hora ya oscurece el valle siguiente.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9176,8 +9176,8 @@
         "generacion": "02ec42f2-15de-408f-bb9a-2d975935236f",
         "variante": 2
       },
-      "titulo": "First class spacefreighter docked to",
-      "alt": "first class spacefreighter docked to",
+      "titulo": "Torres suspendidas sobre el desierto",
+      "alt": "Una estación o nave espacial de estructura oscura con torres verticales flota sobre la superficie rojiza de un planeta desértico, bajo un cielo con degradado verde azulado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9193,7 +9193,7 @@
       "serie": "archivo",
       "orden": 298,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El remo levanta gotas que tardan tanto en caer que el segundo pescador ya cambió de lado antes de que toquen el agua otra vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9207,8 +9207,8 @@
         "generacion": "0422a9d1-95bc-4430-a0a2-d80c14ea3de4",
         "variante": 1
       },
-      "titulo": "Fishermen in a fishing boat at the distance",
-      "alt": "Fishermen in a fishing boat at the distance slice of life in",
+      "titulo": "La canoa corta el brillo",
+      "alt": "Dos hombres en una canoa de madera, siluetas oscuras sobre un mar que refleja el sol en miles de destellos, con montañas lejanas en el horizonte bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9224,7 +9224,7 @@
       "serie": "archivo",
       "orden": 299,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuenta los surcos de la espiral tallada en la tierra y son tantos que ha perdido la cuenta siete veces sin moverse un paso del borde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9238,8 +9238,8 @@
         "generacion": "12cc7e4a-43b3-4be7-8d9b-ab7439497a96",
         "variante": 0
       },
-      "titulo": "Frank whittier on his egyptian expedition 1910 1912",
-      "alt": "frank whittier on his egyptian expedition 1910 1912 ca 1940 i",
+      "titulo": "Frente a la espiral",
+      "alt": "Un hombre con abrigo largo está de pie ante una gran espiral de surcos tallados en la tierra árida, con acantilados y una meseta al fondo, en una fotografía en tono sepia.",
       "w": 1232,
       "h": 976,
       "anchos": [
@@ -9255,7 +9255,7 @@
       "serie": "archivo",
       "orden": 300,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta el machete tan alto que la nube se abre justo encima de la mano, y el caballo blanco no baja el paso aunque arrastre otro caballo vacío detrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9269,8 +9269,8 @@
         "generacion": "1a12a89c-2061-43a6-b4c4-a7e3de605ea0",
         "variante": 1
       },
-      "titulo": "Front shot Scene of venezuelan count",
-      "alt": "Front shot Scene of venezuelan count",
+      "titulo": "El grito alzado al galope",
+      "alt": "Un jinete con camisa roja y sombrero de paja galopa sobre un caballo blanco levantando un machete, con un segundo caballo detrás, entre vegetación tropical y un cielo con nubes oscuras.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9286,7 +9286,7 @@
       "serie": "archivo",
       "orden": 301,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene la lanza tan derecha que parte el cielo en dos mitades exactas, mientras el caballo oscuro devora la sabana sin pisar dos veces la misma brizna.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9300,8 +9300,8 @@
         "generacion": "4f326c24-2518-4cad-8ee1-1f5e858b5570",
         "variante": 1
       },
-      "titulo": "Front shot Scene of venezuelan count",
-      "alt": "Front shot Scene of venezuelan count",
+      "titulo": "La lanza contra el cielo",
+      "alt": "Un jinete vestido de blanco y sombrero de ala ancha cabalga sobre un caballo oscuro sosteniendo una lanza larga, atravesando una pradera con montañas al fondo bajo un cielo azul claro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9317,7 +9317,7 @@
       "serie": "archivo",
       "orden": 302,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pañuelo rojo del que va al frente ondea tanto que el polvo detrás alcanza a cubrir a los seis jinetes que lo siguen sin perderle el paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9331,8 +9331,8 @@
         "generacion": "667b37a5-e4aa-40fb-a5df-2778acf8f16e",
         "variante": 2
       },
-      "titulo": "Front shot Scene of venezuelan country folk horseman",
-      "alt": "front shot Scene of venezuelan country folk horseman charging",
+      "titulo": "La tropa entre el polvo",
+      "alt": "Un grupo de jinetes con sombreros galopa entre una nube de polvo; el que va al frente lleva un pañuelo rojo al cuello y sostiene una cuerda, con árboles borrosos al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9348,7 +9348,7 @@
       "serie": "archivo",
       "orden": 303,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la faja naranja cruzada al pecho y el fusil en alto, y los soldados que vienen detrás no logran alcanzar la nube de polvo que levanta su caballo blanco.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9362,8 +9362,8 @@
         "generacion": "8734ce23-3746-41c8-b3f1-c54cb7d2c06a",
         "variante": 3
       },
-      "titulo": "Front shot Scene of venezuelan country folk horseman",
-      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "titulo": "La faja naranja al frente",
+      "alt": "Un jinete con sombrero y faja naranja cruzada al pecho lidera a caballo blanco una carga de soldados armados con fusiles, levantando polvo bajo un cielo azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9379,7 +9379,7 @@
       "serie": "archivo",
       "orden": 304,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El penacho rojo de la lanza se mece tanto con el galope que ya rozó dos veces las palmas antes de llegar a la cerca de madera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9393,8 +9393,8 @@
         "generacion": "e460132f-3aff-4744-8faf-0de4b9eb51fa",
         "variante": 1
       },
-      "titulo": "Front shot Scene of venezuelan country folk horseman",
-      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "titulo": "La lanza con penacho rojo",
+      "alt": "Un jinete con camisa roja y sombrero de paja cabalga sobre un caballo marrón sosteniendo una lanza con un penacho rojo, cerca de palmeras y una cerca de madera.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9410,7 +9410,7 @@
       "serie": "archivo",
       "orden": 305,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Alza el sable tan derecho que el sol se detiene un segundo en el filo, antes de que caigan detrás los jinetes de casaca roja que lo siguen.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9424,8 +9424,8 @@
         "generacion": "fb9cd5fb-197c-4f4d-8afe-a6b86531a03c",
         "variante": 2
       },
-      "titulo": "Front shot Scene of venezuelan country folk horseman",
-      "alt": "front shot Scene of venezuelan country folk horseman charging",
+      "titulo": "El sable en la carga",
+      "alt": "Un jinete con uniforme militar rojo y dorado carga a caballo con un sable en alto, seguido por otros jinetes con casacas rojas, sobre un campo abierto en tonos ocres.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9441,7 +9441,7 @@
       "serie": "archivo",
       "orden": 306,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La punta de la lanza va tan adelantada que llega a la loma tres pasos antes que el caballo blanco que la sostiene.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9455,8 +9455,8 @@
         "generacion": "ffdda037-43d4-4abb-9de9-f640a4ce6d8a",
         "variante": 1
       },
-      "titulo": "Front shot Scene of venezuelan country folk horseman",
-      "alt": "Front shot Scene of venezuelan country folk horseman charging",
+      "titulo": "La punta que abre camino",
+      "alt": "Un jinete con sombrero blanco carga a caballo sosteniendo una lanza apuntando hacia adelante, seguido por otros jinetes, bajo un cielo azul despejado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -9472,7 +9472,7 @@
       "serie": "archivo",
       "orden": 307,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre la camioneta blanca se amontonan tantos cambures que ya no se ve el capó, y el hombre apoya las manos en la cintura como si acabara de bajar la montaña él mismo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9486,8 +9486,8 @@
         "generacion": "1c787ec6-1db3-4610-b8d9-f33a1b655e7a",
         "variante": 3
       },
-      "titulo": "Full body front shot portrait of a middle",
-      "alt": "full body front shot portrait of a middle aged person who wor",
+      "titulo": "La montaña de cambures",
+      "alt": "Un hombre con overol blanco está de pie junto a una camioneta blanca cubierta por un enorme montón de cambures amarillos, en una carretera con árboles al fondo.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9502,7 +9502,7 @@
       "serie": "archivo",
       "orden": 308,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El humo del cigarrillo sube tan recto en la noche sin viento que parece otra columna del carro negro contra el que se apoya.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9516,8 +9516,8 @@
         "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
         "variante": 0
       },
-      "titulo": "Full body front shot portrait of a middle",
-      "alt": "full body front shot portrait of a middle aged person who wor",
+      "titulo": "Rojo apoyado contra la noche",
+      "alt": "Un hombre con mono de trabajo rojo y lentes de sol fuma un cigarrillo apoyado contra un carro oscuro de noche, con flores anaranjadas y vegetación detrás.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9532,7 +9532,7 @@
       "serie": "archivo",
       "orden": 309,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la insignia dorada prendida al pecho y una nube tan blanca detrás que parece haberse detenido solo para hacerle de fondo mientras termina el cigarrillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9546,8 +9546,8 @@
         "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
         "variante": 2
       },
-      "titulo": "Full body front shot portrait of a middle",
-      "alt": "full body front shot portrait of a middle aged person who wor",
+      "titulo": "La insignia bajo la nube",
+      "alt": "Un hombre con suéter y chaqueta rojos, con una insignia dorada en el pecho, fuma frente a un carro azul de noche, bajo un cielo estrellado con una gran nube y casas humildes al fondo.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9562,7 +9562,7 @@
       "serie": "archivo",
       "orden": 310,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruza los brazos con tanta firmeza que la hebilla dorada del cinturón no se mueve ni cuando el cartel a medio leer parpadea detrás en verde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9576,8 +9576,8 @@
         "generacion": "fb1941ba-2a5a-4366-b447-89fadb0e4668",
         "variante": 3
       },
-      "titulo": "Full body front shot portrait of a middle",
-      "alt": "full body front shot portrait of a middle aged person who wor",
+      "titulo": "Los brazos cruzados en verde",
+      "alt": "Un hombre con la cabeza rapada, brazos cruzados y ropa oscura con un cinturón dorado está de pie frente a un carro oscuro de noche, bajo una luz de tono verdoso, con un letrero parcial al fondo.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9592,7 +9592,7 @@
       "serie": "archivo",
       "orden": 311,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Alza tanto la barbilla que el degradado del fondo parece partirse justo en la línea de los lentes, mitad rojo y mitad amarillo sin que se note la costura.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9606,8 +9606,8 @@
         "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
         "variante": 1
       },
-      "titulo": "Full body photography of African teenager with short",
-      "alt": "full body photography of African teenager with short blonde h",
+      "titulo": "El mentón alzado en fuego",
+      "alt": "Una persona con cabello corto y puntas rubias, gafas de sol de montura fina y camiseta oscura, mira hacia arriba frente a un fondo con degradado de rojo a amarillo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9623,7 +9623,7 @@
       "serie": "archivo",
       "orden": 312,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Contra el fondo que se derrite de rojo en amarillo, la cadena dorada apenas tiembla sobre el perfil quieto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9637,8 +9637,8 @@
         "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
         "variante": 2
       },
-      "titulo": "Full body photography of African teenager with short",
-      "alt": "full body photography of African teenager with short blonde h",
+      "titulo": "El perfil contra el degradado",
+      "alt": "Una persona de perfil con cabello corto, gafas de sol y una cadena dorada al cuello, frente a un fondo con degradado de rojo a amarillo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9654,7 +9654,7 @@
       "serie": "archivo",
       "orden": 313,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La camisa se le resbala del hombro mientras mira hacia arriba, y el rojo del fondo es tan intenso que le tiñe hasta el blanco de los ojos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9668,8 +9668,8 @@
         "generacion": "7ed24ffd-25ed-4c98-ba1f-58a3106a9ff5",
         "variante": 3
       },
-      "titulo": "Full body photography of African teenager with short",
-      "alt": "full body photography of African teenager with short blonde h",
+      "titulo": "La mirada que sube",
+      "alt": "Una persona con camiseta oscura caída de un hombro y una cadena dorada mira hacia arriba frente a un fondo rojo intenso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9685,7 +9685,7 @@
       "serie": "archivo",
       "orden": 314,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El guacamayo rojo le clava las garras en el hombro con tanta calma que hace veinte años que no lo suelta, ni cuando cambia la marea detrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9699,8 +9699,8 @@
         "generacion": "0dd88675-5599-4da9-a0ee-5c5aa2f5c1c6",
         "variante": 3
       },
-      "titulo": "Full body picture of a man with a",
-      "alt": "full body picture of a man with a red and black detailed moor",
+      "titulo": "Garras rojas en el hombro",
+      "alt": "Un hombre de cabello largo y oscuro, con el rostro curtido, lleva un guacamayo rojo posado en el hombro, frente al mar, con una tonalidad general verdosa en la imagen.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9716,7 +9716,7 @@
       "serie": "archivo",
       "orden": 315,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las plumas de la cola del guacamayo alcanzan a rozarle la espalda mientras el cielo detrás quema tan lento que lleva media hora sin terminar de amanecer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9730,8 +9730,8 @@
         "generacion": "c00da319-aa1f-468a-8434-7ee9b325547f",
         "variante": 1
       },
-      "titulo": "Full body picture of a man with a",
-      "alt": "full body picture of a man with a red and black detailed moor",
+      "titulo": "El guacamayo del amanecer",
+      "alt": "Un hombre de cabello oscuro y largo lleva un guacamayo rojo en el hombro frente al mar, bajo un cielo de tonos anaranjados y morados al amanecer o atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9747,7 +9747,7 @@
       "serie": "archivo",
       "orden": 316,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Frente al mar azul y liso, el rojo del guacamayo es la única mancha que se mueve en toda la costa esa mañana.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9761,8 +9761,8 @@
         "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d",
         "variante": 0
       },
-      "titulo": "Full body picture of a man with a",
-      "alt": "full body picture of a man with a red and black detailed moor",
+      "titulo": "Plumas rojas contra el azul",
+      "alt": "Un hombre de cabello oscuro y largo lleva un guacamayo rojo en el hombro, con el mar azul y despejado de fondo bajo luz de día.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9778,7 +9778,7 @@
       "serie": "archivo",
       "orden": 317,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz dorada del final de la tarde se le queda pegada en el pelo tanto como el guacamayo se le queda pegado en el hombro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9792,8 +9792,8 @@
         "generacion": "f8a97c19-b323-4356-a71c-7793474ebf5d",
         "variante": 3
       },
-      "titulo": "Full body picture of a man with a",
-      "alt": "full body picture of a man with a red and black detailed moor",
+      "titulo": "El dorado del último sol",
+      "alt": "Un hombre de cabello oscuro y largo lleva un guacamayo rojo en el hombro, frente al mar, bajo un cielo dorado de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9809,7 +9809,7 @@
       "serie": "archivo",
       "orden": 318,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En la niebla azul del bosque, la pluma roja del tocado no se mueve pese al viento, como si la noche llevara horas conteniendo el aire.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9823,8 +9823,8 @@
         "generacion": "e953e0cf-9f95-445f-b330-5fb79a4cf046",
         "variante": 2
       },
-      "titulo": "Full body picture of Buchibe the last Manaure",
-      "alt": "Full body picture of Buchibe the last Manaure of the Caquetio",
+      "titulo": "El manto dorado en niebla",
+      "alt": "Un hombre con manto dorado, falda roja y un tocado de plumas sostiene una lanza de pie frente a un bosque envuelto en niebla azulada, de noche.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -9839,7 +9839,7 @@
       "serie": "archivo",
       "orden": 319,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz roja le cae tan directa en la cota de malla que cada anillo brilla por separado, mientras sostiene la pica firme contra el marco de piedra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9853,8 +9853,8 @@
         "generacion": "0d6148cc-c146-4742-9895-596c8190a0df",
         "variante": 2
       },
-      "titulo": "Full body portrait of a young soilder conquistador",
-      "alt": "full body portrait of a young soilder conquistador from the X",
+      "titulo": "El yelmo en el umbral",
+      "alt": "Un joven con casco y cota de malla sostiene una pica de pie en un vano de piedra, bajo una luz roja intensa, mirando hacia la cámara.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9870,7 +9870,7 @@
       "serie": "archivo",
       "orden": 320,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Pulsa la última cuerda del shamisen con el bachi dorado y el azul del cielo se detiene una hora entera, prendido a las flores de cerezo que crecen junto a sus rodillas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9884,8 +9884,8 @@
         "generacion": "0fb0dd46-4493-40b4-a06d-dba6da08ddee",
         "variante": 1
       },
-      "titulo": "Full shot of Japanese Geisha wearing",
-      "alt": "Full shot of Japanese Geisha wearing",
+      "titulo": "Shamisen al filo del crepúsculo",
+      "alt": "Mujer con kimono morado, verde y dorado y tocado ornamentado en el cabello, arrodillada al aire libre tocando un shamisen (instrumento de cuerdas japonés) con un plectro, bajo luz azul de atardecer y ramas de flores blancas al lado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9901,7 +9901,7 @@
       "serie": "archivo",
       "orden": 321,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las flores bordadas en la manga se abren al mismo ritmo que el cielo cambia del añil al violeta, y para cuando termina el último acorde ya lucen el color exacto del ocaso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9915,8 +9915,8 @@
         "generacion": "64aa9b47-f395-4257-9946-40722bbdf1ca",
         "variante": 0
       },
-      "titulo": "Full shot of Japanese Geisha wearing a colorful",
-      "alt": "Full shot of Japanese Geisha wearing a colorful kimono and an",
+      "titulo": "Seda violeta y última nota",
+      "alt": "Mujer con kimono azul y dorado con bordados florales, tocado ornamentado en el cabello con adornos colgantes, arrodillada tocando un shamisen contra un cielo morado de atardecer, con una silueta de colinas al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9932,7 +9932,7 @@
       "serie": "archivo",
       "orden": 322,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los hilos dorados del kimono brillan tanto contra la noche que las montañas del fondo se apagan una a una, como si le cedieran su luz a cada puntada del bordado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9946,8 +9946,8 @@
         "generacion": "f3a8fe57-1cee-4baa-b59c-7afad4aaf1f7",
         "variante": 3
       },
-      "titulo": "Full shot of Japanese Geisha wearing",
-      "alt": "Full shot of Japanese Geisha wearing",
+      "titulo": "Hilos dorados contra la noche",
+      "alt": "Mujer con kimono azul y dorado con bordados, tocado ornamentado en el cabello, arrodillada tocando un shamisen contra un cielo azul oscuro de noche, con montañas en silueta al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -9963,7 +9963,7 @@
       "serie": "archivo",
       "orden": 323,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los botones dorados de su casaca llevan sumergidos tanto tiempo en la tormenta que ya conocen cada ola por su nombre, y ninguna ha logrado opacarles el brillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -9977,8 +9977,8 @@
         "generacion": "89e0a919-ff8d-491d-9514-6fcfc6965399",
         "variante": 3
       },
-      "titulo": "Full view o",
-      "alt": "Full view o",
+      "titulo": "Charreteras bajo la tormenta",
+      "alt": "Hombre de cabello canoso vestido con chaqueta militar oscura con botones y detalles dorados, sumergido hasta el pecho en un mar tormentoso de noche, mirando hacia un lado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -9994,7 +9994,7 @@
       "serie": "archivo",
       "orden": 324,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene la capa verde doblada sobre el brazo con tanta firmeza que ni el volcán humeante detrás ni el oleaje logran moverle un solo pliegue de la tela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10008,8 +10008,8 @@
         "generacion": "ea321999-4104-4377-b78a-1427889c0f70",
         "variante": 1
       },
-      "titulo": "Full view of cinematographic scene o",
-      "alt": "Full view of cinematographic scene o",
+      "titulo": "Capa verde frente al volcán",
+      "alt": "Hombre con uniforme militar oscuro con charreteras y bordados dorados, capa verde sobre el brazo, de pie frente a un mar agitado y una montaña con humo al fondo, de noche.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10025,7 +10025,7 @@
       "serie": "archivo",
       "orden": 325,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nave cruza el mismo tramo de desierto ocre desde hace tres lunas y todavía no llega a las torres de la ciudad que se ve enmarcada en la escotilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10039,8 +10039,8 @@
         "generacion": "774ab977-24d3-454c-8f99-756f6c76e625",
         "variante": 0
       },
-      "titulo": "Futuristic City inside a Dome in Pla",
-      "alt": "Futuristic City inside a Dome in Pla",
+      "titulo": "Ciudad vista por la escotilla",
+      "alt": "Vista a través de una ventana ovalada de una nave hacia un paisaje desértico anaranjado con una ciudad de torres y cúpulas, una nave voladora y una luna en el cielo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10056,7 +10056,7 @@
       "serie": "archivo",
       "orden": 326,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cúpula negra se traga el cielo rojo del atardecer y proyecta las sombras de sus torres tan lejos que llegan hasta las naves que apenas despegan del suelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10070,8 +10070,8 @@
         "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d",
         "variante": 0
       },
-      "titulo": "Futuristic City inside a Dome in Planet Mars",
-      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "titulo": "La cúpula devora el ocaso",
+      "alt": "Silueta oscura de una ciudad futurista bajo una gran cúpula, con torres iluminadas y naves espaciales en el suelo, contra un cielo rojo de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10087,7 +10087,7 @@
       "serie": "archivo",
       "orden": 327,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra de la torre en primer plano se estira tanto que cruza toda la explanada y llega a tocar el borde curvo de la cúpula iluminada al fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10101,8 +10101,8 @@
         "generacion": "03b89f48-915c-4337-906e-5c5f2380b00d",
         "variante": 2
       },
-      "titulo": "Futuristic City inside a Dome in Planet Mars",
-      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "titulo": "Torre y cúpula en sombra",
+      "alt": "Silueta de una torre en primer plano frente a una ciudad futurista bajo una gran cúpula iluminada, con naves espaciales estacionadas en el suelo, de noche.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10118,7 +10118,7 @@
       "serie": "archivo",
       "orden": 328,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol de la tarde se enreda en los paneles curvos de la cúpula y tarda tanto en soltarse que la nave alcanza a cruzar toda la ciudad antes de que se apague el reflejo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10132,8 +10132,8 @@
         "generacion": "890dd33d-ee3f-4546-9278-01457a9c074e",
         "variante": 2
       },
-      "titulo": "Futuristic City inside a Dome in Planet Mars",
-      "alt": "Futuristic City inside a Dome in Planet Mars a ship is landin",
+      "titulo": "Sol enredado en la cúpula",
+      "alt": "Ciudad futurista bajo una gran cúpula sobre un paisaje desértico anaranjado, con una nave espacial volando cerca y torres alrededor, bajo luz cálida de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10149,7 +10149,7 @@
       "serie": "archivo",
       "orden": 329,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los anillos de luz derriten la nieve en círculos perfectos a su alrededor, y el hielo solo empieza otra vez justo donde termina el último aro de la estructura.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10163,8 +10163,8 @@
         "generacion": "6b4f4d63-b97e-4a55-8ef0-02fbd08d712b",
         "variante": 1
       },
-      "titulo": "Futuristic Retro of an orbital spacestation in Saturns",
-      "alt": "Futuristic Retro of an orbital spacestation in Saturns ring c",
+      "titulo": "Anillo de luz sobre nieve",
+      "alt": "Vista aérea nocturna de una estructura circular con varios anillos concéntricos iluminados en tonos verdes y dorados, con nieve alrededor y una torre en el centro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -10180,7 +10180,7 @@
       "serie": "archivo",
       "orden": 330,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada centímetro de la superficie del planeta esconde otra torre, otro cable, otro circuito, tantos que ni las lunas que lo rodean alcanzan a contarlos todos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10194,8 +10194,8 @@
         "generacion": "12c48e17-2e12-40a2-922f-470a165172f3",
         "variante": 0
       },
-      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
-      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "titulo": "El planeta hecho de circuitos",
+      "alt": "Cartel ilustrado de un planeta cubierto de estructuras mecánicas y torres, rodeado de anillos y varias lunas en el espacio, con texto estilizado en la parte inferior.",
       "w": 1024,
       "h": 1536,
       "anchos": [
@@ -10211,7 +10211,7 @@
       "serie": "archivo",
       "orden": 331,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El fuego anaranjado de la base lleva ardiendo tanto tiempo que ya forma caminos propios en la arena, sin subir jamás hasta las esferas que flotan sobre los tallos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10225,8 +10225,8 @@
         "generacion": "2bf81f57-ea8c-4162-95b4-e1dc4996b571",
         "variante": 2
       },
-      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
-      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "titulo": "Esferas sobre desierto en llamas",
+      "alt": "Ilustración retro de estructuras esféricas futuristas sobre tallos altos en un paisaje desértico nocturno, con luces anaranjadas en la base y estrellas y lunas en el cielo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10242,7 +10242,7 @@
       "serie": "archivo",
       "orden": 332,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nave esférica lleva grabado en su casco más dibujos que estrellas hay alrededor, y ni Saturno con todos sus anillos logra competirle en adornos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10256,8 +10256,8 @@
         "generacion": "fb9fe24c-9a62-47c9-bdb3-cb50597302f6",
         "variante": 0
       },
-      "titulo": "Futuristic Retro poster of orbital spacestation codename LIFE",
-      "alt": "Futuristic Retro poster of orbital spacestation codename LIFE",
+      "titulo": "Nave esfera y sus planetas",
+      "alt": "Cartel ilustrado enmarcado de una nave espacial esférica con patrones mecánicos detallados, rodeada de planetas y un planeta con anillos, con texto estilizado en la parte inferior.",
       "w": 1024,
       "h": 1536,
       "anchos": [
@@ -10273,7 +10273,7 @@
       "serie": "archivo",
       "orden": 333,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta a contar las luces de las ciudades que pasan bajo la nave y para cuando termina de nombrar la primera ya se encendieron mil más.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10287,8 +10287,8 @@
         "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a",
         "variante": 0
       },
-      "titulo": "Gazing at Earth through a large circ",
-      "alt": "gazing at Earth through a large circ",
+      "titulo": "Silla frente al planeta encendido",
+      "alt": "Persona sentada en una silla mirando por una ventana ovalada grande hacia la Tierra vista desde el espacio, de noche, con luces de ciudades visibles, en el interior curvo de una nave con detalles dorados.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -10304,7 +10304,7 @@
       "serie": "archivo",
       "orden": 334,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los pinos plantados junto a la escalera se inclinan un poco más cada año hacia la abertura, como si quisieran alcanzar las luces de la Tierra que se ven al fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10318,8 +10318,8 @@
         "generacion": "dcd48366-1b59-4989-ad2c-ff24b0ea027a",
         "variante": 2
       },
-      "titulo": "Gazing at Earth through a large circ",
-      "alt": "gazing at Earth through a large circ",
+      "titulo": "Túnel que mira la Tierra",
+      "alt": "Vista a través de una gran abertura circular de piedra hacia la Tierra iluminada de noche, con una escalera curva y árboles de pino cerca de la abertura.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -10335,7 +10335,7 @@
       "serie": "archivo",
       "orden": 335,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Su capa roja es el único color que se sostiene en kilómetros de arena gris, y ni la luna gigante que asoma tras las rocas logra competirle el brillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10349,8 +10349,8 @@
         "generacion": "a39b6706-a920-4f8d-b842-2829cfaf632e",
         "variante": 0
       },
-      "titulo": "Gazing at Earth through a large circular window",
-      "alt": "gazing at Earth through a large circular window in his spaces",
+      "titulo": "Capa roja frente al desierto",
+      "alt": "Persona de cabello canoso con capa roja, de pie mirando por una ventana circular hacia un paisaje desértico con rocas y una gran luna o planeta en el cielo, desde el interior de una nave.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -10366,7 +10366,7 @@
       "serie": "archivo",
       "orden": 336,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La chaqueta rosa lleva más corazones rojos estampados que botones tiene el autobús entero, y el pelaje blanco del cuello se le eriza con cada frenada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10380,8 +10380,8 @@
         "generacion": "207dcfd5-fcd1-498f-b209-848c1339e7b9",
         "variante": 0
       },
-      "titulo": "Grainy overexposed photo of Scene of argentinian public",
-      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "titulo": "Chaqueta rosa de corazones",
+      "alt": "Hombre con peinado mullet y gafas de sol, con chaqueta rosa de peluche blanco y estampado de corazones rojos, sentado en un autobús junto a otros pasajeros.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10397,7 +10397,7 @@
       "serie": "archivo",
       "orden": 337,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La camisa de lentejuelas azules refleja cada tubo de luz del techo del autobús, así que camina sentado bajo un cielo entero de estrellas fluorescentes.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10411,8 +10411,8 @@
         "generacion": "69961938-b634-4146-8e6d-527107b7790a",
         "variante": 2
       },
-      "titulo": "Grainy overexposed photo of Scene of argentinian public",
-      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "titulo": "Camisa que multiplica la luz",
+      "alt": "Hombre de cabello oscuro y rizado con gafas de sol de aviador y camisa azul metálica con lentejuelas, sentado en un autobús con asientos de tela morada estampada.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10428,7 +10428,7 @@
       "serie": "archivo",
       "orden": 338,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los rizos rubios le ocupan tanto espacio que el pasajero de al lado ya perdió medio asiento, y los lunares negros del abrigo blanco parecen contarlos uno por uno.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10442,8 +10442,8 @@
         "generacion": "cf464c66-b90b-4a4e-82b6-48845cf6aa7c",
         "variante": 0
       },
-      "titulo": "Grainy overexposed photo of Scene of argentinian public",
-      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "titulo": "Pelo que llena el vagón",
+      "alt": "Hombre con cabello rubio rizado muy voluminoso y gafas de sol, con abrigo de peluche blanco con lunares negros, rodeado de otros pasajeros con gafas de sol en un autobús.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10459,7 +10459,7 @@
       "serie": "archivo",
       "orden": 339,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El abrigo morado combina tanto con los asientos rosados del autobús que si cerrara los ojos un segundo más se confundiría entero con la tapicería.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10473,8 +10473,8 @@
         "generacion": "dd26f839-469b-4587-b9a6-07d47cf95089",
         "variante": 0
       },
-      "titulo": "Grainy overexposed photo of Scene of argentinian public",
-      "alt": "Grainy overexposed photo of Scene of argentinian public trans",
+      "titulo": "Abrigo morado y asiento rosado",
+      "alt": "Hombre mayor de cabello oscuro despeinado y gafas de sol, con abrigo de peluche morado, sentado en un autobús con asientos rosados, con expresión seria.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10490,7 +10490,7 @@
       "serie": "archivo",
       "orden": 340,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tensa el arco bajo el agua con tanta calma que la flecha ya sabe dónde va a clavarse antes de que la cuerda termine de soltarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10504,8 +10504,8 @@
         "generacion": "242cacc4-12f6-49b4-bdcf-c410dbf6059f",
         "variante": 2
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "Arco que tensa el fondo",
+      "alt": "Ilustración de varias personas con el cuerpo pintado de color rojo anaranjado nadando bajo el agua, una de ellas tensando un arco, en un entorno rocoso de tonos verdes y azules.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -10521,7 +10521,7 @@
       "serie": "archivo",
       "orden": 341,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las puntas amarillas de las lanzas flotan tan quietas junto a los cuerpos que la corriente lleva media hora sin decidirse a moverlas un centímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10535,8 +10535,8 @@
         "generacion": "31b29143-b4c5-41ef-91a1-91b515f2fcc7",
         "variante": 0
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "Lanzas amarillas a la deriva",
+      "alt": "Ilustración de varias personas con el cuerpo pintado de rojo anaranjado flotando horizontalmente bajo el agua junto a lanzas con puntas amarillas, en un entorno submarino verde y azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10552,7 +10552,7 @@
       "serie": "archivo",
       "orden": 342,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arrecife de abajo lleva tantas formas talladas por el agua que ya parece guardar la cuenta exacta de cada cuerpo que ha flotado sobre él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10566,8 +10566,8 @@
         "generacion": "3a996db7-d942-459b-bbdf-810e80ac69a2",
         "variante": 2
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "Cuerpos que flotan sobre arrecife",
+      "alt": "Ilustración de varias personas con el cuerpo pintado de rojo anaranjado flotando horizontalmente bajo el agua sobre un arrecife de coral, rodeadas de plantas verdes, en tonos azules y verdes.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -10583,7 +10583,7 @@
       "serie": "archivo",
       "orden": 343,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las plumas que llevan en el cabello rozan la superficie del agua sin mojarse nunca del todo, aunque las olas alrededor no dejen de moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10597,8 +10597,8 @@
         "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47",
         "variante": 2
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "Plumas que rozan la superficie",
+      "alt": "Ilustración en primer plano de varios rostros con el cuerpo pintado de rojo anaranjado, plumas en el cabello y ojos cerrados, flotando en la superficie del agua junto a flechas, en tonos azules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10614,7 +10614,7 @@
       "serie": "archivo",
       "orden": 344,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levantan tantos brazos al mismo tiempo desde el fondo rocoso que parecen empujar el agua entera hacia arriba, mientras las lanzas quedan clavadas atrás como una valla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10628,8 +10628,8 @@
         "generacion": "4eb2ce92-72c1-45e3-a4b1-d71924c8ba47",
         "variante": 3
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "Brazos alzados desde el fondo",
+      "alt": "Ilustración de un grupo numeroso de personas con el cuerpo pintado de rojo anaranjado, con los brazos levantados, de pie sobre un terreno rocoso bajo el agua, con lanzas al fondo, en tonos verdes y azules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10645,7 +10645,7 @@
       "serie": "archivo",
       "orden": 345,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Siete cuerpos color brasa flotan bocarriba sin mover un dedo, y las flechas que cargan llevan tres mareas completas esperando el primer tirón de cuerda.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10659,8 +10659,8 @@
         "generacion": "a3c44b74-e425-42a8-a4b1-7503f28a843b",
         "variante": 1
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "El descanso de los arqueros",
+      "alt": "Siete figuras humanas de color naranja rojizo flotan boca arriba en aguas azul verdosas oscuras, algunas sujetando arcos y flechas, con un patrón de reflejos claros en la superficie del agua.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10676,7 +10676,7 @@
       "serie": "archivo",
       "orden": 346,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra en cruz abre los brazos y las piernas hasta tocar los cuatro bordes del encuadre, y tarda seis mareas en llegar al fondo verde aunque nadie la empuje.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10690,8 +10690,8 @@
         "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3",
         "variante": 0
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "El nadador en cruz",
+      "alt": "Tres figuras humanas flotan en agua verde azulada; en primer plano una silueta oscura con los brazos y las piernas extendidos en forma de cruz, y dos figuras más pequeñas al fondo en la parte superior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10707,7 +10707,7 @@
       "serie": "archivo",
       "orden": 347,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuatro lanzas se alzan derechas justo sobre la línea de arena, y los cuerpos color naranja caen tres brazadas más abajo antes de tocar el mosaico azul del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10721,8 +10721,8 @@
         "generacion": "aa613638-c221-45ed-8be1-61f5a3f6c5b3",
         "variante": 1
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "El umbral de arena",
+      "alt": "Cuatro figuras de pie sostienen lanzas largas junto a una franja de arena en la parte superior de la imagen, y tres cuerpos de color naranja flotan bajo el agua azul con un patrón de baldosas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10738,7 +10738,7 @@
       "serie": "archivo",
       "orden": 348,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arco y las flechas trazan una equis exacta sobre el agua, y los seis cuerpos que la sostienen no la sueltan aunque lleven cuatro horas flotando en la misma corriente.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10752,8 +10752,8 @@
         "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
         "variante": 1
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "El arco cruzado",
+      "alt": "Seis figuras vestidas con faldas rojas flotan juntas en agua azul oscuro, sosteniendo un arco y flechas, con manchas de color verde en la esquina superior derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10769,7 +10769,7 @@
       "serie": "archivo",
       "orden": 349,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cuerpo cae de cabeza con las piernas apuntando al cielo, y tarda cinco brazadas en decidir si termina la vuelta o se queda a medio camino para siempre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10783,8 +10783,8 @@
         "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
         "variante": 2
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "El cuerpo boca abajo",
+      "alt": "Dos figuras de pie sostienen lanzas a la izquierda; en el centro una figura flota con las piernas hacia arriba y la cabeza hacia abajo, y otra yace sobre una superficie roja, sobre un fondo de agua a cuadros verdes y azules.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10800,7 +10800,7 @@
       "serie": "archivo",
       "orden": 350,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra oscura se pega al fondo rayado de verde y avanza un metro entero por cada cuerpo rojo que pasa flotando encima sin advertirla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10814,8 +10814,8 @@
         "generacion": "f048c9b8-1090-4287-8e1d-f7f7ed68e487",
         "variante": 3
       },
-      "titulo": "Grim shot arrows and bows floating underwater next",
-      "alt": "grim shot arrows and bows floating underwater next to submer",
+      "titulo": "La sombra del fondo rayado",
+      "alt": "Cuatro figuras rojas de pie sostienen lanzas en la parte superior; tres cuerpos rojos flotan boca arriba sobre un fondo de agua con rayas verdes, y una forma oscura alargada aparece en la esquina inferior derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10831,7 +10831,7 @@
       "serie": "archivo",
       "orden": 351,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Voltea la cabeza sin soltar el mando, y dentro del televisor la guerra sigue disparando sola durante los cuatro segundos exactos que dura la mirada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10845,8 +10845,8 @@
         "generacion": "bac3420e-780c-4af6-8e0e-5f963a703c05",
         "variante": 0
       },
-      "titulo": "Grungy analog photo of man playing Call of",
-      "alt": "Grungy analog photo of man playing Call of Duty on a Playstat",
+      "titulo": "El jugador que voltea",
+      "alt": "Joven sentado que gira la cabeza hacia la cámara mientras sostiene un mando de videojuego con cable, frente a un televisor antiguo que muestra una escena de combate, en una habitación oscura y desgastada.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10862,7 +10862,7 @@
       "serie": "archivo",
       "orden": 352,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los pilotes de las casas se clavan derechos en el fondo turquesa, y los tres hombres de short naranja cruzan por debajo sin que el agua les suba nunca más allá de la rodilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10876,8 +10876,8 @@
         "generacion": "8f551616-88a8-42ee-91bf-5b27fc8859ba",
         "variante": 1
       },
-      "titulo": "GZLV4DP1s Panoramic view of a city of stilt",
-      "alt": "GZLV4DP1s Panoramic view of a city of stilt ho",
+      "titulo": "Tres pasos bajo los pilotes",
+      "alt": "Vista desde bajo el agua de una hilera de casas de madera sobre pilotes con techo de paja, con tres hombres de short naranja caminando en aguas poco profundas de color turquesa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -10893,7 +10893,7 @@
       "serie": "archivo",
       "orden": 353,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El velo azul le cubre toda la cara salvo los ojos, y las vueltas de collar dorado que lleva puestas pesan más que la carga de los dos camellos que lo flanquean.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10907,8 +10907,8 @@
         "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c",
         "variante": 0
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El velo azul del rostro",
+      "alt": "Persona con el rostro cubierto por un velo azul, dejando solo los ojos visibles, con varios collares dorados en el pecho, entre dos camellos, uno de color arena y otro cubierto con tela blanca, bajo un cielo azul oscuro.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -10924,7 +10924,7 @@
       "serie": "archivo",
       "orden": 354,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos jinetes envueltos hasta los ojos cruzan la duna montados en camellos cargados de cadenas y borlas, y ninguno afloja las riendas aunque lleven media jornada sin ver un pozo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10938,8 +10938,8 @@
         "generacion": "5856b9f0-9b93-444b-a6d2-2a93462ad27c",
         "variante": 2
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "Dos jinetes de velo",
+      "alt": "Dos personas con el rostro cubierto por telas, una azul y otra blanca, montadas en camellos adornados con collares y borlas, sobre dunas de arena bajo un cielo despejado.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -10955,7 +10955,7 @@
       "serie": "archivo",
       "orden": 355,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada jinete sostiene sobre las piernas una caja de madera tallada con las cuerdas tensas, y los camellos se quedan clavados en la arena para no desafinar ni una nota.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -10969,8 +10969,8 @@
         "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
         "variante": 0
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "La caja de madera tallada",
+      "alt": "Dos personas con turbantes, una con velo azul y otra con velo blanco, montadas sobre camellos arrodillados en la arena, cada una sosteniendo una caja de madera tallada con cuerdas, bajo un cielo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -10986,7 +10986,7 @@
       "serie": "archivo",
       "orden": 356,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre los dos jinetes se asoma una tercera figura envuelta en blanco que sostiene en alto un bastón coronado de metal, y ningún camello vuelve la cabeza aunque la sombra le roce la oreja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11000,8 +11000,8 @@
         "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
         "variante": 2
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El farol entre los dos",
+      "alt": "Dos personas veladas montadas en camellos, una con tela azul y otra con tela blanca sosteniendo un bastón, con una tercera figura de pie detrás sosteniendo un objeto metálico en alto, bajo un cielo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11017,7 +11017,7 @@
       "serie": "archivo",
       "orden": 357,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre las cabezas cubiertas cuelga una luna del tamaño de una moneda, y el jinete de verde oscuro sostiene un bastón dorado tan derecho que parece sujetarla él solo desde abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11031,8 +11031,8 @@
         "generacion": "5cf798de-5b21-4ce9-af19-6be22513dd6e",
         "variante": 3
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El astro diminuto",
+      "alt": "Tres personas con el rostro cubierto por velos, una con manto verde oscuro sosteniendo un bastón dorado y dos con mantos blancos, montadas sobre camellos arrodillados en terreno rocoso y arenoso, con una pequeña luna en el cielo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11048,7 +11048,7 @@
       "serie": "archivo",
       "orden": 358,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El jinete del centro lleva tantas vueltas de oro al cuello que el camello acorta el paso, mientras los dos que lo escoltan de blanco brillan recién salidos del telar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11062,8 +11062,8 @@
         "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
         "variante": 0
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El manto azul central",
+      "alt": "Tres jinetes con el rostro cubierto por velos oscuros montan camellos en el desierto; el del centro viste un manto azul con collares dorados y los otros dos visten de blanco con reflejos dorados, al atardecer.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -11079,7 +11079,7 @@
       "serie": "archivo",
       "orden": 359,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El velo añil les ha teñido la piel del mismo azul después de tantos años de roce, y ya no se sabe si el color se lo puso la tela o el desierto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11093,8 +11093,8 @@
         "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
         "variante": 1
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "La piel teñida de añil",
+      "alt": "Dos personas con la piel de tono azulado, cubiertas con velos plateados bordados con joyas, junto a un camello, sobre un fondo azul oscuro.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -11110,7 +11110,7 @@
       "serie": "archivo",
       "orden": 360,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La caravana avanza en fila sobre el filo exacto de la duna, y las sombras que proyecta cada camello son tan largas que llegan al valle antes que ellos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11124,8 +11124,8 @@
         "generacion": "c9f684b5-b3db-415f-9f85-2c8578f08595",
         "variante": 3
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "La fila sobre la duna",
+      "alt": "Una caravana de personas montadas en camellos avanza en fila sobre la cresta de una gran duna de arena, proyectando largas sombras al atardecer.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -11141,7 +11141,7 @@
       "serie": "archivo",
       "orden": 361,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna llena cuelga exacta sobre las tres cabezas cubiertas, y el que viste de turquesa no suelta la guitarra ni cuando el camello se acomoda entero bajo su peso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11155,8 +11155,8 @@
         "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
         "variante": 0
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "La luna sobre los tres",
+      "alt": "Tres personas con el rostro cubierto por velos, vestidas de blanco, morado y turquesa, sentadas sobre camellos arrodillados en la arena, con una luna llena en el cielo nocturno y joyas doradas esparcidas en el suelo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11172,7 +11172,7 @@
       "serie": "archivo",
       "orden": 362,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El jinete del centro sostiene un jarro de metal labrado que parece gotear luz en vez de agua, y los otros dos no apartan la vista aunque lleven toda la noche mirándolo brillar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11186,8 +11186,8 @@
         "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
         "variante": 1
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El jarro de metal labrado",
+      "alt": "Tres personas con velos, dos con manto azul y una con manto blanco sosteniendo un jarro metálico decorado, montadas sobre camellos arrodillados en la arena, con joyas esparcidas en el suelo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11203,7 +11203,7 @@
       "serie": "archivo",
       "orden": 363,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El camello del centro carga tantas hileras de cuentas al cuello que el jinete apenas necesita sujetar la caja de madera tallada que lleva sobre las piernas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11217,8 +11217,8 @@
         "generacion": "dd8239fa-2a61-4a33-adbf-5ea631f629bc",
         "variante": 3
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El instrumento entre las joyas",
+      "alt": "Tres personas con velos vestidas de azul turquesa y blanco, montadas sobre camellos cargados de collares, con una caja de madera decorada sobre las piernas del jinete central, bajo un cielo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11234,7 +11234,7 @@
       "serie": "archivo",
       "orden": 364,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cielo se corta en un rectángulo exacto sobre las dunas, como si alguien lo hubiera pegado encima de la arena, y a los pies de los camellos queda tendido un laúd que nadie recoge.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11248,8 +11248,8 @@
         "generacion": "ef8cb3eb-0742-4c18-8221-d2fc605c234c",
         "variante": 1
       },
-      "titulo": "HgPO2mYYw httpss.mj.r",
-      "alt": "hgPO2mYYw httpss.mj.r",
+      "titulo": "El cielo recortado",
+      "alt": "Dos personas con velos montadas en camellos en el desierto, una con manto naranja y otra con manto blanco sosteniendo un instrumento de cuerdas, con un recorte rectangular de cielo azul sobre las dunas y varios objetos como alfombras, vasijas y un laúd dispuestos en la arena.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -11265,7 +11265,7 @@
       "serie": "archivo",
       "orden": 365,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El brazo derecho se pliega en placas de metal como una armadura de bisagras, y las botas de charol suben tan por encima de la rodilla que rozan el dobladillo de la camiseta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11279,8 +11279,8 @@
         "generacion": "1b8b6a94-1748-417f-b4cc-e38093b42d50",
         "variante": 0
       },
-      "titulo": "High heel over the knee boots with platform",
-      "alt": "high heel over the knee boots with platform and clear sole bl",
+      "titulo": "El brazo de placas metálicas",
+      "alt": "Persona con cabello corto teñido de naranja, gafas de sol y camiseta negra estampada, con un brazo protésico metálico articulado, tatuajes en las piernas y botas de plataforma de charol negro por encima de la rodilla, de pie en una acera.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -11295,7 +11295,7 @@
       "serie": "archivo",
       "orden": 366,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De pie detrás, las manos ajustan hebra por hebra un peinado que no existe todavía, frente a un valle entero cubierto por la misma neblina azul que los tiñe a los dos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11309,8 +11309,8 @@
         "generacion": "34f26cb7-d409-41f7-a724-a85b0049a128",
         "variante": 2
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "El peinado bajo la niebla",
+      "alt": "Una persona de pie con túnica azul oscura bordada en dorado y tocado ornamentado ajusta el cabello de otra persona sentada, de piel pálida azulada y cabeza rapada, frente a un paisaje montañoso brumoso de tono azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11326,7 +11326,7 @@
       "serie": "archivo",
       "orden": 367,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mano articulada del robot sostiene la barbilla del hombre como si calibrara cada arruga, y el rostro azul que lo mira no parpadea desde que se apagaron las luces de la ciudad de abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11340,8 +11340,8 @@
         "generacion": "56bdc61e-afd4-4e63-b721-3e8e5783979b",
         "variante": 1
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "La mano en la barbilla",
+      "alt": "Un robot humanoide blanco y azul con el rostro iluminado se inclina sobre un hombre recostado en una cama, tocándole la barbilla, con una ciudad iluminada y montañas visibles a través de una ventana durante la noche.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11357,7 +11357,7 @@
       "serie": "archivo",
       "orden": 368,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El anciano lo mira desde la camilla sin apartar los ojos del casco espejado, y en el reflejo del vidrio caben las montañas enteras que se ven por la ventana detrás de los dos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11371,8 +11371,8 @@
         "generacion": "5a953274-3daa-488c-a8d2-9939f1617730",
         "variante": 0
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "El casco que refleja",
+      "alt": "Un hombre anciano recostado en una camilla dentro de una cabina mira hacia un robot o astronauta con traje blanco y azul y casco con visor reflectante de pie junto a él, con montañas visibles a través de una ventana durante el día.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11388,7 +11388,7 @@
       "serie": "archivo",
       "orden": 369,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La corona de oro parece soldada al cráneo de metal desde hace siglos, y la mano se posa suave en la mejilla de la anciana sin que los ojos rojos dejen de mirar fijo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11402,8 +11402,8 @@
         "generacion": "64e69518-ef28-4371-a5f4-294e94e76a98",
         "variante": 1
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "La corona sobre el cráneo",
+      "alt": "Una figura robótica con calavera metálica, ojos rojos brillantes, corona dorada y manto rojo, apoya una mano sobre la mejilla de una mujer anciana con gorro y ropa blanca, frente a un fondo de ciudad nocturna iluminada.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11419,7 +11419,7 @@
       "serie": "archivo",
       "orden": 370,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ojo azul del cirujano parpadea una sola vez y cuenta, sin prisa, los ciento diez años que le quedan al hombre que tiene debajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11433,8 +11433,8 @@
         "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e",
         "variante": 0
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "El cirujano de ojo azul",
+      "alt": "Figura robótica con cráneo metálico y un ojo azul brillante, vestida con una bata azul, inclinada sobre un anciano de piel pálida acostado boca arriba en una cama, con las luces de una ciudad nocturna al fondo bajo un cielo oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11450,7 +11450,7 @@
       "serie": "archivo",
       "orden": 371,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le conectan un solo cable a la nuca y el robot blanco memoriza, en ese instante, cada nube que cubre la Tierra a través de la cúpula.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11464,8 +11464,8 @@
         "generacion": "725932c9-0ea2-41c3-9ffa-7a608a96947e",
         "variante": 1
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "El robot en la cúpula",
+      "alt": "Robot humanoide blanco dentro de un módulo espacial en forma de cúpula, con una mano humana conectándole un cable en la nuca, mientras se ven la Tierra y las nubes a través de las ventanas curvas y paneles de control alrededor.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11481,7 +11481,7 @@
       "serie": "archivo",
       "orden": 372,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya dos dedos azules y dorados en la sien del anciano, y basta ese roce para que las luces de la ciudad, abajo, se enciendan todas a la vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11495,8 +11495,8 @@
         "generacion": "7dbf7e10-4300-4d7e-9b0a-03db205f1ff4",
         "variante": 3
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a mind",
+      "titulo": "El toque de la androide",
+      "alt": "Figura robótica de piel azul con motas doradas que sostiene con una mano la cabeza de un anciano de piel pálida, con luces de una ciudad extendiéndose bajo un cielo morado al atardecer.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11512,7 +11512,7 @@
       "serie": "archivo",
       "orden": 373,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los cables le entran por la nuca de hueso y el copiloto de cráneo descubierto no aparta la vista del desierto que corre, quieto, bajo la cabina.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11526,8 +11526,8 @@
         "generacion": "923a241c-4601-4469-b526-73b4c8904d58",
         "variante": 1
       },
-      "titulo": "High tech operating room a cyborg doctor is",
-      "alt": "High tech operating room a cyborg doctor is inserting a heari",
+      "titulo": "El copiloto de cráneo dorado",
+      "alt": "Androide con cráneo metálico visible y armadura dorada y blanca sentado en la cabina de una nave, con un panel de controles iluminado y un desierto rocoso visible por la ventana, y una persona con túnica dorada en primer plano.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11543,7 +11543,7 @@
       "serie": "archivo",
       "orden": 374,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de ellos el muro entero se llena de columnas de números rojos, y ninguno de los dos gira la cabeza para leer los dígitos que ya lleva memorizados de nacimiento.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11557,8 +11557,8 @@
         "generacion": "b52724d8-5dbe-4cd5-af49-d93d04db360b",
         "variante": 3
       },
-      "titulo": "High tech Operating Room the doctor inserts a",
-      "alt": "High tech Operating Room the doctor inserts a hearing modific",
+      "titulo": "El muro de números rojos",
+      "alt": "Dos figuras de aspecto robótico con rostros pálidos, una vestida de blanco y otra con un vestido rosado de cuello blanco, de pie frente a paredes cubiertas de texto y números rojos en un entorno oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11574,7 +11574,7 @@
       "serie": "archivo",
       "orden": 375,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuarenta techos de paja se paran sobre el agua turquesa sin mojarse un solo día del año, y el cielo se pinta de verde solo para hacerles compañía.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11588,8 +11588,8 @@
         "generacion": "16baf748-d34b-4652-8864-0510e6c0185b",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El pueblo de agua turquesa",
+      "alt": "Vista elevada de un poblado de casas con techo de paja sobre pilotes construidas sobre un mar de color turquesa, con vegetación de palmeras en primer plano, un cielo verde azulado al atardecer y personas caminando por pasarelas de madera.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11605,7 +11605,7 @@
       "serie": "archivo",
       "orden": 376,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El agua devuelve cada techo de paja al revés con tanta exactitud que quien cruza de noche ya no sabe cuál de las dos mitades está pisando.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11619,8 +11619,8 @@
         "generacion": "1f4f0793-5a81-468c-bb70-5651b8660c81",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El pueblo bajo la luna",
+      "alt": "Vista nocturna de un poblado de chozas con techo de paja construidas sobre el agua, bajo un cielo azul oscuro, con personas sentadas y de pie sobre plataformas de madera junto al agua.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11636,7 +11636,7 @@
       "serie": "archivo",
       "orden": 377,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva dos aros de oro cruzados en el tabique y tantos anillos de metal apilados en el cuello que ninguna brisa del Caribe logra moverle ni un solo mechón.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11650,8 +11650,8 @@
         "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El aro doble",
+      "alt": "Retrato de una mujer con pintura facial roja en puntos sobre la frente, un aro doble de metal dorado en el tabique nasal, aretes grandes con racimos de conchas, varios anillos metálicos apilados en el cuello y un collar de cuentas blancas y azules, frente a una pared de paja.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -11666,7 +11666,7 @@
       "serie": "archivo",
       "orden": 378,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar le suma tantas conchas de mar y cuentas de vidrio al cuello que el peso entero de la orilla parece haberse mudado ahí, capa sobre capa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11680,8 +11680,8 @@
         "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
         "variante": 2
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El collar de conchas apiladas",
+      "alt": "Retrato de una mujer con un aro dorado en el tabique nasal, aretes circulares de concha, un collar de anillos metálicos negros y dorados en el cuello y un collar más grueso de conchas y cuentas sobre un top azul estampado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -11696,7 +11696,7 @@
       "serie": "archivo",
       "orden": 379,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le sembraron puntos rojos por toda la cara, uno por uno, hasta cubrirle las mejillas de una constelación entera que ningún cielo del Caribe llegó a tener.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11710,8 +11710,8 @@
         "generacion": "1f8924b6-da88-434d-bd7c-b05c20b08105",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Las pecas rojas",
+      "alt": "Retrato de una mujer con puntos de pintura roja sobre las mejillas y la frente, un aro dorado en el tabique nasal, aretes blancos en forma de argolla y un collar de varias vueltas de cuentas veteadas sobre un top azul a rayas.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -11726,7 +11726,7 @@
       "serie": "archivo",
       "orden": 380,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por el canal central pasan tantas balsas cargadas de gente esa noche que el agua entera del pueblo se pone a flotar en vez de correr.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11740,8 +11740,8 @@
         "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El canal de las balsas",
+      "alt": "Escena nocturna de un poblado sobre el agua con techos de paja iluminados por la luna, un canal central por donde navegan balsas con personas, y un estandarte rojo colgando de una de las casas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11757,7 +11757,7 @@
       "serie": "archivo",
       "orden": 381,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Mira de frente aunque tenga el pueblo entero de techos cónicos desplegado a la espalda, y ni un tejado se le refleja en los ojos por más que la luna azul insista.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11771,8 +11771,8 @@
         "generacion": "1fd50f6c-91c4-4fbc-9769-073e3e77b422",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La guardiana del pueblo azul",
+      "alt": "Mujer en primer plano con un tocado y collares de cuentas, de pie y mirando hacia el frente, con un extenso poblado de casas con techos cónicos de paja junto a un lago detrás de ella bajo un cielo azul de atardecer, y dos personas caminando por un sendero a la derecha.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11788,7 +11788,7 @@
       "serie": "archivo",
       "orden": 382,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El visor de placa verde le cubre los ojos con tantos cables soldados que ya no necesita parpadear para saber qué hora es en cualquier parte del mundo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11802,8 +11802,8 @@
         "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El visor de circuitos verdes",
+      "alt": "Fotografía en blanco y negro de una persona con la cabeza rapada, que lleva un visor con placa de circuito verde y cables sobre los ojos, vestida con una camisa de cuello azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11819,7 +11819,7 @@
       "serie": "archivo",
       "orden": 383,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cosieron cuenta a cuenta el casco verde que lleva, y ni girando la cabeza hacia la sombra pierde el brillo dorado del uniforme.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11833,8 +11833,8 @@
         "generacion": "26a96291-4c1e-48db-ad52-661816a24f7a",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El casco de cuentas verdes",
+      "alt": "Hombre de perfil con un casco verde cubierto de cuentas y un uniforme blanco con adornos dorados en el hombro, sobre un fondo oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -11850,7 +11850,7 @@
       "serie": "archivo",
       "orden": 384,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las rayas rojas le cruzan la cara de lado a lado y aun así sonríe apenas, como si llevara pintadas encima todas las tardes que ha visto el sol caer sobre el golfo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11864,8 +11864,8 @@
         "generacion": "2d12c98d-6d52-472a-b4ee-6bd7a075797d",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Las rayas rojas",
+      "alt": "Retrato de una mujer con rayas de pintura facial roja y verde, aros dorados en el tabique nasal, aretes circulares grandes de concha y un collar de conchas sobre un top de cuentas azules y rosadas, con fondo dorado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -11880,7 +11880,7 @@
       "serie": "archivo",
       "orden": 385,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Desde la loma más alta se ve arder una sola nube dorada tan despacio que el pueblo entero, abajo, alcanza a terminar el mercado antes de que se apague.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11894,8 +11894,8 @@
         "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La nube dorada del pueblo",
+      "alt": "Vista panorámica de un poblado de techos de paja junto al agua al atardecer, con nubes iluminadas de dorado y varias personas en primer plano mirando hacia el pueblo desde una elevación, una de ellas con un tocado de plumas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11911,7 +11911,7 @@
       "serie": "archivo",
       "orden": 386,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se detiene entre las flores blancas con la túnica naranja tan quieta que el río, al copiarla, tarda toda la noche en decidirse a moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11925,8 +11925,8 @@
         "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
         "variante": 2
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El manto entre las flores",
+      "alt": "Persona con túnica de color naranja de pie junto a flores blancas a la orilla de un canal de noche, con reflejos de luces de colores en el agua y estructuras iluminadas al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11942,7 +11942,7 @@
       "serie": "archivo",
       "orden": 387,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El techo cónico se levanta tan alto sobre el agua verde que las canoas de abajo parecen juguetes olvidados junto a la puerta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11956,8 +11956,8 @@
         "generacion": "3b4bc54d-e7a0-4ae6-b1c5-f5ab1dc3966d",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La casa cónica",
+      "alt": "Gran choza con techo cónico de paja construida sobre pilotes en medio de un cuerpo de agua verde, con pequeñas canoas cerca y una mujer de pie entre la hierba en primer plano, bajo un cielo con nubes al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -11973,7 +11973,7 @@
       "serie": "archivo",
       "orden": 388,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajan la escalera de madera despacio, y el único pájaro que cruza el cielo esa tarde alcanza a contarles cada peldaño antes de perderse entre los techos de paja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -11987,8 +11987,8 @@
         "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Los que bajan al agua",
+      "alt": "Dos personas bajando una escalera de madera hacia el agua en un poblado de casas con techo de paja al atardecer, con hojas de palmera en primer plano y un ave volando en el cielo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12004,7 +12004,7 @@
       "serie": "archivo",
       "orden": 389,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se paran sobre las ramas más altas del acantilado y desde ahí llevan la cuenta exacta de las canoas que entran al pueblo antes de que oscurezca del todo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12018,8 +12018,8 @@
         "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
         "variante": 2
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Los vigías sobre las ramas",
+      "alt": "Dos personas en una elevación con vegetación en primer plano, una de pie y otra sentada, mirando hacia un poblado de casas con techo de paja sobre el agua con canoas, al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12035,7 +12035,7 @@
       "serie": "archivo",
       "orden": 390,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se reúnen en las plataformas de madera a ambos lados del canal justo cuando el agua se pone dorada, y nadie se mueve hasta que el color entero se apaga.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12049,8 +12049,8 @@
         "generacion": "43f24e50-44e8-4fae-bc32-e229cb73835b",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La reunión del canal dorado",
+      "alt": "Poblado de casas con techo de paja construidas sobre pilotes a ambos lados de un canal de agua, con varias personas reunidas en las plataformas de madera al atardecer y una estructura alta al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12066,7 +12066,7 @@
       "serie": "archivo",
       "orden": 391,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El código le cubre la cara entera, línea por línea, hasta que ya no queda un centímetro de piel sin una cifra corriendo encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12080,8 +12080,8 @@
         "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El rostro escrito en código",
+      "alt": "Retrato de una mujer cuyo rostro está cubierto por líneas de texto y código digital de color turquesa brillante, con un anillo de texto sobre la cabeza como si fuera un sombrero, sobre fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12097,7 +12097,7 @@
       "serie": "archivo",
       "orden": 392,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le baja el código azul por la cara en hileras tan largas que parece llorar cifras enteras desde antes de nacer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12111,8 +12111,8 @@
         "generacion": "4be9a7f3-84e4-42cb-bbd0-6eb6c66c8b8f",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El código que llora",
+      "alt": "Retrato de un hombre con líneas de texto y código digital de color azul turquesa cayendo por su rostro, con ojos claros y fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12128,7 +12128,7 @@
       "serie": "archivo",
       "orden": 393,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El símbolo de la frente se repite después en el aro de la nariz y en cada anillo del cuello, como si un solo dibujo hubiera decidido cubrirle el cuerpo entero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12142,8 +12142,8 @@
         "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El símbolo de la frente",
+      "alt": "Retrato de una mujer con un símbolo tatuado en la frente y el cuello, un aro dorado en el tabique nasal, aretes con racimos de flores, varios anillos metálicos apilados en el cuello y collares de cuentas sobre un top azul tejido.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12158,7 +12158,7 @@
       "serie": "archivo",
       "orden": 394,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El adorno de oro en forma de ave le cuelga de la nariz tan quieto que parece llevar posado ahí desde el primer amanecer del golfo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12172,8 +12172,8 @@
         "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
         "variante": 2
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El ave dorada",
+      "alt": "Retrato de una mujer con rayas de pintura facial roja, un adorno dorado con forma de ave en el tabique nasal, aretes redondos con cuentas claras y varios collares de perlas y cuentas superpuestos sobre un top azul texturizado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12188,7 +12188,7 @@
       "serie": "archivo",
       "orden": 395,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cinco vueltas de hueso le rodean el cuello, pesadas como si cargaran solas la historia entera de la aldea, y el nudo de conchas del centro nunca roza el suelo aunque ella incline la cabeza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12202,8 +12202,8 @@
         "generacion": "4c015cd6-d9b0-43c3-bab1-dfa6e89b36db",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Cinco vueltas de hueso",
+      "alt": "Mujer con pintura facial roja en espiral, arete y anillo de nariz dorados, y un collar grueso de varias vueltas de cuentas de hueso y conchas, sobre fondo azul.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12218,7 +12218,7 @@
       "serie": "archivo",
       "orden": 396,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Golpea el cuero del tambor con las manos tan rápido que la foto solo logra pintarlas de niebla, y el mar detrás se queda quieto para no llevarse el compás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12232,8 +12232,8 @@
         "generacion": "551e89c3-af18-4a85-9880-b5fdff559b8d",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La noche hecha tambor",
+      "alt": "Hombre con túnica oscura bordada y gorro toca un tambor djembe en una playa al atardecer, con otras personas borrosas alrededor y el mar y el cielo nublado al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12249,7 +12249,7 @@
       "serie": "archivo",
       "orden": 397,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En las mejillas le arden dos soles pequeños, tan fijos que el techo de paja de atrás solo se atreve a dorarse cuando ella gira la cara hacia la puerta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12263,8 +12263,8 @@
         "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Dos soles en las mejillas",
+      "alt": "Retrato de una persona con dos círculos rojos pintados en las mejillas, líneas en la frente y la nariz, un arete dorado en forma de flor en el tabique nasal, aretes de concha en espiral y un collar de conchas, con un techo de paja dorado al fondo.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12279,7 +12279,7 @@
       "serie": "archivo",
       "orden": 398,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cuentas azules le trepan el cuello anillo tras anillo, y ya van tantas vueltas que una más y le tocaría la barbilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12293,8 +12293,8 @@
         "generacion": "6a1ad429-abc4-434c-93fc-a120bdef86f4",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Las cuentas azules al cuello",
+      "alt": "Retrato de una persona con las mejillas pintadas de rojo, un anillo dorado en la nariz, aretes de concha redondos y un collar ajustado de cuentas azules en el cuello, sobre fondo de madera y paja al atardecer.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12309,7 +12309,7 @@
       "serie": "archivo",
       "orden": 399,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le cubre la cara el código, línea por línea, y ya son tantas que solo los ojos azules quedan afuera del programa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12323,8 +12323,8 @@
         "generacion": "7d86befe-22ca-44b7-8cce-27fd92aa1eb0",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La piel escrita en código",
+      "alt": "Primer plano del rostro de una mujer cubierto por líneas de texto digital y código binario en tonos verdes y azules, con ojos azules brillantes, sobre un fondo oscuro con luces azules.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12340,7 +12340,7 @@
       "serie": "archivo",
       "orden": 400,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de él el cielo se enrosca en un remolino azul y dorado tan cerrado que parece que el tambor lo estuviera hilando con cada golpe.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12354,8 +12354,8 @@
         "generacion": "7f39f421-5b9e-4467-b574-9e0188f6ced2",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El remolino detrás del tambor",
+      "alt": "Hombre con gorro blanco toca un tambor djembe en una playa, con un patrón espiral hipnótico azul y dorado de fondo y otras personas tocando tambores a los lados.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -12371,7 +12371,7 @@
       "serie": "archivo",
       "orden": 401,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las casas se paran sobre el agua en una sola pata de madera cada una, y la choza naranja del centro guarda el último sol del día para prestárselo a la luna.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12385,8 +12385,8 @@
         "generacion": "8fd2b300-c707-41b4-ad96-6eb053b51616",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El pueblo sobre el agua",
+      "alt": "Poblado de chozas de techo de paja construidas sobre pilotes de madera en el agua, con personas con tocados de plumas de pie en las plataformas, bajo un cielo azul oscuro con luna y nubes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12402,7 +12402,7 @@
       "serie": "archivo",
       "orden": 402,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tanto se afilan en punta los techos de paja que parecen contar, uno por uno, cada canoa que cruza despacio entre las casas hasta la última luz verde del cielo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12416,8 +12416,8 @@
         "generacion": "a03a000f-02fd-455b-b323-9d86909c0f9e",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La aldea de techos puntiagudos",
+      "alt": "Vista de un poblado con numerosas chozas de techo cónico de paja construidas sobre pilotes en un lago turquesa, con canoas y personas caminando por pasarelas de madera, bajo un cielo verde y azul al atardecer con luna.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12433,7 +12433,7 @@
       "serie": "archivo",
       "orden": 403,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta la lanza tan alto sobre el caballo blanco que el galope entero parece sostenerse solo para no hacerla temblar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12447,8 +12447,8 @@
         "generacion": "b55e571f-c0f7-482b-9053-1adb0e4bf862",
         "variante": 3
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "La lanza que no baja",
+      "alt": "Hombre con camisa a rayas amarillas y rojas monta un caballo blanco al galope y sostiene una lanza en alto, con otros jinetes con lanzas al fondo en un campo abierto al atardecer.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -12464,7 +12464,7 @@
       "serie": "archivo",
       "orden": 404,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las espirales pintadas le nacen en la cara y no se detienen ahí: le bajan por el cuello y el pecho como si seis vueltas de collar no alcanzaran para pararlas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12478,8 +12478,8 @@
         "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Espirales que bajan al pecho",
+      "alt": "Retrato de una persona con tatuajes en espiral en el rostro, el cuello y el pecho, un aro dorado doble en la nariz, un arete en el labio y un collar grueso de cuentas grandes moteadas, dentro de una choza de techo de paja.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12494,7 +12494,7 @@
       "serie": "archivo",
       "orden": 405,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le cubre la nariz entera un adorno dorado, y dos aros más cuelgan debajo, uno dentro del otro, como si la nariz necesitara tres anuncios distintos de que ahí empieza la cara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12508,8 +12508,8 @@
         "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El cono de oro",
+      "alt": "Retrato de una persona con un gran adorno dorado en forma de cono sobre la nariz, dos aros de nariz adicionales, grandes aretes dorados esféricos y un collar de cuentas rojas y azules con conchas, sobre fondo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12524,7 +12524,7 @@
       "serie": "archivo",
       "orden": 406,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre toda la cara le tienden una red de pintura roja tan cerrada que no queda piel sin cruzar, y el aro dorado de la nariz es la única línea recta de todo el dibujo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12538,8 +12538,8 @@
         "generacion": "baf42107-91b2-4ab3-8a4f-4d7e61286d58",
         "variante": 2
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Red roja sobre la cara",
+      "alt": "Retrato de una persona con el rostro cubierto por un patrón de pintura facial roja en forma de red, un aro dorado en la nariz, aretes de concha y un collar de cuentas plateadas y conchas, frente a un fondo de paja.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -12554,7 +12554,7 @@
       "serie": "archivo",
       "orden": 407,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Diez veces cabría la persona que camina al frente dentro de un solo techo de paja, y el pueblo entero se acomoda a la sombra de tres puntas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12568,8 +12568,8 @@
         "generacion": "cc768606-4f8f-492d-be5b-45120af5f783",
         "variante": 1
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "Las torres de paja",
+      "alt": "Escena de un poblado con grandes chozas de techo cónico de paja muy altas junto al agua, con una persona caminando en primer plano y varias personas reunidas cerca de las chozas, bajo un cielo azul verdoso al atardecer, en estilo de ilustración pictórica.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12585,7 +12585,7 @@
       "serie": "archivo",
       "orden": 408,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cerro baja tan despacio hasta el agua que las últimas chozas ya no distinguen la tierra del río, y las dos personas de rojo en la orilla vigilan la frontera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12599,8 +12599,8 @@
         "generacion": "f4a20894-3b4f-4724-86b9-7de04259d468",
         "variante": 0
       },
-      "titulo": "Httpss.mj.r",
-      "alt": "httpss.mj.r",
+      "titulo": "El cerro moja los pies",
+      "alt": "Vista de un poblado con chozas de techo de paja en una colina y sobre pilotes junto al agua al atardecer, con botes y dos personas con ropa roja cerca de la orilla, bajo un cielo azul oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12616,7 +12616,7 @@
       "serie": "archivo",
       "orden": 409,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las rayas del fondo se le enroscan alrededor como olas paradas en el aire, y él las mira tan fijo que ninguna se atreve a moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12630,8 +12630,8 @@
         "generacion": "057075f5-7fd8-4da8-8303-45cdb243badc",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Entre las olas negras",
+      "alt": "Retrato de un hombre de piel pálida con gorro y capa negros, cabello oscuro ondulado, mirada seria, sobre un fondo de líneas onduladas azules y negras.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -12647,7 +12647,7 @@
       "serie": "archivo",
       "orden": 410,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le cae por el hombro el bordado dorado de la bufanda, con tantas vueltas que cualquiera diría que ahí guarda todo el oro que nunca mostró en la cara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12661,8 +12661,8 @@
         "generacion": "237116cf-69c6-4db5-9eb9-f28a646f7577",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "La bufanda dorada al hombro",
+      "alt": "Retrato pintado de un hombre de cabello oscuro y rizado, cejas fruncidas, con una túnica azul y una bufanda con bordado dorado y azul sobre el hombro, frente a un fondo morado texturizado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12678,7 +12678,7 @@
       "serie": "archivo",
       "orden": 411,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Toda la luz del cuadro se le escapó a una esquina de arriba, y a él no le hizo falta ni un rayo para que los ojos igual quemaran.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12692,8 +12692,8 @@
         "generacion": "59616bc8-067f-41f8-8e32-dd883dde7e73",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "La mancha de luz",
+      "alt": "Retrato pintado al óleo de un hombre de cabello oscuro y rizado, mirada intensa, cuello de camisa blanca y abrigo oscuro, sobre un fondo oscuro con una mancha de luz cálida en la esquina superior izquierda.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12709,7 +12709,7 @@
       "serie": "archivo",
       "orden": 412,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Justo detrás de la cabeza le crece un triángulo verde, tan puntiagudo que parece una montaña que decidió asomarse solo para él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12723,8 +12723,8 @@
         "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Triángulo verde a la espalda",
+      "alt": "Retrato ilustrado de un hombre de cabello oscuro peinado hacia atrás, expresión seria, con un abrigo oscuro y una banda diagonal marrón cruzada al pecho, frente a una forma triangular verde sobre fondo claro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12740,7 +12740,7 @@
       "serie": "archivo",
       "orden": 413,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El fondo se queda tan en blanco que el azul del abrigo tiene que sostener solo todo el color de la escena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12754,8 +12754,8 @@
         "generacion": "780fcb70-bf05-43c2-99cd-5ede24ffcd34",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Azul contra el blanco vacío",
+      "alt": "Retrato ilustrado de un hombre de cabello oscuro y ondulado, expresión seria, con abrigo azul y cuello negro, sobre un fondo liso color crema.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12771,7 +12771,7 @@
       "serie": "archivo",
       "orden": 414,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ni un color cálido sobrevive en ese fondo pálido y helado, así que la mirada oscura tiene que cargar sola con toda la temperatura del cuadro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12785,8 +12785,8 @@
         "generacion": "84c04a57-897f-4151-a505-7f04e0ffafda",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "La mirada atraviesa el frío",
+      "alt": "Retrato ilustrado de un hombre de cabello oscuro y rizado, mirada intensa, con abrigo morado y azul, sobre un fondo degradado azul pálido y blanco.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12802,7 +12802,7 @@
       "serie": "archivo",
       "orden": 415,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene las manos tan apretadas frente al pecho que el barco del fondo ya se rindió a esperar y sigue navegando solo, chiquito, contra el cielo dorado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12816,8 +12816,8 @@
         "generacion": "8a539940-494c-46bd-afd2-0da61296e669",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "El barco queda atrás",
+      "alt": "Retrato pintado de un hombre de cabello oscuro y ondulado con las manos entrelazadas frente al pecho, vestido con un abrigo azul y cuello blanco con volantes, frente a un mar y un cielo de atardecer dorado y morado con un velero a lo lejos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12833,7 +12833,7 @@
       "serie": "archivo",
       "orden": 416,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las ojeras se le hunden tanto que parecen llevar sin dormir todo el tiempo que el pincel tardó en pintar cada una de esas rayas blancas del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12847,8 +12847,8 @@
         "generacion": "a0e6e495-417d-47cb-8e45-54983fb36ca7",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Las ojeras que no duermen",
+      "alt": "Retrato pintado con trazos expresivos de un hombre de cabello oscuro despeinado, ojos hundidos y rostro demacrado, envuelto en una capa oscura, sobre un fondo claro con pinceladas rugosas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12864,7 +12864,7 @@
       "serie": "archivo",
       "orden": 417,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Contra el pecho esconde un papel doblado, tan pequeño y tan blanco que es lo único del cuadro que el mar azul no logra teñir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12878,8 +12878,8 @@
         "generacion": "b9ab3891-83b1-40e4-9236-f4c33eba0324",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Papel blanco contra el pecho",
+      "alt": "Retrato pintado de un hombre de cabello oscuro y rizado con barba incipiente, vestido con una túnica azul y un pequeño papel blanco asomando en el pecho, frente a un mar azul verdoso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12895,7 +12895,7 @@
       "serie": "archivo",
       "orden": 418,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos espadas cruzadas le cuelgan a la espalda, y ninguna mano busca la empuñadura, como si la sola mirada bastara para que nadie se atreviera a probar cuál desenvaina primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12909,8 +12909,8 @@
         "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Dos espadas a la espalda",
+      "alt": "Retrato ilustrado de un hombre de cabello oscuro y rizado, expresión seria, con una capa oscura y una correa de cuero cruzada al pecho, y dos empuñaduras de espada asomando detrás de los hombros, sobre fondo morado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12926,7 +12926,7 @@
       "serie": "archivo",
       "orden": 419,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene el palo de madera con el puño tan cerrado que el botón dorado del pecho es lo único de todo el cuadro que se permite brillar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12940,8 +12940,8 @@
         "generacion": "ba586301-0b06-486a-aa34-44f98a8a95e8",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "El remo que sostiene solo",
+      "alt": "Retrato ilustrado de un hombre de cabello oscuro y rizado, expresión seria, con abrigo azul, una correa de cuero cruzada al pecho y un botón dorado, sosteniendo un palo de madera, sobre fondo morado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12957,7 +12957,7 @@
       "serie": "archivo",
       "orden": 420,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La correa le cruza el pecho tan ceñida que el triángulo de luz violeta que se abre detrás no encuentra otro hueco por donde colarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -12971,8 +12971,8 @@
         "generacion": "ca5f5381-1d51-42ee-b309-fdd5e1bdfed0",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "Correaje bajo el rayo malva",
+      "alt": "Hombre de cabello oscuro rizado y ceño fruncido, con abrigo azul oscuro y una correa cruzada al pecho, de pie ante un mar oscuro bajo un cielo violeta con un haz de luz triangular.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -12988,7 +12988,7 @@
       "serie": "archivo",
       "orden": 421,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene una pluma tan delgada entre los dedos que basta con que la deje quieta un segundo para que el barco entero, a su espalda, se detenga a esperarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13002,8 +13002,8 @@
         "generacion": "e1a2747f-cac6-4a68-b451-cf9ac974eadf",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "La pluma contra la tormenta",
+      "alt": "Hombre de cabello oscuro rizado y expresión seria, sostiene un objeto delgado entre las manos entrelazadas frente al pecho, con abrigo azul y correa cruzada; detrás, un barco y un mar agitado bajo un cielo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13019,7 +13019,7 @@
       "serie": "archivo",
       "orden": 422,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ceño se le hunde tan hondo entre las cejas que raja en dos mitades exactas el azul liso del fondo, sin dejar ni una costura visible.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13033,8 +13033,8 @@
         "generacion": "fc9c8ad9-ce0a-401d-a2b7-3f7039798c9d",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium d",
-      "alt": "Juan de La Torre from Cadiz Medium d",
+      "titulo": "El ceño raja el azul",
+      "alt": "Retrato de hombre de cabello oscuro rizado y ceño fruncido, con el cuello envuelto en tela azul oscura, sobre un fondo azul liso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13050,7 +13050,7 @@
       "serie": "archivo",
       "orden": 423,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "A la altura exacta del cuello le corta el horizonte el retrato en dos: arriba, la arena entera del cielo; abajo, el mar cabe en un dedo de franja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13064,8 +13064,8 @@
         "generacion": "22a985ea-418a-4431-b940-b1535d2ff610",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La franja de mar",
+      "alt": "Retrato de hombre de cabello oscuro rizado y expresión seria, con abrigo azul, sobre fondo color arena dividido por una franja azul de mar a la altura de los hombros.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13081,7 +13081,7 @@
       "serie": "archivo",
       "orden": 424,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le quitaron el mar de detrás y solo dejaron la luz color arena, así que ahora el único horizonte que queda en el cuadro es la línea recta de su ceño.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13095,8 +13095,8 @@
         "generacion": "22a985ea-418a-4431-b940-b1535d2ff610",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El rostro sin horizonte",
+      "alt": "Retrato de hombre de cabello oscuro rizado, ceño fruncido y abrigo azul, sobre un fondo liso color arena claro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13112,7 +13112,7 @@
       "serie": "archivo",
       "orden": 425,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cielo se le parte justo detrás de la cabeza: a la izquierda cae la noche entera, a la derecha todavía queda oro suficiente para no apagarle el mar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13126,8 +13126,8 @@
         "generacion": "26bb487d-0347-43bd-abec-9bc03cfdbdf9",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El cielo partido en oro",
+      "alt": "Retrato pintado de hombre de cabello oscuro rizado con abrigo azul, ante un mar oscuro y un cielo dividido entre tonos dorados y sombras violáceas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13143,7 +13143,7 @@
       "serie": "archivo",
       "orden": 426,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra le come media cara con tanta hambre que solo deja libres un ojo, el bigote y el cuello blanco de la camisa, y ni así queda satisfecha.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13157,8 +13157,8 @@
         "generacion": "35560008-b3e3-45d2-b05d-adff705e73cf",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El ojo libre de sombra",
+      "alt": "Primer plano oscuro de un rostro masculino con bigote, mitad iluminada y mitad en sombra profunda, con cuello de camisa blanco visible y un adorno dorado difuso en la esquina superior.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13174,7 +13174,7 @@
       "serie": "archivo",
       "orden": 427,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva una mancha oscura en el pómulo que ninguna tormenta ha logrado lavarle, ni esta agua verde que se le enrosca detrás como si quisiera tragarse el mástil entero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13188,8 +13188,8 @@
         "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La mancha sin lavar",
+      "alt": "Primer plano de un rostro masculino con expresión adusta y una mancha oscura en la mejilla, cabello oscuro rizado, sobre fondo verde azulado tormentoso con un mástil de barco visible al borde.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13205,7 +13205,7 @@
       "serie": "archivo",
       "orden": 428,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se planta justo en medio de dos barcos que navegan en direcciones contrarias, y ninguno de los dos consigue moverle ni un grado la mirada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13219,8 +13219,8 @@
         "generacion": "4450a4b7-c4ae-47be-94b7-729dc7255c50",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Entre dos barcos sin moverse",
+      "alt": "Primer plano de hombre de cabello oscuro rizado y mirada fija, con dos barcos de vela visibles a ambos lados en un mar nocturno azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13236,7 +13236,7 @@
       "serie": "archivo",
       "orden": 429,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un arcoíris entero decide cruzarle la cara justo cuando el velero de mástiles dorados pasa detrás, y no hay quien lo convenza de moverse antes de que termine de pasar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13250,8 +13250,8 @@
         "generacion": "455b8ad3-a701-46b8-8ab2-8ed687549bbe",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El arcoíris en la cara",
+      "alt": "Perfil de una persona con reflejos de luz multicolor sobre el rostro y cabello oscuro largo, con un velero de velas doradas navegando en un mar en calma al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13267,7 +13267,7 @@
       "serie": "archivo",
       "orden": 430,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un palo de madera le cruza tan exacto detrás de la nuca que parece sostenerle la cabeza en su sitio mientras el mar gris se mueve solo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13281,8 +13281,8 @@
         "generacion": "4bd650fe-bcd0-4294-bd92-289acf7eb3ae",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El palo tras la nuca",
+      "alt": "Primer plano de hombre de cabello oscuro rizado y expresión seria, con una barra de madera horizontal detrás del cuello y el mar al fondo en tonos grises azulados.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13298,7 +13298,7 @@
       "serie": "archivo",
       "orden": 431,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Carga a la espalda un edificio entero de arcos de piedra y techo de teja, y aun así el ceño le pesa más que toda la construcción.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13312,8 +13312,8 @@
         "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El arco de piedra",
+      "alt": "Retrato de hombre de cabello oscuro rizado y ceño fruncido, con abrigo azul, frente a un edificio de piedra con arcos y techo de teja bajo luz diurna.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13329,7 +13329,7 @@
       "serie": "archivo",
       "orden": 432,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz dorada le cae tan pareja sobre la cara y el mar que ya no se distingue dónde termina su piel y dónde empieza el agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13343,8 +13343,8 @@
         "generacion": "5349d98a-70d8-4b2c-b434-fc7c518b0530",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Oro parejo sobre el ceño",
+      "alt": "Retrato de hombre de cabello oscuro rizado y mirada intensa, bañado en luz dorada, con el mar en calma al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13360,7 +13360,7 @@
       "serie": "archivo",
       "orden": 433,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Junta las manos y le nace fuego entre los dedos, tan vivo que los dientes apretados le brillan del mismo naranja antes de que el viento azul de atrás se lo lleve.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13374,8 +13374,8 @@
         "generacion": "5a509ab8-c968-44c4-aac1-e5517115fa11",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Fuego entre las manos",
+      "alt": "Hombre con expresión furiosa y dientes apretados sostiene fuego entre las manos ahuecadas, sobre un fondo azul oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13391,7 +13391,7 @@
       "serie": "archivo",
       "orden": 434,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se anuda un pañuelo oscuro en la cabeza y, detrás, tan chiquito que cabe bajo su propia ceja, navega un bote que tarda un siglo en cruzar el atardecer morado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13405,8 +13405,8 @@
         "generacion": "70810425-686a-4cea-851e-770584dfe42a",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El pañuelo y el bote",
+      "alt": "Hombre con pañuelo oscuro en la cabeza y expresión seria, con un pequeño velero navegando al atardecer en un mar violeta y naranja al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13422,7 +13422,7 @@
       "serie": "archivo",
       "orden": 435,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz le reparte la cara en dos climas exactos: un lado tibio como si aún fuera tarde, el otro ya frío como si el mar de atrás le hubiera adelantado la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13436,8 +13436,8 @@
         "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La cara entre dos climas",
+      "alt": "Retrato de hombre de cabello oscuro rizado con el rostro iluminado en dos tonalidades, cálida y fría, con el mar en calma al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13453,7 +13453,7 @@
       "serie": "archivo",
       "orden": 436,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El azul del atardecer le gana tanto terreno a la piel que ya no se distingue si el mar se le pega a la cara o si la cara se derrama sobre el mar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13467,8 +13467,8 @@
         "generacion": "799e10c0-451d-46de-b3aa-8c817cade8b0",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El azul contra la piel",
+      "alt": "Primer plano de hombre de cabello oscuro rizado con tono de piel azulado, mirada seria y mar en calma al fondo bajo luz de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13484,7 +13484,7 @@
       "serie": "archivo",
       "orden": 437,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta los ojos hacia un punto que solo él parece ver, mientras la pared de piedra gris de atrás se le cierra sobre los hombros como si quisiera detenerle el gesto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13498,8 +13498,8 @@
         "generacion": "87322e48-bdb8-4e74-98b2-1399ed214157",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La roca sobre el hombro",
+      "alt": "Retrato de hombre de cabello oscuro rizado visto desde un ángulo elevado, mirando hacia arriba, con una pared rocosa gris detrás.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13515,7 +13515,7 @@
       "serie": "archivo",
       "orden": 438,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los ojos le brillan de un blanco pálido justo cuando el cielo verde se apaga en una sola línea naranja al fondo, como si la última luz del día se le hubiera escondido ahí.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13529,8 +13529,8 @@
         "generacion": "87d936de-a46c-45b4-9f7e-66f97d64b0fd",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Ojos con la última luz",
+      "alt": "Retrato pintado de hombre de cabello oscuro rizado y ojos claros y brillantes, sobre un cielo en degradado de verde a naranja en el horizonte.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13546,7 +13546,7 @@
       "serie": "archivo",
       "orden": 439,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cielo se despeja entero y el mar se pone azul de postal, pero ni un solo rayo de sol le afloja el ceño fruncido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13560,8 +13560,8 @@
         "generacion": "a836637d-5728-464a-8329-ec1f033b62c7",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Día claro, ceño intacto",
+      "alt": "Retrato de hombre de cabello oscuro rizado y ceño fruncido, con abrigo azul, bajo un cielo despejado y mar en calma en un día soleado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13577,7 +13577,7 @@
       "serie": "archivo",
       "orden": 440,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La chaqueta le suma tantos botones de metal en fila que, cuando el sol pega, parecen un collar entero de monedas, mientras la roca de la costa se queda callada detrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13591,8 +13591,8 @@
         "generacion": "ad8cc8ed-c502-4719-9418-71f07bb679a4",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Botones que brillan como monedas",
+      "alt": "Retrato pintado de hombre de cabello oscuro rizado, con chaqueta oscura de botones metálicos, ante una costa rocosa y mar en tonos apagados.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13608,7 +13608,7 @@
       "serie": "archivo",
       "orden": 441,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás, el cielo entero se le incendia de naranja hasta el borde del mar, y ni el reflejo del fuego le alcanza para entibiarle la cara azul.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13622,8 +13622,8 @@
         "generacion": "af5396cf-a8c0-4a66-895d-54db37a44b81",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El cielo en llamas",
+      "alt": "Retrato de hombre de cabello oscuro rizado y rostro en sombra azulada, con un cielo rojo anaranjado ardiente en el horizonte y un mástil visible al borde.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13639,7 +13639,7 @@
       "serie": "archivo",
       "orden": 442,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un solo foco le cae desde arriba y apenas le rescata la cara y la correa cruzada al pecho; todo lo demás se lo traga la oscuridad del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13653,8 +13653,8 @@
         "generacion": "c22eec5e-f065-4a04-ac31-9b61112a4562",
         "variante": 2
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La correa bajo el foco",
+      "alt": "Retrato de hombre de cabello oscuro rizado con una correa cruzada al pecho, iluminado por un único foco de luz contra un fondo oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13670,7 +13670,7 @@
       "serie": "archivo",
       "orden": 443,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El mismo hombre se multiplica tres veces en el mismo azul verdoso: de perfil, de cuerpo entero y de cerca, como si no lograra decidir en cuál instante quedarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13684,8 +13684,8 @@
         "generacion": "c4167ca9-97bf-4265-8587-badfd7088616",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El hombre repetido tres veces",
+      "alt": "Collage de tres imágenes del mismo hombre de cabello oscuro ondulado con atuendo de marinero, en distintos planos y posturas, sobre fondo azul verdoso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13701,7 +13701,7 @@
       "serie": "archivo",
       "orden": 444,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya el codo y deja la mano flotando cerca de la barbilla, mientras la cortina blanca de atrás cuelga tan quieta que parece llevar toda la función esperándolo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13715,8 +13715,8 @@
         "generacion": "c4b6cc2e-18df-4072-99d8-9355b5035322",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El codo ante la cortina",
+      "alt": "Retrato pintado de hombre de cabello oscuro largo, apoyado sobre un brazo con la mano cerca del rostro, con un cinturón ancho de hebilla, ante una cortina blanca de fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13732,7 +13732,7 @@
       "serie": "archivo",
       "orden": 445,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Frunce el ceño con tanta fuerza que la arruga central le divide la frente en dos mitades que ya no vuelven a encontrarse, ni siquiera cuando gira la cara hacia la sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13746,8 +13746,8 @@
         "generacion": "cdf3f12b-d33f-414a-b5fc-b17ad909a8fd",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El ceño partido en dos",
+      "alt": "Retrato de un hombre de cabello oscuro y rizado con el rostro pálido e iluminado, vestido con una bata azul oscuro, sobre un fondo negro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13763,7 +13763,7 @@
       "serie": "archivo",
       "orden": 446,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las olas de atrás se quedan tan quietas bajo su mirada que la espuma tarda un minuto entero en decidirse a romper contra la roca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13777,8 +13777,8 @@
         "generacion": "cf88fee8-5b80-4ed2-9947-ccea9a4d18e5",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El mar que obedece",
+      "alt": "Retrato pintado de un hombre de cabello oscuro y rizado con capa azul, frente a un mar agitado con rocas y cielo nublado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13794,7 +13794,7 @@
       "serie": "archivo",
       "orden": 447,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de su hombro un velero de vela dorada lleva toda la tarde intentando alejarse mar adentro sin conseguir ganar ni un metro de distancia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13808,8 +13808,8 @@
         "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El velero que no avanza",
+      "alt": "Ilustración de un hombre de cabello oscuro con un manto oscuro sobre los hombros, iluminado por luz dorada, con un velero navegando en el mar al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13825,7 +13825,7 @@
       "serie": "archivo",
       "orden": 448,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene el cuchillo tan pegado al pecho que el filo le devuelve el mismo mar de atrás, reducido entero a una sola línea de acero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13839,8 +13839,8 @@
         "generacion": "d634b332-b796-46d0-9e8f-88b7d5d45336",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El filo y su mar",
+      "alt": "Retrato ilustrado en primer plano de un hombre de cabello oscuro y rizado sosteniendo un cuchillo cerca del pecho, con el mar al fondo bajo luz cálida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13856,7 +13856,7 @@
       "serie": "archivo",
       "orden": 449,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra que proyecta contra el muro se alarga tanto que dobla la esquina del pasillo antes de que él mismo alcance a dar el primer paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13870,8 +13870,8 @@
         "generacion": "d77639d9-a0f9-4cba-9394-b6b0d8fc2ea6",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "La sombra que llega primero",
+      "alt": "Retrato de un hombre de cabello oscuro vestido con una chaqueta azul oscuro, iluminado de lado junto a una pared clara, con una sombra alargada detrás de él.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13887,7 +13887,7 @@
       "serie": "archivo",
       "orden": 450,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las nubes que se amontonan detrás llevan tres días completos sin decidirse a romper sobre el mismo trozo de mar que él observa con el ceño fruncido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13901,8 +13901,8 @@
         "generacion": "dc5e217d-a47d-4380-94d5-60cd57afb4b3",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Las nubes que no rompen",
+      "alt": "Pintura de un hombre de cabello oscuro y rizado, vestido con abrigo oscuro, con expresión seria y los brazos apoyados, frente a un mar agitado bajo un cielo nublado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -13918,7 +13918,7 @@
       "serie": "archivo",
       "orden": 451,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se planta justo en la línea donde el azul de la mañana todavía no le cede el sitio por completo al naranja que ya empieza a subirle por el hombro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13932,8 +13932,8 @@
         "generacion": "de5308d8-67dd-4f3b-9382-a8f52ca165dc",
         "variante": 0
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El azul contra el naranja",
+      "alt": "Ilustración de un hombre de cabello oscuro con abrigo azul y una correa cruzada al pecho, de pie sobre un fondo dividido en tonos azules y anaranjados.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13949,7 +13949,7 @@
       "serie": "archivo",
       "orden": 452,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cejas se le tensan tan rectas que igualan la línea exacta del horizonte que tiene detrás, sin una sola curva de diferencia entre las dos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13963,8 +13963,8 @@
         "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f",
         "variante": 1
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "Las cejas del horizonte",
+      "alt": "Retrato ilustrado en primer plano de un hombre de cabello oscuro y rizado con expresión seria, frente a un mar en calma bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -13980,7 +13980,7 @@
       "serie": "archivo",
       "orden": 453,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El barco diminuto que aparece detrás de su hombro lleva media vida cruzando el mismo trozo de mar sin alcanzar nunca el borde de la imagen.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -13994,8 +13994,8 @@
         "generacion": "f8ba322e-6b5e-4838-8097-8420adf8d59f",
         "variante": 3
       },
-      "titulo": "Juan de La Torre from Cadiz Medium dark",
-      "alt": "Juan de La Torre from Cadiz Medium dark Hair Mulato Long dark",
+      "titulo": "El barco que no llega",
+      "alt": "Retrato ilustrado en primer plano de un hombre de cabello oscuro y rizado, con un pequeño barco navegando en el mar al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14039,7 +14039,7 @@
       "serie": "archivo",
       "orden": 455,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva tantos collares superpuestos que el espejo de al lado necesita reflejarlos dos veces para no perder ni una sola vuelta de cadena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14053,8 +14053,8 @@
         "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070",
         "variante": 1
       },
-      "titulo": "Latin american boy with an alternative nu-metal attire",
-      "alt": "Latin american boy with an alternative nu-metal attire and vi",
+      "titulo": "El collar que se duplica",
+      "alt": "Retrato de una persona joven de cabello oscuro y rizado, con top oscuro con lentejuelas y varios collares, junto a un espejo que refleja la habitación en tonos verdosos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -14070,7 +14070,7 @@
       "serie": "archivo",
       "orden": 456,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El tinte azul del pelo se le mezcla tanto con la pared que hace falta contar los mechones dos veces para saber dónde termina el cuarto y empieza la cabeza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14084,8 +14084,8 @@
         "generacion": "61e3ec5c-a925-4741-9695-c0fc1382b070",
         "variante": 2
       },
-      "titulo": "Latin american boy with an alternative nu-metal attire",
-      "alt": "Latin american boy with an alternative nu-metal attire and vi",
+      "titulo": "El pelo que se funde",
+      "alt": "Retrato de una persona joven con el pelo teñido de azul y varios collares plateados, frente a una pared verde azulada con estampas religiosas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -14101,7 +14101,7 @@
       "serie": "archivo",
       "orden": 457,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se queda de pie con la bata puesta como si fuera a asomarse al patio, mientras la Tierra entera gira despacio detrás, esperando su turno de mirada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14115,8 +14115,8 @@
         "generacion": "95e801a2-53ac-4d18-a479-1f15622d3310",
         "variante": 0
       },
-      "titulo": "Latin american etnicity moon human gazes at Earth",
-      "alt": "latin american etnicity moon human gazes at Earth from the Mo",
+      "titulo": "La Tierra en su turno",
+      "alt": "Ilustración en tonos grises de una persona vista de espaldas, con bata blanca, observando el planeta Tierra en el cielo desde la superficie de la Luna, junto a una montaña rocosa.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -14132,7 +14132,7 @@
       "serie": "archivo",
       "orden": 458,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El traje naranja es el único color en kilómetros de piedra gris, y aun así la Tierra que cuelga del cielo se las arregla para robarle todo el protagonismo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14146,8 +14146,8 @@
         "generacion": "af07695a-1dac-4acd-9b3f-1731b8baba39",
         "variante": 3
       },
-      "titulo": "Latin american etnicity moon human gazes at Earth",
-      "alt": "latin american etnicity moon human gazes at Earth from the Mo",
+      "titulo": "El naranja frente al planeta",
+      "alt": "Renderizado de un astronauta con traje naranja de pie sobre un terreno rocoso, frente a una estructura futurista en forma de platillo y el planeta Tierra visible en el cielo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -14163,7 +14163,7 @@
       "serie": "archivo",
       "orden": 459,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En esa cocina las ollas guardan el sonido de las comidas anteriores, y por eso él se sienta callado: espera a que terminen de sonar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14177,8 +14177,8 @@
         "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
         "variante": 1
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La cocina antes del ruido",
+      "alt": "Fotografía granulada de un joven con camiseta blanca sentado junto a una mesa con mantel floreado rojo, ollas y jarras metálicas, en una cocina modesta.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14194,7 +14194,7 @@
       "serie": "archivo",
       "orden": 460,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta a la mesa rodeado de tantas plantas que el mesero tarda un minuto entero en encontrar el hueco exacto por donde servirle el café.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14208,8 +14208,8 @@
         "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
         "variante": 2
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La mesa entre las hojas",
+      "alt": "Fotografía de un hombre con gorra y camisa roja sentado a una mesa exterior rodeada de plantas, frente a un vidrio con reflejos verdosos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14225,7 +14225,7 @@
       "serie": "archivo",
       "orden": 461,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Contra la misma pared se sientan los dos, pero dejan entre ambos el largo exacto de una acera entera, como si la calle tuviera que caber de por medio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14239,8 +14239,8 @@
         "generacion": "1830b0dd-c57d-4196-bab8-1bdae9b40d4c",
         "variante": 3
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La acera repartida entre dos",
+      "alt": "Fotografía borrosa de dos personas sentadas por separado en una acera junto a una pared, con bolsas a su lado, en una calle urbana.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14256,7 +14256,7 @@
       "serie": "archivo",
       "orden": 462,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina con la gorra calada hasta las cejas mientras a su espalda una fila entera de torres se estira para alcanzar la altura exacta de la montaña.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14270,8 +14270,8 @@
         "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24",
         "variante": 1
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "Las torres y la montaña",
+      "alt": "Fotografía de un hombre caminando por una acera con gorra y camisa a cuadros, con edificios altos y una montaña verde al fondo, y autos en tráfico en la calle.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14287,7 +14287,7 @@
       "serie": "archivo",
       "orden": 463,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El chándal metalizado le devuelve a la ciudad la misma luz que ella empieza a encender abajo, ventana por ventana, mientras el cielo termina de apagarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14301,8 +14301,8 @@
         "generacion": "1dc5ac9e-27cc-40f8-a588-e2ebede70d24",
         "variante": 2
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El brillo contra la ciudad",
+      "alt": "Fotografía de un joven con chándal metalizado de pie en un balcón, mirando hacia una ciudad de edificios altos al atardecer, con luces de autos abajo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14318,7 +14318,7 @@
       "serie": "archivo",
       "orden": 464,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se recuesta contra la reja verde con los ojos cerrados, y dos periódicos sin vender siguen esperando en el kiosco a que despierte para cobrarle el vuelto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14332,8 +14332,8 @@
         "generacion": "28e76c57-19d6-4b41-a6ff-1cc0e3465538",
         "variante": 0
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La siesta contra la reja",
+      "alt": "Fotografía de un hombre con gorra y camisa estampada, sentado y con los ojos cerrados junto a una reja verde, cerca de un kiosco de periódicos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14349,7 +14349,7 @@
       "serie": "archivo",
       "orden": 465,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El televisor lleva tanto tiempo sentado entre las macetas que las flores anaranjadas ya le crecen alrededor como si fuera una maceta más del patio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14363,8 +14363,8 @@
         "generacion": "397d7ceb-1ba0-4606-9109-63be3ef523bd",
         "variante": 1
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El televisor hecho maceta",
+      "alt": "Fotografía de un televisor antiguo colocado al aire libre entre macetas con flores anaranjadas, frente a un edificio de apartamentos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14380,7 +14380,7 @@
       "serie": "archivo",
       "orden": 466,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La fila de carros se estira tanto calle abajo que el último parachoques todavía no consigue ver la montaña que corona al primero de todos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14394,8 +14394,8 @@
         "generacion": "4ea279aa-1b48-4b1c-befb-9bf0225623f0",
         "variante": 2
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La fila sin montaña",
+      "alt": "Fotografía de un embotellamiento de autos en una calle de ciudad, con edificios y una montaña al fondo, entre árboles floridos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14411,7 +14411,7 @@
       "serie": "archivo",
       "orden": 467,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las torres altas y las casas bajas del barrio comparten la misma nube morada del atardecer, aunque a las primeras les sobren diez pisos para alcanzarla primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14425,8 +14425,8 @@
         "generacion": "946cf2ed-0959-473b-9e10-0f7145dc9486",
         "variante": 2
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El morado de dos ciudades",
+      "alt": "Fotografía de una ciudad al atardecer, con torres de apartamentos altas y un barrio de casas bajas en primer plano, bajo un cielo morado y azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14442,7 +14442,7 @@
       "serie": "archivo",
       "orden": 468,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Extiende sobre el mantel de colores más aparatos de los que la mesa alcanza a sostener, y aun así encuentra sitio para señalar uno más con la mano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14456,8 +14456,8 @@
         "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b",
         "variante": 0
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El mantel sin abasto",
+      "alt": "Fotografía de un joven con gorra y camisa roja sentado frente a una mesa cubierta con un mantel de colores, con varios objetos electrónicos a la venta.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14473,7 +14473,7 @@
       "serie": "archivo",
       "orden": 469,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ventana enmarca la montaña con tanta precisión que las macetas del alféizar parecen puestas ahí solo para no dejarla escapar del cuadro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14487,8 +14487,8 @@
         "generacion": "98f2844e-e3ea-4dd3-a9b1-83382558b82b",
         "variante": 1
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La montaña en la ventana",
+      "alt": "Fotografía tomada desde el interior de una habitación, a través de una ventana con plantas, mostrando una montaña y edificios bajo luz cálida de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14504,7 +14504,7 @@
       "serie": "archivo",
       "orden": 470,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Instala el televisor en la ladera y luego le da la espalda, prefiriendo la ciudad entera que ya transmite en vivo cuesta abajo sin necesidad de antena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14518,8 +14518,8 @@
         "generacion": "a13e96b0-8dbe-49ee-b2a8-d0c4e0ba3b63",
         "variante": 0
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El televisor de espaldas",
+      "alt": "Fotografía de un hombre visto de espaldas, sentado en un banco en una ladera con un televisor y objetos domésticos cerca, mirando una ciudad extensa al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14535,7 +14535,7 @@
       "serie": "archivo",
       "orden": 471,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La tela blanca del traje es lo único que el asfalto gris no logra tragarse, aunque él se acomode con las piernas cruzadas justo en el borde de la avenida vacía.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14549,8 +14549,8 @@
         "generacion": "b86cf818-8898-4232-8165-e1a877c2d679",
         "variante": 3
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El blanco contra el asfalto",
+      "alt": "Fotografía de un hombre vestido de blanco sentado con las piernas cruzadas en el separador de una avenida ancha, con tiendas y edificios al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14566,7 +14566,7 @@
       "serie": "archivo",
       "orden": 472,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta justo en el borde donde la sombra del edificio corta la acera al medio, y ese filo de diez centímetros le basta para leer sin que el mediodía le queme una letra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14580,8 +14580,8 @@
         "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50",
         "variante": 0
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El filo de la sombra",
+      "alt": "Un hombre con camisa clara está sentado en la sombra de un muro de esquina leyendo un papel; detrás se ven una calle con motos y carros estacionados, edificios de apartamentos y una montaña bajo un cielo nublado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14597,7 +14597,7 @@
       "serie": "archivo",
       "orden": 473,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al lado deja una silla plástica blanca completamente vacía, reservada con tanta constancia que ya lleva catorce años esperando a que alguien se siente.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14611,8 +14611,8 @@
         "generacion": "c0a2992f-9c8b-4472-91e4-ebfbb72afa50",
         "variante": 1
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La silla blanca vacía",
+      "alt": "Un hombre mayor está sentado en la penumbra de una habitación iluminada por una sola luz cálida, junto a una silla plástica blanca vacía y una mesa con mantel verde y frascos de vidrio.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14628,7 +14628,7 @@
       "serie": "archivo",
       "orden": 474,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un relámpago le enciende las nubes por detrás a las torres más altas, y el destello dura lo bastante para contar, una por una, las mil ventanas encendidas del barrio de abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14642,8 +14642,8 @@
         "generacion": "d4cbe190-b143-4406-abdf-e2b4bdcd4dd8",
         "variante": 0
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "El rayo tras las torres",
+      "alt": "Vista nocturna desde un balcón de una ciudad con edificios altos e iluminados, un cielo azul oscuro cargado de nubes de tormenta, y un barrio de casas humildes con luces cálidas en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14659,7 +14659,7 @@
       "serie": "archivo",
       "orden": 475,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la camisa cubierta de salpicaduras blancas que parecen haber caído gota a gota durante los mismos veinte años que lleva parado en esa esquina junto al kiosco verde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14673,8 +14673,8 @@
         "generacion": "e13c784e-922f-4601-ba1d-41c58d4f4d6c",
         "variante": 3
       },
-      "titulo": "Life still in Caracas",
-      "alt": "Life still in Caracas",
+      "titulo": "La camisa salpicada de blanco",
+      "alt": "Un hombre con camisa clara salpicada de manchas mira a la cámara junto a un kiosco de madera verde con afiches; detrás, un policía con tapabocas y otra persona con mascarilla caminan por la calle.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14690,7 +14690,7 @@
       "serie": "archivo",
       "orden": 476,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Vuelan tan pegadas ala con ala que desde las azoteas de abajo cuesta contar si son dos guacamayas o una sola con cuatro alas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14704,8 +14704,8 @@
         "generacion": "57e84694-ded5-4cd4-9b20-b34570301ee3",
         "variante": 0
       },
-      "titulo": "Life still in Caracas with Guacamayas",
-      "alt": "Life still in Caracas with Guacamayas",
+      "titulo": "Dos guacamayas sobre la neblina",
+      "alt": "Dos guacamayas azules y amarillas vuelan una junto a otra sobre una ciudad con edificios altos y una zona de viviendas densas, bajo un cielo gris y brumoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14721,7 +14721,7 @@
       "serie": "archivo",
       "orden": 477,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La bandada pasa tan espesa que por tres segundos las dos torres más altas de la avenida desaparecen detrás de puras alas azules y amarillas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14735,8 +14735,8 @@
         "generacion": "5bfc12b2-8cf0-470e-9ca4-ae1b3196fd02",
         "variante": 2
       },
-      "titulo": "Life still in Caracas with Guacamayas",
-      "alt": "Life still in Caracas with Guacamayas",
+      "titulo": "La bandada que tapa torres",
+      "alt": "Una gran bandada de guacamayas azules y amarillas vuela en movimiento borroso frente a dos torres de apartamentos y árboles verdes, en un día nublado sobre la ciudad.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14752,7 +14752,7 @@
       "serie": "archivo",
       "orden": 478,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Estaciona la moto verde y blanca tan pegada a la reja de la ventana que en veinte años de subir esa acera nunca ha rozado ni un barrote.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14766,8 +14766,8 @@
         "generacion": "055ea6b8-fe43-4726-9ffb-cc5ff136a295",
         "variante": 2
       },
-      "titulo": "Life still in Paraguan",
-      "alt": "Life still in Paraguan",
+      "titulo": "La moto contra la reja",
+      "alt": "Un hombre con casco está sentado sobre una motocicleta antigua estacionada frente a una casa de paredes rosadas y azules descascaradas, con una ventana enrejada y una puerta azul abierta.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14783,7 +14783,7 @@
       "serie": "archivo",
       "orden": 479,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El portón de hierro se oxidó tanto esperando que alguien lo cierre que las flores rosadas ya le treparon por encima los seis barrotes.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14797,8 +14797,8 @@
         "generacion": "7243af9b-aecb-4e43-8333-94c9fb366501",
         "variante": 1
       },
-      "titulo": "Life still in Paraguan",
-      "alt": "Life still in Paraguan",
+      "titulo": "La reja oxidada del jardín",
+      "alt": "Una casa pequeña con techo de tejas rojas y paredes rosadas descascaradas, puerta y ventanas azules, rodeada de un jardín con maleza y flores rosadas, con un portón de metal oxidado al frente.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14814,7 +14814,7 @@
       "serie": "archivo",
       "orden": 480,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las flores azules de la camisa se repiten tantas veces sobre la tela que ya superan, una por una, los destellos que ha dado el faro blanco de allá atrás en toda la tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14828,8 +14828,8 @@
         "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef",
         "variante": 1
       },
-      "titulo": "Life still in Paraguan",
-      "alt": "Life still in Paraguan",
+      "titulo": "El faro tras las flores",
+      "alt": "Un hombre con sombrero y camisa de estampado floral azul mira hacia la cámara en primer plano; detrás, varias personas con ropa de camuflaje están junto a un carro, con un faro blanco y un cielo nublado al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14845,7 +14845,7 @@
       "serie": "archivo",
       "orden": 481,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al otro lado del agua la refinería enciende tantas torres a la vez que desde este patio de zinc y palmeras hace más luz que la luna llena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14859,8 +14859,8 @@
         "generacion": "f47b6efe-3cd5-4b11-8384-e924b75626ef",
         "variante": 2
       },
-      "titulo": "Life still in Paraguan",
-      "alt": "Life still in Paraguan",
+      "titulo": "Las luces de la refinería",
+      "alt": "Vista de una zona costera con casas humildes de zinc y una palmera en primer plano, y al fondo, cruzando el agua, las torres y chimeneas de una refinería petrolera bajo un cielo azul brumoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14876,7 +14876,7 @@
       "serie": "archivo",
       "orden": 482,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La camisa de flores azules queda tan pegada al vestido morado de la vecina de asiento que entre los dos estampados no cabe ni el aire del vagón.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14890,8 +14890,8 @@
         "generacion": "22bc6902-beaa-4477-868f-41450ecd58c9",
         "variante": 0
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "El estampado junto al vestido",
+      "alt": "Dentro de un vagón del metro, una mujer con vestido morado y un hombre con camisa de flores azules están sentados uno junto al otro; en primer plano se ve borroso otro pasajero.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14907,7 +14907,7 @@
       "serie": "archivo",
       "orden": 483,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El tren lleva pintada una franja de siete colores a lo largo del vagón, y la multitud que baja logra vestir, entre camisas y blusas, exactamente los mismos siete sin ponerse de acuerdo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14921,8 +14921,8 @@
         "generacion": "2592a93b-b323-42ce-b7c4-892b0185f79b",
         "variante": 1
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "La raya de colores",
+      "alt": "Una multitud de personas baja de un tren del metro con una franja de colores en el costado, todos en movimiento borroso, vestidos con camisas de distintos colores y estampados.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14938,7 +14938,7 @@
       "serie": "archivo",
       "orden": 484,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina por el andén tan mojado por la lluvia que el reflejo del tren duplica cada luz roja, y por un segundo parecen dos trenes esperando en vez de uno.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14952,8 +14952,8 @@
         "generacion": "4487d810-dd9d-4098-b6da-649037110a29",
         "variante": 2
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "El andén duplicado",
+      "alt": "Un hombre con chaqueta y pantalón azul camina hacia un tren del metro que llega a la estación, sobre un andén mojado por la lluvia que refleja las luces; hay una caseta roja a un lado y vegetación en la ladera de arriba.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -14969,7 +14969,7 @@
       "serie": "archivo",
       "orden": 485,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva el pelo teñido de un rojo tan fijo que aunque el vagón entero tiembla y se desenfoca detrás de ella, ni un solo mechón se le mueve del sitio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -14983,8 +14983,8 @@
         "generacion": "7384e7bf-82b1-4089-9d1c-e5ccb3bf6b10",
         "variante": 1
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "El rojo que no tiembla",
+      "alt": "Una mujer de cabello rojo y vestido estampado morado y azul está sentada en un vagón del metro, con un bolso naranja al lado, mientras las ventanas detrás se ven borrosas por el movimiento.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -15000,7 +15000,7 @@
       "serie": "archivo",
       "orden": 486,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pantalón morado le brilla tanto bajo la luz del vagón que refleja, uno por uno, los cinco tubos fluorescentes del techo mientras cruza las piernas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15014,8 +15014,8 @@
         "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe",
         "variante": 2
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "El pantalón morado que brilla",
+      "alt": "Un hombre con camisa clara y pantalón morado brillante está sentado solo en un asiento del metro; al fondo, otros pasajeros con camisas de colores están sentados en la banca de enfrente.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -15031,7 +15031,7 @@
       "serie": "archivo",
       "orden": 487,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Comparten el mismo asiento de metal aunque entre la camisa estampada del mayor y la camisa azul lisa del joven se cuenten cuarenta años exactos de diferencia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15045,8 +15045,8 @@
         "generacion": "ba90e8ae-7209-47d7-a60f-3efb6dfd32fe",
         "variante": 3
       },
-      "titulo": "Life still in the metro of Caracas",
-      "alt": "Life still in the metro of Caracas",
+      "titulo": "Cuarenta años en un asiento",
+      "alt": "Un hombre mayor con camisa estampada y un joven con camisa azul están sentados uno al lado del otro en un vagón del metro, con afiches de colores en la pared detrás.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -15062,7 +15062,7 @@
       "serie": "archivo",
       "orden": 488,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El toldo blanco lleva tantas lluvias encima que ya deja pasar el sol como si fuera una sábana tendida sobre las mesas y sillas plásticas de abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15076,8 +15076,8 @@
         "generacion": "e9155478-a48f-47ec-91ee-0d24d2540d4d",
         "variante": 0
       },
-      "titulo": "Liminal image of a restaurant postcard in the",
-      "alt": "liminal image of a restaurant postcard in the style of 1990s",
+      "titulo": "El toldo entre palmeras",
+      "alt": "Un puesto de comida al aire libre con un toldo blanco de lona, mesas y sillas plásticas, entre palmeras y suelo de tierra; la fotografía tiene un tono envejecido con matices verdosos y anaranjados.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15093,7 +15093,7 @@
       "serie": "archivo",
       "orden": 489,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ninguna de las sillas combina con la de al lado —azules, rojas, plateadas— y aun así cada mesa vacía tiene sus cuatro puestas en el orden exacto de siempre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15107,8 +15107,8 @@
         "generacion": "ef172ec5-fbe5-483e-8b13-309ad254218a",
         "variante": 2
       },
-      "titulo": "Liminal image of a restaurant postcard in the",
-      "alt": "liminal image of a restaurant postcard in the style of 1990s",
+      "titulo": "Las sillas que no combinan",
+      "alt": "Interior de un restaurante vacío con mesas y sillas de distintos colores y estilos, piso rojo, y afiches y calendarios colgados en la pared del fondo; la imagen tiene una textura pictórica y borrosa.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15124,7 +15124,7 @@
       "serie": "archivo",
       "orden": 490,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva soldadas sobre los ojos dos placas de circuito verde tan densas que en vez de parpadear parece que procesa cada segundo que pasa frente a él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15138,8 +15138,8 @@
         "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392",
         "variante": 2
       },
-      "titulo": "Low shot of",
-      "alt": "Low shot of",
+      "titulo": "El visor de circuitos",
+      "alt": "Retrato de una persona con el cabello oscuro peinado hacia atrás, que lleva unos anteojos hechos de placas de circuito electrónico verde sobre los ojos, cuello blanco alto y chaqueta oscura con adornos dorados, sobre fondo negro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15155,7 +15155,7 @@
       "serie": "archivo",
       "orden": 491,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene el rostro conectado a un manojo de cables que le sale de la sien izquierda, y respira tan despacio recostado en el cojín verde que ninguno de los cables se mueve ni un milímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15169,8 +15169,8 @@
         "generacion": "3d6e4044-949c-4e1d-94a7-011f41b0d392",
         "variante": 3
       },
-      "titulo": "Low shot of",
-      "alt": "Low shot of",
+      "titulo": "Los cables de la sien",
+      "alt": "Una persona joven de cabello claro está recostada con los ojos cerrados sobre un cojín verde y una manta morada, con varios cables conectados a la cabeza y vistiendo una chaqueta blanca con adornos dorados.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15186,7 +15186,7 @@
       "serie": "archivo",
       "orden": 492,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La corona le cubre la cabeza con tantas perlas cosidas una a una que ya pesa lo mismo que el libro de tapa enjoyada que sostiene con la otra mano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15200,8 +15200,8 @@
         "generacion": "7b37ca9b-1f7f-4829-8f33-396433eea4c8",
         "variante": 2
       },
-      "titulo": "Low shot of",
-      "alt": "Low shot of",
+      "titulo": "La corona de perlas conectada",
+      "alt": "Una persona con los ojos cerrados lleva una corona bordada con perlas y una túnica verde y dorada muy adornada, con cables conectados a la cabeza, mientras sostiene un libro de tapa enjoyada con una mano.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15217,7 +15217,7 @@
       "serie": "archivo",
       "orden": 493,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un cilindro de metal cuelga apenas a dos dedos de su frente, y lleva tantas horas fijo en ese mismo punto que ya no hace falta que nadie lo sostenga.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15231,8 +15231,8 @@
         "generacion": "c969b056-b482-4232-840d-87865b01c3d1",
         "variante": 0
       },
-      "titulo": "Low shot of",
-      "alt": "Low shot of",
+      "titulo": "El aparato sobre la almohada",
+      "alt": "Una persona joven recostada sobre un cojín verde y una manta morada tiene la cabeza conectada por cables a un dispositivo metálico cilíndrico suspendido justo encima, y viste una chaqueta blanca con adornos dorados.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15248,7 +15248,7 @@
       "serie": "archivo",
       "orden": 494,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cientos de piezas diminutas y brillantes forman el casco que lleva puesto, tan pulidas que en cada una cabe, en miniatura, todo lo que tiene delante.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15262,8 +15262,8 @@
         "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163",
         "variante": 1
       },
-      "titulo": "Low shot of martian film the scene shows",
-      "alt": "Low shot of martian film the scene shows a man in formal atti",
+      "titulo": "El casco de espejos",
+      "alt": "Una persona con gafas oscuras lleva un casco cubierto de piezas brillantes y una chaqueta verde y dorada con bordado de perlas, vista de perfil sobre un fondo oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15279,7 +15279,7 @@
       "serie": "archivo",
       "orden": 495,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se enrolla en la cabeza tantas cadenas de cuentas plateadas que si las estirara todas en línea recta le darían tres vueltas completas al cuello del abrigo verde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15293,8 +15293,8 @@
         "generacion": "2ad60863-9bc3-4bb0-8bd8-7aae93a2c163",
         "variante": 3
       },
-      "titulo": "Low shot of martian film the scene shows",
-      "alt": "Low shot of martian film the scene shows a man in formal atti",
+      "titulo": "Las cadenas enrolladas",
+      "alt": "Una persona de perfil lleva la cabeza envuelta en cadenas de cuentas plateadas y una chaqueta verde y dorada con detalles de perlas, sobre un fondo oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15310,7 +15310,7 @@
       "serie": "archivo",
       "orden": 496,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El visor le cruza la frente entera armado con decenas de piezas diminutas y cables soldados, y bajo esa maraña metálica el cráneo rapado no deja ver un centímetro de piel.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15324,8 +15324,8 @@
         "generacion": "f0eed234-165d-4750-9da3-29691eda4ae6",
         "variante": 1
       },
-      "titulo": "Low shot of student in formal attire from",
-      "alt": "Low shot of student in formal attire from the martian navy sc",
+      "titulo": "La frente armada de cables",
+      "alt": "Una persona de cabeza rapada lleva un visor hecho de piezas metálicas y cables que le cubre la frente y los ojos, con cuello blanco alto y chaqueta morada, sobre un fondo oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15341,7 +15341,7 @@
       "serie": "archivo",
       "orden": 497,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El fósforo asoma su cabeza de ceniza sobre el mar y tarda tres mareas en apagarse, mientras la fruta partida bajo la manzana-luna gotea semillas rojas sobre el agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15355,8 +15355,8 @@
         "generacion": "4c5b73b1-7e00-4c4c-b3f3-c6a944162896",
         "variante": 0
       },
-      "titulo": "Lunar Punk Green Goblin under a Big Red",
-      "alt": "Lunar Punk Green Goblin under a Big Red and Green mushroom",
+      "titulo": "El fósforo junto al mar",
+      "alt": "Ilustración con una manzana verde brillante en la parte superior como una luna, una fruta partida por la mitad con pulpa rosada flotando sobre agua azul oscuro, y un fósforo gigante de cabeza gris y palo naranja a la derecha.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -15371,7 +15371,7 @@
       "serie": "archivo",
       "orden": 498,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El marco dorado se garabatea a mano alrededor del cartel, y los faros del callejón detrás siguen encendidos aunque la fotografía tenga treinta años de grano azul.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15385,8 +15385,8 @@
         "generacion": "9f8a2b1e-a1e7-4529-ab54-058162c2ff26",
         "variante": 1
       },
-      "titulo": "Magazine font title for Curiana Radio 90s print",
-      "alt": "Magazine font title for Curiana Radio 90s print style",
+      "titulo": "Rótulo de neón pixelado",
+      "alt": "Imagen de título con el texto 'Curiana Radio' en letras amarillas grandes y rosadas pequeñas, sobre una fotografía nocturna azulada de una calle borrosa con luces, todo enmarcado por un borde dorado dibujado a mano tipo revista de los años noventa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -15402,7 +15402,7 @@
       "serie": "archivo",
       "orden": 499,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pantalla circular del centro repite el mismo pulso azul desde hace siete turnos, y ningún tripulante levanta la vista de sus propios once monitores encendidos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15416,8 +15416,8 @@
         "generacion": "794b6938-e74e-4405-b01e-f861d447e8a3",
         "variante": 0
       },
-      "titulo": "Main deck of a Intergalactic Freighter Navigation chart",
-      "alt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+      "titulo": "La sala de pantallas azules",
+      "alt": "Sala de control futurista y oscura con varias personas sentadas frente a consolas con pantallas azules brillantes, y una pantalla circular grande en el centro con un gráfico luminoso.",
       "w": 1400,
       "h": 700,
       "anchos": [
@@ -15433,7 +15433,7 @@
       "serie": "archivo",
       "orden": 500,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuatro siluetas se recortan contra el ventanal blanco, y la luz que entra por el cristal borra el horizonte hasta que no queda mar, solo una hoja en blanco de sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15447,8 +15447,8 @@
         "generacion": "b7931fda-ebab-4c8f-8119-1946280088b9",
         "variante": 0
       },
-      "titulo": "Main deck of a Intergalactic Freighter Navigation chart",
-      "alt": "Main deck of a Intergalactic Freighter Navigation chart admin",
+      "titulo": "La tripulación mirando el resplandor",
+      "alt": "Interior de un puente de mando con cuatro personas de pie, vistas de espaldas en silueta, frente a un gran ventanal muy iluminado que muestra un cielo y mar brillantes, con pantallas pequeñas encendidas en los paneles de control.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -15464,7 +15464,7 @@
       "serie": "archivo",
       "orden": 501,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mano se acerca tanto al lente que borra cuatro de sus cinco dedos, y el fondo rojo detrás de la mirada no ha bajado de temperatura en lo que va del retrato.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15478,8 +15478,8 @@
         "generacion": "42d93de0-5ba1-49fa-a639-884cb7119e4f",
         "variante": 3
       },
-      "titulo": "Man practicing Kung Fu in a Traditional Shaolin",
-      "alt": "Man practicing Kung Fu in a Traditional Shaolin Dojo in the s",
+      "titulo": "La mano contra el lente",
+      "alt": "Retrato de un hombre joven de cabello oscuro y rizado, mirando fijamente a la cámara, con una mano extendida y borrosa en primer plano como si tocara el lente, sobre un fondo rojo intenso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15524,7 +15524,7 @@
       "serie": "archivo",
       "orden": 503,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los dos sombreros llevan tanta nieve en el ala que parecen llevar el invierno entero encima, mientras miran una sierra que no ha cambiado de sitio en blanco y negro desde hace un siglo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15538,8 +15538,8 @@
         "generacion": "940f9ae4-6d68-4d13-82ef-05a7d5862d0f",
         "variante": 1
       },
-      "titulo": "Men in hats standing on snow next to",
-      "alt": "men in hats standing on snow next to mountains in the style o",
+      "titulo": "Sombreros frente a la sierra",
+      "alt": "Fotografía en blanco y negro de dos hombres con abrigo oscuro y sombrero, de pie sobre nieve, mirando hacia una cadena de montañas rocosas bajo un cielo nublado.",
       "w": 1264,
       "h": 944,
       "anchos": [
@@ -15555,7 +15555,7 @@
       "serie": "archivo",
       "orden": 504,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Del punto blanco del centro salen ondas que se repiten cien veces hacia cada lado sin perder el ritmo, y las líneas rojas cosen el cielo justo por encima del perfil oscuro de la montaña.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15569,8 +15569,8 @@
         "generacion": "5448c501-cdee-4905-8edd-26100961919e",
         "variante": 3
       },
-      "titulo": "Minimalist logo for pulse an asistant for keeping",
-      "alt": "minimalist logo for pulse an asistant for keeping track your",
+      "titulo": "El pulso sobre la montaña",
+      "alt": "Ilustración minimalista con un punto de luz blanca en el centro rodeado de ondas concéntricas horizontales, cruzado por finas líneas rojas, sobre un fondo azul oscuro con la silueta de una montaña y el mar en la parte inferior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15586,7 +15586,7 @@
       "serie": "archivo",
       "orden": 505,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La onda dibuja dos jorobas de luz hechas de puntos sueltos, y ninguno de esos puntos toca al de al lado aunque el negro alrededor los junte a todos en la misma curva.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15600,8 +15600,8 @@
         "generacion": "abfc611c-0a19-493d-adc5-6a7728a30c4d",
         "variante": 0
       },
-      "titulo": "Minimalist logo in the shape of wave lenghts",
-      "alt": "minimalist logo in the shape of wave lenghts with quirky and",
+      "titulo": "La onda en la oscuridad",
+      "alt": "Logotipo minimalista de una onda sonora en forma de dos curvas conectadas, hecha de puntos de luz blanca, amarilla y verde, sobre un fondo completamente negro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15617,7 +15617,7 @@
       "serie": "archivo",
       "orden": 506,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El único cuadro naranja de la pared lleva encendido su color desde antes de que pintaran el resto del cuarto de azul, y la luz de la ventana solo calienta la mitad de la alfombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15631,8 +15631,8 @@
         "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341",
         "variante": 1
       },
-      "titulo": "Minimalist monochromatic for pulse an asistant for keeping",
-      "alt": "minimalist monochromatic for pulse an asistant for keeping tr",
+      "titulo": "El cuarto azul en penumbra",
+      "alt": "Habitación pintada de azul con un cuadro naranja abstracto en la pared izquierda, un cuadro en blanco en la derecha, una ventana con cortina que muestra montañas, un aparato oscuro alto con pantalla y una silla de madera, con una alfombra en el piso.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15648,7 +15648,7 @@
       "serie": "archivo",
       "orden": 507,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La línea de pulso azul le atraviesa la cara y la blusa a rayas sin desviarse un milímetro, y justo sobre la frente da su salto más alto de la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15662,8 +15662,8 @@
         "generacion": "94d3370b-587d-4e91-b55c-40abf64e0341",
         "variante": 2
       },
-      "titulo": "Minimalist monochromatic for pulse an asistant for keeping",
-      "alt": "minimalist monochromatic for pulse an asistant for keeping tr",
+      "titulo": "El pulso cruza su rostro",
+      "alt": "Retrato de una mujer con peinado de los años cincuenta y blusa a rayas, iluminada en tonos cálidos, con una línea de electrocardiograma azul brillante superpuesta que le cruza el rostro y el cuerpo sobre un fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -15679,7 +15679,7 @@
       "serie": "archivo",
       "orden": 508,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La capa roja es lo único que tiene color en todo el desierto, y la sombra del disco que flota encima le cabe en el cuerpo sin que se le mueva un pliegue de tela.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15693,8 +15693,8 @@
         "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
         "variante": 0
       },
-      "titulo": "Minimalist science fiction magazine cover photography",
-      "alt": "Minimalist science fiction magazine cover photography",
+      "titulo": "Capa roja bajo la nave",
+      "alt": "Persona con capa roja y capucha de pie en un desierto rocoso, mirando hacia una enorme nave o disco oscuro y texturizado que flota en el cielo verde azulado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15710,7 +15710,7 @@
       "serie": "archivo",
       "orden": 509,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna verde se deja ver solo a medias detrás del pico más alto, y la escarcha blanca le cubre la roca entera como si nunca hubiera dejado de nevar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15724,8 +15724,8 @@
         "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
         "variante": 1
       },
-      "titulo": "Minimalist science fiction magazine cover photography",
-      "alt": "Minimalist science fiction magazine cover photography",
+      "titulo": "Luna verde sobre los picos",
+      "alt": "Paisaje rocoso de otro planeta con picos oscuros y afilados cubiertos de escarcha blanca, bajo un cielo verde con una gran luna o planeta en fase creciente.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15741,7 +15741,7 @@
       "serie": "archivo",
       "orden": 510,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol rojo es un círculo tan perfecto que parece recortado con tijera, y su color se derrama camino abajo hasta teñir de rosa las botas de los dos que caminan hacia él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15755,8 +15755,8 @@
         "generacion": "2b2906ce-0e5b-4892-be76-17e9da4b8245",
         "variante": 2
       },
-      "titulo": "Minimalist science fiction magazine cover photography",
-      "alt": "Minimalist science fiction magazine cover photography",
+      "titulo": "Dos siluetas frente al sol",
+      "alt": "Dos personas caminan en silueta hacia un gran sol o círculo rojo sobre un paisaje rocoso desértico bajo un cielo verde azulado, con el camino teñido de rosa por el reflejo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15772,7 +15772,7 @@
       "serie": "archivo",
       "orden": 511,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El halo blanco dibuja un anillo tan ancho que no cabe entero en la vista, y la persona de abajo apenas le llega al tobillo con la sombra de su propio cuerpo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15786,8 +15786,8 @@
         "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c",
         "variante": 2
       },
-      "titulo": "Minimalist science fiction magazine cover photography",
-      "alt": "Minimalist science fiction magazine cover photography",
+      "titulo": "El halo sobre la duna",
+      "alt": "Fotografía en blanco y negro de una persona de pie en silueta dentro de un paisaje árido, mirando hacia un enorme halo o anillo de luz que domina el cielo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15803,7 +15803,7 @@
       "serie": "archivo",
       "orden": 512,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La grieta roja del monolito es la única luz que la niebla no se atreve a tragarse, y la figura que la mira desde abajo no le llega ni a la mitad de la base.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15817,8 +15817,8 @@
         "generacion": "53702410-1d54-47cc-8e79-6ca3caad0f0c",
         "variante": 3
       },
-      "titulo": "Minimalist science fiction magazine cover photography",
-      "alt": "Minimalist science fiction magazine cover photography",
+      "titulo": "Grieta roja en la niebla",
+      "alt": "Persona de pie envuelta en niebla azulada, frente a una estructura oscura en forma de triángulo con una franja de luz roja vertical en su interior, sobre un terreno rocoso.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -15834,7 +15834,7 @@
       "serie": "archivo",
       "orden": 513,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se le cuentan uno a uno los colmillos mientras aúlla, y la luna se ha corrido tanto hacia la esquina del cuadro que parece que intenta salirse del retrato.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15848,8 +15848,8 @@
         "generacion": "2c992c98-303e-4c56-8e9b-8fa822fb4df3",
         "variante": 0
       },
-      "titulo": "Movie cinematic still of a medium sh",
-      "alt": "Movie cinematic still of a medium sh",
+      "titulo": "Colmillos bajo la luna fría",
+      "alt": "Primer plano de un hombre lobo peludo aullando con la boca abierta y los colmillos a la vista, en tonos azules fríos, con una luna llena parcialmente visible en la esquina superior derecha.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -15865,7 +15865,7 @@
       "serie": "archivo",
       "orden": 514,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "A la luna se le corrió el rojo como si alguien la hubiera rozado con la misma zarpa que le tiñó el pecho al lobo, y ninguno de los dos colores ha terminado de secar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15879,8 +15879,8 @@
         "generacion": "08b62b1e-aa5a-4fca-ae44-af596fecbe00",
         "variante": 3
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "La luna manchada de rojo",
+      "alt": "Hombre lobo oscuro aullando con manchas rojizas en el pecho y el hocico, junto a una luna llena con tonos rojos como sangre, entre árboles oscuros por la noche.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -15896,7 +15896,7 @@
       "serie": "archivo",
       "orden": 515,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De toda la oscuridad del lobo solo se le enciende un punto, el ojo, y ese punto rojo pesa más en la imagen que la luna entera detrás de él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15910,8 +15910,8 @@
         "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82",
         "variante": 1
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Ojo rojo entre la sombra",
+      "alt": "Primer plano de un hombre lobo negro gruñendo con un ojo rojo brillante, frente a una luna llena rosada, rodeado de ramas oscuras de árboles.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -15927,7 +15927,7 @@
       "serie": "archivo",
       "orden": 516,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los hombros del lobo son tan anchos que le tapan medio bosque detrás, y cada pelo del lomo se le para por separado como si contara los segundos hasta la luna llena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15941,8 +15941,8 @@
         "generacion": "3f7f6f89-c45a-484b-bec4-8f09f228cb82",
         "variante": 3
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Hombros que tapan el bosque",
+      "alt": "Hombre lobo negro visto de hombros hacia arriba, gruñendo con el pelaje erizado, un ojo rojo brillante, frente a una luna llena rosada entre árboles oscuros.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -15958,7 +15958,7 @@
       "serie": "archivo",
       "orden": 517,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le pintaron el pelaje con pinceladas moradas que no existen en ningún lobo real, y echa tanto la cabeza atrás para aullar que la nuca casi le toca la espalda.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -15972,8 +15972,8 @@
         "generacion": "4ae21d91-3328-4b9c-adc0-7be61f5f3374",
         "variante": 0
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "El aullido pintado de violeta",
+      "alt": "Ilustración de un hombre lobo aullando con la cabeza echada hacia atrás, pelaje oscuro con reflejos morados, ramas secas de árboles alrededor y una luna amarilla pálida al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -15989,7 +15989,7 @@
       "serie": "archivo",
       "orden": 518,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las ramas secas se cierran alrededor del lobo y la luna como un marco que alguien talló a propósito, y ninguna rama se anima a cruzar el círculo rosado de luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16003,8 +16003,8 @@
         "generacion": "6ca482c8-4536-4657-b5ba-eaef74169a3a",
         "variante": 0
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Ramas que enmarcan la luna",
+      "alt": "Hombre lobo aullando con un ojo rojo brillante, enmarcado por ramas oscuras de árboles a los costados, frente a una luna llena de tono rosado.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -16020,7 +16020,7 @@
       "serie": "archivo",
       "orden": 519,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Solo dos cosas del lobo resisten la oscuridad, el ojo rojo y la luna, y entre las dos no juntan luz suficiente para dibujarle el resto del pelaje.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16034,8 +16034,8 @@
         "generacion": "8df90112-475a-416b-8a79-690972131c3b",
         "variante": 1
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Silueta negra, un solo ojo",
+      "alt": "Silueta casi completamente negra de un hombre lobo aullando, con un ojo rojo brillante como único detalle visible, frente a una luna amarilla en la esquina superior derecha, en formato vertical.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16050,7 +16050,7 @@
       "serie": "archivo",
       "orden": 520,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las garras delanteras se le quedan justo en el borde de la roca, sin pasarse ni un centímetro, mientras el resto del cuerpo se estira entero hacia la luna amarilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16064,8 +16064,8 @@
         "generacion": "d49b413f-6e77-4d2d-99ea-12f5d6a71cdb",
         "variante": 2
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Al borde del risco",
+      "alt": "Hombre lobo de pelaje oscuro con tonos rojizos, de pie sobre el borde de una roca o risco, aullando hacia una luna amarilla, con ramas de árboles alrededor.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -16081,7 +16081,7 @@
       "serie": "archivo",
       "orden": 521,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se yergue tan derecho sobre dos patas que desde abajo parece más alto que los árboles que lo rodean, y el pecho se le hincha con cada nota del aullido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16095,8 +16095,8 @@
         "generacion": "f33e029e-7429-47dd-94fb-f5a7a5a44519",
         "variante": 3
       },
-      "titulo": "Movie still of a medium shot grim sc",
-      "alt": "Movie still of a medium shot grim sc",
+      "titulo": "Más alto que los árboles",
+      "alt": "Hombre lobo musculoso de pie sobre dos patas, visto desde un ángulo bajo, aullando hacia una luna amarilla rodeada de siluetas de árboles.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -16112,7 +16112,7 @@
       "serie": "archivo",
       "orden": 522,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Abre los brazos tanto que las garras le llegan a los árboles de los dos costados a la vez, y en medio de ese abrazo imposible sigue aullando sin bajar la cabeza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16126,8 +16126,8 @@
         "generacion": "7d1a34b0-9126-451a-8bc0-bae578a12c12",
         "variante": 0
       },
-      "titulo": "Movie still of a medium shot grim scene",
-      "alt": "Movie still of a medium shot grim scene a hairy terrifying an",
+      "titulo": "Brazos abiertos hacia la luna",
+      "alt": "Hombre lobo de cuerpo completo con los brazos y garras extendidos hacia los lados, aullando bajo una luna blanca amarillenta, en tonos azulados de noche.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -16143,7 +16143,7 @@
       "serie": "archivo",
       "orden": 523,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Empuña la espada envainada de cara al mar, y desde el hombro hasta la mandíbula la luz azul lleva grabada la misma marea desde hace tres siglos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16157,8 +16157,8 @@
         "generacion": "30802e38-5fec-4fd3-9672-d6896b97f6f9",
         "variante": 2
       },
-      "titulo": "Mulato Man with dark skin wears a vintage",
-      "alt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+      "titulo": "Espada frente al mar",
+      "alt": "Retrato de un hombre de piel morena con cabello largo y ondulado, mitad del rostro iluminada en azul, vestido con una prenda azul oscuro tipo túnica, con una espada envainada sobre el hombro y el mar de fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -16174,7 +16174,7 @@
       "serie": "archivo",
       "orden": 524,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene la cara partida en dos luces, la mitad tibia y la mitad azul marino, y ninguna de las dos gana terreno aunque lleve toda una vida de espaldas al sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16188,8 +16188,8 @@
         "generacion": "3ae49587-138d-4618-b088-54749c8dedc6",
         "variante": 1
       },
-      "titulo": "Mulato Man with dark skin wears a vintage",
-      "alt": "Mulato Man with dark skin wears a vintage whaler coat from 15",
+      "titulo": "La mitad azul del rostro",
+      "alt": "Retrato frontal de un hombre de piel morena con cabello largo suelto, rostro iluminado con luz cálida de un lado y azul del otro, vestido con una prenda azul oscuro de cuello alto, con el mar al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -16205,7 +16205,7 @@
       "serie": "archivo",
       "orden": 525,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva puesto un chaleco tejido con cuentas de todos los colores del mercado y los audífonos blancos le tapan tanto los oídos que ya no escucha nada que no sea la propia música.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16219,8 +16219,8 @@
         "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba",
         "variante": 0
       },
-      "titulo": "Music Magazine cover of a futuristic Caqueto Woman",
-      "alt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+      "titulo": "Auriculares sobre el telar",
+      "alt": "Retrato de una mujer de piel morena con el cabello trenzado, gafas oscuras cubriéndole los ojos, audífonos blancos grandes y un chaleco tejido con cuentas de colores vivos, sobre fondo negro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -16235,7 +16235,7 @@
       "serie": "archivo",
       "orden": 526,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar de cuentas rojas y turquesas le sube por el cuello capa sobre capa, tantas vueltas que ya no se sabe dónde empieza el bordado y dónde termina la garganta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16249,8 +16249,8 @@
         "generacion": "a1101b34-6e5f-4f1c-9886-3e19dd6893ba",
         "variante": 3
       },
-      "titulo": "Music Magazine cover of a futuristic Caqueto Woman",
-      "alt": "Music Magazine cover of a futuristic Caqueto Woman with color",
+      "titulo": "Cuentas rojas en capas",
+      "alt": "Retrato de una mujer joven con flequillo, gafas verdes rectangulares, audífonos blancos, un collar de cuentas de colores en capas y una prenda rosa y turquesa bordada, sobre fondo negro con textura granulada.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -16265,7 +16265,7 @@
       "serie": "archivo",
       "orden": 527,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cartel rojo y amarillo descansa apoyado sobre el radio como si fuera una antena, y desde ahí lleva sintonizada la misma frecuencia sin moverse un centímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16279,8 +16279,8 @@
         "generacion": "dc2600db-f27a-4e30-af7c-6470afce0c3a",
         "variante": 3
       },
-      "titulo": "Music Magazine Curiana Radio title type in 90s",
-      "alt": "Music Magazine Curiana Radio title type in 90s style -",
+      "titulo": "Curiana Radio sobre el dial",
+      "alt": "Fotografía de un radio receptor vintage color crema sobre una mesa roja, con un cartel rojo y amarillo que dice Curiana Radio apoyado encima, cables sueltos y un disco de vinilo al lado, contra una pared turquesa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -16296,7 +16296,7 @@
       "serie": "archivo",
       "orden": 528,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se cubre la cabeza con un tocado de plumas que pesa como si cargara todos los pájaros que las soltaron, y aun así se ajusta los audífonos sin que se le mueva una sola.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16310,8 +16310,8 @@
         "generacion": "ce96d707-2dca-4858-b7f2-baae83bfd8d2",
         "variante": 3
       },
-      "titulo": "Music Magazine titled Curiana Radio",
-      "alt": "Music Magazine titled Curiana Radio",
+      "titulo": "Plumas y auriculares",
+      "alt": "Portada de revista con el título Curiana Radio en letras amarillas, con la imagen de una persona con tocado de plumas, pintura facial roja, audífonos y ropa de flecos color canela, sentada sobre rocas frente a una bahía tropical.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -16326,7 +16326,7 @@
       "serie": "archivo",
       "orden": 529,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz roja se queda encendida en la azotea mientras la lluvia raya el cielo entero de arriba abajo, y ya lleva tantas noches ahí que se volvió parte del techo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16340,8 +16340,8 @@
         "generacion": "06c61482-495c-4a2f-93a9-f52c6ff58ecc",
         "variante": 1
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "titulo": "El farol bajo la lluvia",
+      "alt": "Vista nocturna de una azotea bajo lluvia intensa, con una luz roja encendida en primer plano y el perfil de edificios iluminados de una ciudad al fondo, bajo un cielo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16357,7 +16357,7 @@
       "serie": "archivo",
       "orden": 530,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El edificio se estira tanto hacia las nubes moradas que termina por rozarlas, mientras abajo los carros hacen fila como si nada, ajenos a la altura que cargan encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16371,8 +16371,8 @@
         "generacion": "0d45fa0b-5eb6-4f01-98e3-4cab0721464b",
         "variante": 0
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s arawak socei",
+      "titulo": "La torre contra las nubes",
+      "alt": "Fotografía de un edificio residencial alto iluminado al atardecer, con nubes azules y moradas de fondo, autos y palmeras en la calle frente al edificio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16388,7 +16388,7 @@
       "serie": "archivo",
       "orden": 531,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El camino de luces rojas baja directo hacia las montañas mientras un marco de manchas como piel de fiera envuelve la postal entera, dispuesto a guardarla otro siglo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16402,8 +16402,8 @@
         "generacion": "1cf26918-afe3-4d55-9408-067af333cd09",
         "variante": 1
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "titulo": "La avenida enmarcada en leopardo",
+      "alt": "Postal con borde decorativo de manchas rojas y verdes tipo piel animal, con una fotografía de una avenida urbana al atardecer, tráfico con luces rojas, edificios altos y montañas al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16419,7 +16419,7 @@
       "serie": "archivo",
       "orden": 532,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los faros de los carros se estiran en hilos de colores por toda la avenida, tan largos que parece que ningún carro haya llegado a frenar todavía esta noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16433,8 +16433,8 @@
         "generacion": "1cf26918-afe3-4d55-9408-067af333cd09",
         "variante": 2
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "titulo": "Los hilos de luz",
+      "alt": "Vista aérea nocturna de una avenida urbana con estelas de luces de colores dejadas por el tráfico, edificios y vallas publicitarias iluminadas a los lados, bajo un cielo azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16450,7 +16450,7 @@
       "serie": "archivo",
       "orden": 533,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El carro cruza la avenida entera teñido de un rojo tan parejo que hasta el asfalto se pinta del mismo color, como si la ciudad completa ardiera despacio esa noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16464,8 +16464,8 @@
         "generacion": "398b77bf-98cb-4f6e-b588-aa7609a52adf",
         "variante": 1
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "titulo": "El sedán bañado en rojo",
+      "alt": "Fotografía nocturna con tono rojo intenso de una calle de ciudad, con un automóvil sedán en primer plano, edificios iluminados, letreros de neón y tráfico al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16481,7 +16481,7 @@
       "serie": "archivo",
       "orden": 534,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los letreros le cubren toda la fachada de arriba abajo, tantos y tan juntos que la calle mojada de enfrente se los bebe enteros sin dejar uno solo sin reflejo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16495,8 +16495,8 @@
         "generacion": "85c7980f-5ace-498f-8d46-5bda23a6728c",
         "variante": 3
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "titulo": "El edificio derramado en neón",
+      "alt": "Fotografía nocturna de un edificio comercial cubierto de grandes letreros de neón con caracteres asiáticos y símbolos de colores, con reflejos sobre la calle mojada.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16512,7 +16512,7 @@
       "serie": "archivo",
       "orden": 535,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La neblina se traga los rascacielos del fondo casi por completo, y solo la camioneta estacionada al frente se salva del naranja espeso que cubre la calle entera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16526,8 +16526,8 @@
         "generacion": "9a5e59c0-5e33-4ca3-8801-e7a6cd89d3f2",
         "variante": 0
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s venezuelan p",
+      "titulo": "La camioneta entre la niebla",
+      "alt": "Fotografía nocturna con tono naranja de una calle con neblina, una camioneta estacionada en primer plano y rascacielos iluminados difuminados por la bruma al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16543,7 +16543,7 @@
       "serie": "archivo",
       "orden": 536,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las dos torres se alzan tan rojas sobre la ciudad que parecen dos brasas paradas, y abajo miles de ventanas encendidas hacen de chispas que nunca llegan a apagarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16557,8 +16557,8 @@
         "generacion": "9dc8b50c-68ce-46e6-9d4e-f363aa695651",
         "variante": 2
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 2000s arawak socei",
+      "titulo": "Dos torres ardiendo",
+      "alt": "Vista aérea nocturna de dos torres residenciales altas iluminadas en tono rojo anaranjado, rodeadas de una ciudad extensa con luces del mismo color hasta el horizonte.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16574,7 +16574,7 @@
       "serie": "archivo",
       "orden": 537,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina de espaldas por el callejón mojado con un abrigo tan blanco que hasta los letreros rojos a los lados se apagan un poco para dejarlo pasar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16588,8 +16588,8 @@
         "generacion": "a1069948-d882-4469-840b-8e3d1c2bbeac",
         "variante": 2
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "titulo": "El abrigo blanco",
+      "alt": "Fotografía nocturna de un callejón estrecho con letreros de neón y caracteres asiáticos, una persona con abrigo blanco caminando de espaldas sobre el pavimento mojado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16605,7 +16605,7 @@
       "serie": "archivo",
       "orden": 538,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La autopista se curva entera en un solo trazo rojo que no se corta ni un segundo, como si todos los carros de la noche hubieran salido a la misma hora exacta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16619,8 +16619,8 @@
         "generacion": "cf4db9a0-90b7-45c3-986a-696b70774dba",
         "variante": 3
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s venezuelan p",
+      "titulo": "La curva de luces rojas",
+      "alt": "Vista aérea nocturna de una autopista curva con estelas de luces rojas de tráfico, con el horizonte de una ciudad iluminada al fondo y árboles oscuros en primer plano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16636,7 +16636,7 @@
       "serie": "archivo",
       "orden": 539,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cúpulas doradas se quedan encendidas sobre el cuerpo azul del edificio mientras abajo los carros pasan tan rápido que se vuelven líneas, y ni una sola luz se mueve un milímetro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16650,8 +16650,8 @@
         "generacion": "e117d47b-22df-4129-8735-da73bb249e18",
         "variante": 2
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s arawak socei",
+      "titulo": "El domo azul",
+      "alt": "Fotografía nocturna de un edificio de arquitectura con cúpulas doradas iluminado de azul, con tráfico en movimiento borroso en la avenida frente a él y letreros luminosos alrededor.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16667,7 +16667,7 @@
       "serie": "archivo",
       "orden": 540,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La gente cruza la calle entera bajo un techo de letreros y bombillos que cuelgan tan bajo que casi les rozan la cabeza, y nadie levanta la vista para mirarlos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16681,8 +16681,8 @@
         "generacion": "f2cfba9b-5587-4951-9bf4-6df6467d23b7",
         "variante": 2
       },
-      "titulo": "Night in the city postcard in the style",
-      "alt": "night in the city postcard in the style of 1970s japanese pho",
+      "titulo": "La calle que camina",
+      "alt": "Fotografía nocturna de una calle peatonal concurrida con personas caminando, letreros de neón con caracteres asiáticos y luces colgantes, en tonos azules y rojos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16698,7 +16698,7 @@
       "serie": "archivo",
       "orden": 541,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta en la orilla con las piernas cruzadas frente a dos canoas ancladas que no se mueven ni un centímetro, como si el mar entero contuviera la respiración por él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16712,8 +16712,8 @@
         "generacion": "020002d0-d027-4a46-af2c-552c8ccc170e",
         "variante": 2
       },
-      "titulo": "Night in the sea postcard in the style",
-      "alt": "night in the sea postcard in the style of 2000s arawak soceit",
+      "titulo": "Junto a las canoas",
+      "alt": "Fotografía al atardecer de una persona sentada de espaldas en una playa, con dos canoas de madera flotando cerca de la orilla, una choza con tela verde a un lado y ramas de árbol enmarcando la parte superior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -16757,7 +16757,7 @@
       "serie": "archivo",
       "orden": 543,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La túnica estampada le llega hasta las rodillas y ahí empiezan las piernas de metal, articuladas pieza por pieza, que sostienen el peso entero del cuerpo sin un solo crujido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16771,8 +16771,8 @@
         "generacion": "0ce8227e-dbef-45f1-bd15-c799fb15ff51",
         "variante": 3
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "Las piernas de metal",
+      "alt": "Retrato de una persona con cresta roja, gafas de sol claras, una túnica holgada estampada en verde, naranja y rosa, y piernas protésicas metálicas visibles desde la rodilla hasta zapatillas rojas, sobre un fondo blanco con sombra de palmera.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16787,7 +16787,7 @@
       "serie": "archivo",
       "orden": 544,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La camisa cambia de color con el paso que da, del dorado al verde al rosado, y el brazo de acero que le cuelga al lado no cambia nunca, fiel siempre al mismo gris.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16801,8 +16801,8 @@
         "generacion": "1192c8a4-0c39-48d2-8e2f-f5dc03dce2a4",
         "variante": 2
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "El brazo de acero",
+      "alt": "Retrato de una persona con cabello corto naranja, gafas de sol espejadas, una camiseta holográfica de colores, shorts de mezclilla rotos, un brazo protésico metálico y botas rojas, de pie en un piso de baldosas junto a un edificio de vidrio.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16817,7 +16817,7 @@
       "serie": "archivo",
       "orden": 545,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las botas rojas le suben hasta la pantorrilla con placas de armadura completas, tan pesadas que cada paso debería hundir la acera, y sin embargo camina como si no cargara nada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16831,8 +16831,8 @@
         "generacion": "1a6caa8a-730d-4672-b797-efc7614364ee",
         "variante": 3
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "Botas rojas de una tonelada",
+      "alt": "Retrato de una persona con cabello corto rojo de puntas, gafas de sol, camiseta negra corta con estampado, shorts de mezclilla, un brazo protésico metálico, tatuajes en el otro brazo y botas rojas voluminosas tipo plataforma, recostada contra una pared.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16847,7 +16847,7 @@
       "serie": "archivo",
       "orden": 546,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cadenas le cruzan el pecho en tantas vueltas como bombillos hay encendidos detrás, y desde el amplificador donde está sentada domina el escenario entero sin decir una palabra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16861,8 +16861,8 @@
         "generacion": "775591d8-3271-4dbd-bda6-97cb784d6dcd",
         "variante": 0
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "Cadenas entre luces de escenario",
+      "alt": "Retrato de una persona con cabello corto rizado rojizo, gafas de sol, top oscuro con cadenas y una pieza metálica en el pecho, un brazo con guantelete metálico, sentada sobre un altavoz con luces rojas y verdes de fondo y una cortina detrás.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16877,7 +16877,7 @@
       "serie": "archivo",
       "orden": 547,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se para junto a la columna blanca mientras la palmera del jardín se le mete de reflejo entero en el vidrio de al lado, sin pedir permiso para compartir la foto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16891,8 +16891,8 @@
         "generacion": "7866ae51-0f8a-48f5-a413-73dd41d44e0a",
         "variante": 0
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "El reflejo de la palmera",
+      "alt": "Retrato de una persona con cabello corto naranja, gafas de sol, camiseta holográfica de colores, shorts de mezclilla desgastados, un brazo protésico metálico y botas rojas, de pie junto a una columna blanca frente a un ventanal.",
       "w": 1400,
       "h": 2498,
       "anchos": [
@@ -16908,7 +16908,7 @@
       "serie": "archivo",
       "orden": 548,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El guantelete de metal le descansa sobre la rodilla como si fuera una mascota dormida, mientras los tatuajes le suben por el otro brazo hasta perderse bajo la manga de la camiseta negra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16922,8 +16922,8 @@
         "generacion": "acbe3176-37e1-4505-9099-b10417890bb9",
         "variante": 2
       },
-      "titulo": "Non binary character with Caribbean ancestry a bionic",
-      "alt": "non binary character with Caribbean ancestry a bionic arm and",
+      "titulo": "El guantelete sobre la rodilla",
+      "alt": "Retrato de una persona con cabello corto rojo de puntas, gafas de sol, top negro con estampado, tatuajes en los brazos, un guantelete metálico en una mano, sentada con las piernas abiertas sobre un altavoz, con luces rojas y verdes de fondo.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -16938,7 +16938,7 @@
       "serie": "archivo",
       "orden": 549,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los hilos de plata le cercan el cráneo en veinte vueltas exactas y sintonizan la única emisora que sigue transmitiendo desde 1962.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16952,8 +16952,8 @@
         "generacion": "4af9de2d-4e00-449d-a133-24ba9c551851",
         "variante": 3
       },
-      "titulo": "Nw22o httpss.mj.r",
-      "alt": "nw22o httpss.mj.r",
+      "titulo": "Corona de hilos de plata",
+      "alt": "Retrato de un hombre de piel clara y cabello corto pelirrojo, vestido con traje azul y corbata plateada, con finos hilos plateados curvados alrededor de la cabeza, sobre fondo negro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -16969,7 +16969,7 @@
       "serie": "archivo",
       "orden": 550,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El yelmo le cose mil cuentas de plata alrededor de la cara y ninguna se mueve aunque el viento lleve tres días soplando sin parar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -16983,8 +16983,8 @@
         "generacion": "ae8608b6-ec30-4c67-be93-faec2ffc380b",
         "variante": 3
       },
-      "titulo": "Nw22o httpss.mj.r",
-      "alt": "nw22o httpss.mj.r",
+      "titulo": "Yelmo de cuentas plateadas",
+      "alt": "Retrato de una persona con un tocado ornamentado de cuentas plateadas y bordes verdes, vistiendo una prenda con motivos azules y plateados, sobre fondo oscuro rojizo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -17000,7 +17000,7 @@
       "serie": "archivo",
       "orden": 551,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cúpula de vidrio guarda la última ciudad en pie, y por dentro cae exactamente la misma lluvia que caía antes de que el planeta se pusiera rojo por fuera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17014,8 +17014,8 @@
         "generacion": "2af63a93-a99f-4026-943e-e5e7ff629947",
         "variante": 1
       },
-      "titulo": "O6k Futuristic City inside a Dome in Pla",
-      "alt": "O6k Futuristic City inside a Dome in Pla",
+      "titulo": "Cúpula sobre tierra roja",
+      "alt": "Ciudad futurista con torres y luces verdes dentro de una cúpula transparente, sobre un paisaje rocoso de color rojo, con naves espaciales alrededor y un cielo oscuro estrellado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17031,7 +17031,7 @@
       "serie": "archivo",
       "orden": 552,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El grano cae justo en el centro y empuja veintitrés anillos dorados hacia el borde negro sin gastarse nunca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17045,8 +17045,8 @@
         "generacion": "171de610-1932-48a6-8a7f-00d9ffcc3197",
         "variante": 3
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Anillos de arena dorada",
+      "alt": "Círculos concéntricos dorados sobre fondo negro, como ondas expandiéndose desde un punto central, con el texto Curiana Radio en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17062,7 +17062,7 @@
       "serie": "archivo",
       "orden": 553,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tres gotas cayeron sobre la arena hace un instante y la más grande todavía tiembla, aunque el agua se secó hace mil años.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17076,8 +17076,8 @@
         "generacion": "17dc456a-ea30-416f-b151-240a2204a810",
         "variante": 3
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Tres charcos en la arena",
+      "alt": "Textura de arena dorada con tres patrones de ondas concéntricas, dos pequeños en la parte superior y uno grande en el centro inferior, con el texto Curiana Radio.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -17093,7 +17093,7 @@
       "serie": "archivo",
       "orden": 554,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos espirales de arena se buscan desde extremos opuestos del círculo y llevan girando la una hacia la otra desde antes de que existiera el reloj.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17107,8 +17107,8 @@
         "generacion": "21734978-3411-4927-b504-546e4d7081bd",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "El nudo de dos espirales",
+      "alt": "Círculo formado por dos espirales doradas entrelazadas que se unen en el centro como un corazón, sobre fondo negro, con el texto Curiana Radio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17124,7 +17124,7 @@
       "serie": "archivo",
       "orden": 555,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos oleajes de arena se cruzan en el aire y dejan grabada la marca exacta del segundo en que chocaron, antes de seguir cada uno su camino.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17138,8 +17138,8 @@
         "generacion": "2481fcaa-1f09-4fa3-b4c8-b20e24625878",
         "variante": 2
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Las olas que se cruzan",
+      "alt": "Patrón de ondas doradas y negras entrecruzadas sobre una textura granulada, con un círculo concéntrico en la parte inferior y el logo circular de Curiana Radio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17155,7 +17155,7 @@
       "serie": "archivo",
       "orden": 556,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La montaña se levanta en veinte anillos exactos hasta terminar en una sola punta que roza el borde del cartel sin llegar nunca a tocarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17169,8 +17169,8 @@
         "generacion": "2ec1e10e-7a7d-427f-9091-43a29eb672f1",
         "variante": 2
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "La montaña de anillos",
+      "alt": "Ilustración de una montaña cónica formada por anillos concéntricos de color beige sobre fondo oscuro, con el texto Curiana en rojo arriba y Radio en rojo abajo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17186,7 +17186,7 @@
       "serie": "archivo",
       "orden": 557,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La arena se curva en diez crestas paralelas y todos sus granos devuelven una chispa distinta de luz, como si el sol se hubiera quedado a vivir ahí abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17200,8 +17200,8 @@
         "generacion": "3b16cf33-2706-4492-a4c1-e2b8befe783e",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Duna de arena dorada",
+      "alt": "Vista en primer plano y ángulo bajo de dunas de arena dorada con textura granulada brillante, formando ondas paralelas, con el texto Curiana Radio parcialmente visible.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -17216,7 +17216,7 @@
       "serie": "archivo",
       "orden": 558,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El círculo dibuja una huella digital tan antigua que ya nadie recuerda a quién pertenecía el dedo, y aun así sigue girando hacia su propio centro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17230,8 +17230,8 @@
         "generacion": "434962ca-7c67-460e-826e-fbcd7f04289c",
         "variante": 3
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "La huella que gira sola",
+      "alt": "Círculo con un patrón de espiral que converge en el centro, formando una textura similar a una huella digital en tonos dorados y negros, sobre fondo beige.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17247,7 +17247,7 @@
       "serie": "archivo",
       "orden": 559,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El remolino lleva girando en el mismo punto veinte vueltas completas y todavía no decide si es un agujero o una montaña.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17261,8 +17261,8 @@
         "generacion": "4fe3520b-287c-4e07-87e4-f6a0fcf09410",
         "variante": 2
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Vórtice de arena dorada",
+      "alt": "Espiral de textura granulada en tonos dorados y sepia formando un vórtice, sobre fondo beige claro, con el texto Curiana Radio en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17278,7 +17278,7 @@
       "serie": "archivo",
       "orden": 560,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mitad de arriba quedó lisa como si nunca hubiera soplado el viento, y la de abajo guarda catorce olas que se formaron esa misma tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17292,8 +17292,8 @@
         "generacion": "940edc4d-1bad-429a-bde7-605a2f8c21c3",
         "variante": 3
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "La duna partida en dos",
+      "alt": "Círculo con la mitad superior de arena lisa en degradado y la mitad inferior con líneas de ondas horizontales, en tonos beige y negro, con el texto Curiana Radio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17309,7 +17309,7 @@
       "serie": "archivo",
       "orden": 561,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Arriba giran nueve anillos completos y abajo la arena se extiende en una sola ola ancha, y entre las dos mitades no cae ni un grano de más.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17323,8 +17323,8 @@
         "generacion": "a1db1804-9775-4ce9-af7a-f4db25d22861",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "La espiral sobre la duna",
+      "alt": "Espiral de anillos dorados concéntricos sobre una forma de duna ondulada en la parte inferior, ambas en tonos dorados sobre fondo negro, con el texto Curiana Radio.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17340,7 +17340,7 @@
       "serie": "archivo",
       "orden": 562,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos espirales se cruzan formando una malla de veinte hilos, y ninguno se rompe aunque el círculo entero no deje de girar en direcciones opuestas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17354,8 +17354,8 @@
         "generacion": "ab31399b-9e56-437d-a433-12425ab213ba",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Espirales cruzadas en malla",
+      "alt": "Círculo con dos espirales entrecruzadas formando un patrón de malla en tonos dorados y negros, con textura granulada, sobre fondo beige.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17371,7 +17371,7 @@
       "serie": "archivo",
       "orden": 563,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La tapa de arriba y el cuenco de abajo llevan catorce líneas cada uno y encajan tan justo que ni la línea negra que los separa se mueve.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17385,8 +17385,8 @@
         "generacion": "b47420a9-4b99-42ef-ba8c-df4646a55d05",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "El cuenco y su tapa",
+      "alt": "Dos formas ovaladas con líneas onduladas horizontales en tonos dorados, una arriba a modo de tapa y otra abajo a modo de cuenco, sobre fondo negro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17402,7 +17402,7 @@
       "serie": "archivo",
       "orden": 564,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol amarillo se sienta justo en la cresta de la montaña azul y ahí se queda, sin subir ni bajar, desde la primera vez que alguien miró hacia el oeste.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17416,8 +17416,8 @@
         "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "El sol sobre la duna",
+      "alt": "Círculo amarillo pálido como un sol sobre una montaña de ondas azul marino, con fondo color arena, y el texto Curiana Radio en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17433,7 +17433,7 @@
       "serie": "archivo",
       "orden": 565,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La esfera pierde su forma grano a grano y en el suelo se acomoda en diez círculos perfectos, como si llevara cayendo despacio desde hace un siglo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17447,8 +17447,8 @@
         "generacion": "b8e33fb5-9041-49f3-a81d-7fe470446920",
         "variante": 2
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "La esfera que se disuelve",
+      "alt": "Esfera oscura con textura granulada en degradado que se convierte en ondas concéntricas horizontales en la parte inferior, sobre fondo negro, con el texto Curiana Radio arriba.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17464,7 +17464,7 @@
       "serie": "archivo",
       "orden": 566,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dentro del círculo caben veinte olas de arena exactas y ninguna se sale del borde, aunque el viento sople siempre hacia el mismo lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17478,8 +17478,8 @@
         "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "El círculo de arena ondulada",
+      "alt": "Círculo relleno de textura de arena ondulada horizontal en tonos dorados sobre fondo negro, con el logo circular de Curiana Radio en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17495,7 +17495,7 @@
       "serie": "archivo",
       "orden": 567,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos espirales doradas flotan sobre una malla azul de mil celdas iguales y giran cada una a su ritmo sin chocar nunca entre ellas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17509,8 +17509,8 @@
         "generacion": "bdd5c1a6-fbc1-4cd2-a42e-2bac83182317",
         "variante": 3
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "Espirales sobre malla azul",
+      "alt": "Dos espirales doradas entrelazadas sobre un fondo azul marino con un patrón de malla hexagonal, con el texto Curiana Radio en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17526,7 +17526,7 @@
       "serie": "archivo",
       "orden": 568,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El caparazón guarda catorce vueltas apretadas y descansa sobre una arena que se curva en las mismas líneas, como si el cielo entero girara alrededor de esa sola pieza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17540,8 +17540,8 @@
         "generacion": "e43a51dc-8abe-4ec0-b2b3-821d90b83c46",
         "variante": 1
       },
-      "titulo": "Organic flowing logo for Curiana Radio three main",
-      "alt": "Organic flowing logo for Curiana Radio three main spiral wave",
+      "titulo": "El caparazón bajo las estrellas",
+      "alt": "Esfera oscura con textura de caparazón estriado sobre una superficie de arena con líneas curvas paralelas, bajo un cielo estrellado, con el texto Curiana Radio arriba.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -17556,7 +17556,7 @@
       "serie": "archivo",
       "orden": 569,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le crecen tres ojos y ninguno parpadea, y las llamas rojas que la rodean llevan ardiendo alrededor de su cabeza desde antes de que existiera la primera sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17570,8 +17570,8 @@
         "generacion": "3a24e9ed-2902-4a09-a5a3-6bad7f98d88c",
         "variante": 0
       },
-      "titulo": "Painting of a demon having his eyes on",
-      "alt": "painting of a demon having his eyes on the floor of a room in",
+      "titulo": "La deidad de piel azul",
+      "alt": "Pintura de una figura de piel azul con tres ojos, colmillos visibles y una aureola de llamas rojas alrededor de la cabeza, sosteniendo objetos rituales, sobre fondo oscuro con motivos en espiral.",
       "w": 800,
       "h": 1214,
       "anchos": [
@@ -17586,7 +17586,7 @@
       "serie": "archivo",
       "orden": 570,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La nave atraviesa un remolino partido en dos colores, naranja de un lado y azul del otro, y vuela en línea recta sin que ninguno de los dos la alcance.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17600,8 +17600,8 @@
         "generacion": "08a32afd-360a-49e0-894e-662cdb8a462e",
         "variante": 0
       },
-      "titulo": "Painting of a Spaceship going through a Spacial",
-      "alt": "painting of a Spaceship going through a Spacial Wormhole",
+      "titulo": "La nave en el remolino",
+      "alt": "Pintura de una nave espacial atravesando un vórtice en espiral de colores naranja y azul, con pinceladas texturizadas sobre fondo abstracto.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17617,7 +17617,7 @@
       "serie": "archivo",
       "orden": 571,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El arco de red blanca cruza el cielo entero en una sola curva, y bajo él el campo morado sigue sus surcos exactos, sin torcerse un grado, hacia el horizonte rojo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17631,8 +17631,8 @@
         "generacion": "504ec514-1e20-4385-8933-a21959874894",
         "variante": 0
       },
-      "titulo": "Painting of a Spaceship going through a Spacial",
-      "alt": "painting of a Spaceship going through a Spacial Wormhole",
+      "titulo": "El arco sobre el campo",
+      "alt": "Pintura de un campo de surcos morados bajo un cielo rojo, con una estructura curva en forma de túnel de red blanca sobre el paisaje y siluetas de árboles al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17648,7 +17648,7 @@
       "serie": "archivo",
       "orden": 572,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El jinete cruza frente al caserío al paso lento del caballo, y la sombra de los dos dura lo mismo que tarda el sol en cambiar de lado del techo de paja.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17662,8 +17662,8 @@
         "generacion": "99e1b4fc-1f02-4c92-a5f6-aea4d90aac3d",
         "variante": 1
       },
-      "titulo": "Panorama of a pintoresque scene a young couple",
-      "alt": "Panorama of a pintoresque scene a young couple riding a donke",
+      "titulo": "El jinete frente al caserío",
+      "alt": "Una persona monta a caballo y pasa frente a una construcción rural de techo de paja con una pequeña torre, rodeada de árboles, bajo un cielo azul despejado durante el día.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17679,7 +17679,7 @@
       "serie": "archivo",
       "orden": 573,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El burro trota bajo una luna tan redonda y tan llena que parece haberse detenido solo para alumbrarle el camino hasta la casa con las luces encendidas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17693,8 +17693,8 @@
         "generacion": "b8489318-dbe0-4940-973a-5014ba48b155",
         "variante": 2
       },
-      "titulo": "Panorama of a pintoresque scene a young couple",
-      "alt": "Panorama of a pintoresque scene a young couple riding a donke",
+      "titulo": "El burro bajo la luna",
+      "alt": "Una persona monta un burro de noche frente a una casa con las luces encendidas, bajo una luna llena, con efecto de movimiento en la imagen.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17710,7 +17710,7 @@
       "serie": "archivo",
       "orden": 574,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuelgan bombillos de palmera en palmera hasta cercar el palenque de luz, y la luna se sienta a escuchar en primera fila, junto a los que llegaron con sillas propias.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17724,8 +17724,8 @@
         "generacion": "6debf54a-a74e-44f9-a601-316c10346e19",
         "variante": 0
       },
-      "titulo": "Panorama of a pintoresque scene of a quintet",
-      "alt": "Panorama of a pintoresque scene of a quintet playling boleros",
+      "titulo": "El palenque de las luces",
+      "alt": "Músicos tocan bajo un pabellón de techo de paja iluminado de amarillo, de noche, con luces colgantes entre palmeras y espectadores sentados alrededor bajo un cielo estrellado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17741,7 +17741,7 @@
       "serie": "archivo",
       "orden": 575,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Hilos de luces cruzan la enramada de extremo a extremo hasta fabricarle un cielo propio, y los cinco sombreros se inclinan hacia las cuerdas sin que ninguno alce la vista para comprobarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17755,8 +17755,8 @@
         "generacion": "d94dcb7c-b081-44e0-a7a1-a9c57b6eeb33",
         "variante": 2
       },
-      "titulo": "Panorama of a pintoresque scene of a quintet",
-      "alt": "Panorama of a pintoresque scene of a quintet playling cumbia",
+      "titulo": "El cielo bajo techo",
+      "alt": "Cinco hombres con sombrero tocan guitarra sentados en círculo, de noche, bajo una techumbre cruzada por luces cálidas colgantes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17772,7 +17772,7 @@
       "serie": "archivo",
       "orden": 576,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sostiene una esfera de oro contra la cadera con la misma firmeza con que el otro sostiene la espada, y ninguno de los dos la suelta aunque el cielo se les oscurezca encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17786,8 +17786,8 @@
         "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377",
         "variante": 2
       },
-      "titulo": "Panoramic and cinematic movie still depiction of duel",
-      "alt": "panoramic and cinematic movie still depiction of duel of two",
+      "titulo": "Armadura frente a penacho",
+      "alt": "Dos hombres posan uno junto al otro: uno con armadura metálica completa y casco, el otro con un tocado de plumas verdes y rojas, collar dorado y una esfera dorada en la mano, con colinas al fondo en tonos azulados.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -17803,7 +17803,7 @@
       "serie": "archivo",
       "orden": 577,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una cruz de metal le cubre el pecho, y al otro un incendio de plumas rojas le corona la cabeza, quietos los dos aunque el viento suba desde la colina.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17817,8 +17817,8 @@
         "generacion": "a0f3cf50-e0c9-464c-8e6e-59a14594f377",
         "variante": 3
       },
-      "titulo": "Panoramic and cinematic movie still depiction of duel",
-      "alt": "panoramic and cinematic movie still depiction of duel of two",
+      "titulo": "La cruz sobre el peto",
+      "alt": "Dos hombres en primer plano: uno con armadura metálica con una cruz en el peto, el otro con un tocado de plumas rojas y verdes y adornos dorados, luz cálida y colinas al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -17834,7 +17834,7 @@
       "serie": "archivo",
       "orden": 578,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre las piedras de la orilla, la canoa lleva tanto tiempo varada que la marea se ha corrido cien metros mar adentro, y las dos personas que caminan la orilla parecen no haberlo notado todavía.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17848,8 +17848,8 @@
         "generacion": "391c9cc2-73a5-4e3f-9b38-9959e248e991",
         "variante": 3
       },
-      "titulo": "Panoramic view A canoe rests in the shore",
-      "alt": "Panoramic view A canoe rests in the shore of a beach with nat",
+      "titulo": "La canoa que espera sola",
+      "alt": "Una canoa de madera vacía descansa sobre piedras en la orilla, con dos personas de pie a lo lejos sobre un banco de arena, mar en calma, nubes blancas y montañas difusas al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -17865,7 +17865,7 @@
       "serie": "archivo",
       "orden": 579,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta de espaldas al pueblo de palafitos con las líneas del cuerpo recién pintadas, y el sol tarda tanto en secarlas que los otros ya llevan rato nadando cuando ella no se mueve.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17879,8 +17879,8 @@
         "generacion": "25cbccf8-e922-48a8-a224-fa91946316df",
         "variante": 1
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "De espaldas al palafito",
+      "alt": "Una mujer con pintura corporal está sentada de espaldas a la orilla de un agua turquesa, mirando hacia un grupo de personas que nadan frente a un poblado de casas de techo de paja sobre pilotes, con luz cálida de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17896,7 +17896,7 @@
       "serie": "archivo",
       "orden": 580,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre ella y el grupo que nada hay veinte brazadas exactas de agua color té, y las casas de paja se alinean detrás como si custodiaran cada metro de esa distancia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17910,8 +17910,8 @@
         "generacion": "25cbccf8-e922-48a8-a224-fa91946316df",
         "variante": 2
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Veinte brazadas de distancia",
+      "alt": "Una mujer con pintura corporal está sentada de espaldas junto a la orilla, mirando a varias personas que nadan a distancia en agua turquesa, frente a un poblado de chozas de paja sobre pilotes de madera, con luz dorada de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17927,7 +17927,7 @@
       "serie": "archivo",
       "orden": 581,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los rayos caen tan rectos sobre el canal que parecen postes de luz clavados desde el cielo, y la única canoa que cruza arrastra tras de sí todos los colores del agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17941,8 +17941,8 @@
         "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180",
         "variante": 1
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Rayos rectos sobre el canal",
+      "alt": "Vista aérea de decenas de techos de paja en forma cónica sobre el agua, con rayos de luz cayendo del cielo, una pequeña canoa navegando por un canal central y el agua con reflejos de varios colores.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17958,7 +17958,7 @@
       "serie": "archivo",
       "orden": 582,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se parte la fotografía justo en la línea del agua, y bajo esa costura de burbujas los mismos postes sostienen el caserío por abajo sin que nadie arriba lo note.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -17972,8 +17972,8 @@
         "generacion": "44fff746-3cea-468c-bafe-d2f7ba08c180",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "La aldea cortada al medio",
+      "alt": "Fotografía en tono sepia de un poblado de casas con techo de paja sobre pilotes de madera junto al agua, con montañas difusas y nubes al fondo, dividida por una línea que muestra los postes también por debajo de la superficie del agua.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -17989,7 +17989,7 @@
       "serie": "archivo",
       "orden": 583,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Desde la sombra de la colina se cuentan más de treinta techos de paja apretados sobre el agua, y la única canoa que se mueve entre todos ellos tarda una eternidad en cruzarlos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18003,8 +18003,8 @@
         "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b",
         "variante": 1
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Desde la colina, el pueblo",
+      "alt": "Vista elevada desde una colina oscura hacia un poblado de decenas de chozas con techo cónico de paja sobre una laguna turquesa, con una pequeña canoa navegando entre ellas, en tonos azulados de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18020,7 +18020,7 @@
       "serie": "archivo",
       "orden": 584,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Avanza tan despacio la niebla sobre la laguna que ya se comió la mitad de los techos del fondo, y solo los más cercanos a la orilla alcanzan a asomar la punta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18034,8 +18034,8 @@
         "generacion": "46b16266-1f9b-4dc8-a1d5-a8049dfeda2b",
         "variante": 2
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "La niebla avanza despacio",
+      "alt": "Vista elevada de un poblado de chozas con techo de paja sobre una laguna verde azulada, con niebla que difumina los techos más alejados y vegetación oscura en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18051,7 +18051,7 @@
       "serie": "archivo",
       "orden": 585,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pasarela de tablas tuerce tres veces antes de llegar a la puerta, como si la casa de techo dorado no quisiera dejarse encontrar por cualquiera que camine derecho.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18065,8 +18065,8 @@
         "generacion": "4771b1a7-b872-4dae-9b14-78bd6bf859ef",
         "variante": 0
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Puente hacia la choza dorada",
+      "alt": "Una casa grande con techo de paja dorada se levanta sobre pilotes en el mar turquesa, con una pasarela de madera en zigzag que conduce hasta su entrada, bajo un cielo despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18082,7 +18082,7 @@
       "serie": "archivo",
       "orden": 586,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cae el rayo de luz tan preciso sobre el muelle que parece medido con regla, y las dos que llevan rojo no dan ni medio paso fuera de esa columna.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18096,8 +18096,8 @@
         "generacion": "6ab28b3f-797e-459f-bdf6-b07bccc9eb71",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Bajo el rayo vertical",
+      "alt": "Dos personas vestidas de rojo están de pie sobre un muelle de madera de noche, iluminadas por un haz de luz vertical, frente a una casa de techo de paja sobre el agua verde brillante.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18113,7 +18113,7 @@
       "serie": "archivo",
       "orden": 587,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada choza de la fila se pinta la puerta de un rojo distinto, y el agua, partida en dos por la fotografía, repite las mismas puertas boca abajo sin equivocarse de color ni una vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18127,8 +18127,8 @@
         "generacion": "7df7f9c2-2362-4d1a-a2c8-69898996e758",
         "variante": 0
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Las puertas rojas del canal",
+      "alt": "Fila de casas con techo de paja sobre pilotes en tonos cálidos anaranjados, con puertas rojas, rayos de luz cayendo desde el cielo y una imagen dividida que muestra su reflejo bajo el agua.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18144,7 +18144,7 @@
       "serie": "archivo",
       "orden": 588,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Vistos desde arriba, los techos se aprietan tanto unos contra otros que apenas dejan un hilo de agua libre, y por ese hilo exacto avanza la única canoa de todo el poblado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18158,8 +18158,8 @@
         "generacion": "9454aa5a-5235-480b-bfca-7274252d5567",
         "variante": 1
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "El bote entre los tejados",
+      "alt": "Vista aérea directamente desde arriba de un denso conjunto de techos de paja sobre el agua, con una canoa y una persona navegando por un estrecho canal entre ellos, bordes verdes de vegetación acuática.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18175,7 +18175,7 @@
       "serie": "archivo",
       "orden": 589,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El canal central es tan ancho que los techos de los dos lados apenas se rozan con la niebla, y el bote que lo cruza parece la única cosa en kilómetros que sabe adónde va.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18189,8 +18189,8 @@
         "generacion": "955996eb-bdc7-4d54-a5fe-2be7c2a59c23",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "El bote del canal central",
+      "alt": "Vista aérea de un ancho canal de agua flanqueado por altos techos cónicos de paja, con un pequeño bote y una persona en el centro, bruma cubriendo el fondo de la imagen.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18206,7 +18206,7 @@
       "serie": "archivo",
       "orden": 590,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Rema de espaldas a la cámara sin saber que la fotografía le corta el mundo justo a la altura del agua, y bajo su canoa las mismas casas repiten los postes como si fueran raíces.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18220,8 +18220,8 @@
         "generacion": "9702d5d6-796a-4eaf-af12-a2c85e5eaedd",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Rema sobre su reflejo hundido",
+      "alt": "Una persona rema en una canoa de madera vista desde atrás, en una fotografía dividida por la línea del agua que muestra, debajo, las casas de techo de paja reflejadas y sus postes sumergidos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18237,7 +18237,7 @@
       "serie": "archivo",
       "orden": 591,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los botes que cruzan el canal a la vez se pierden de la cuenta antes de llegar a la última choza, con montañas veladas al fondo bajo el mismo sol de todos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18251,8 +18251,8 @@
         "generacion": "9c382ad4-4c72-4040-8c9f-66708d6e89b6",
         "variante": 0
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Muchos botes, un solo canal",
+      "alt": "Pintura de un poblado de casas con techo cónico de paja sobre el agua, con numerosos botes navegando entre ellas, montañas al fondo y luz cálida de día.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18268,7 +18268,7 @@
       "serie": "archivo",
       "orden": 592,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Copia el agua cada techo con tanta exactitud que hacen falta los botes, únicos que se mueven, para saber cuál mitad de la simetría es la de verdad.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18282,8 +18282,8 @@
         "generacion": "b417955e-ad15-4c8b-86c3-b5aef6658f66",
         "variante": 0
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Techos duplicados en el agua",
+      "alt": "Ilustración de un canal de agua bordeado por techos cónicos de paja que se reflejan simétricamente en la superficie, con botes navegando y montañas azuladas al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18299,7 +18299,7 @@
       "serie": "archivo",
       "orden": 593,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El techo más grande de todos junta a su gente en la base, como si fuera el único que diera sombra de verdad, mientras los demás, más lejos, se quedan sin nadie cerca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18313,8 +18313,8 @@
         "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249",
         "variante": 0
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "El techo que junta gente",
+      "alt": "Pintura en tonos azulados de un poblado con techos cónicos de paja, con un techo grande en primer plano rodeado de personas, otras chozas y botes se extienden hacia el fondo en luz de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18330,7 +18330,7 @@
       "serie": "archivo",
       "orden": 594,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De todo el pueblo solo quedan encendidas las ventanas, una hilera de puntos amarillos flotando en la niebla azul, y la canoa vacía del primer plano parece llevar horas esperando a que alguna se apague.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18344,8 +18344,8 @@
         "generacion": "b4d0daa4-82e4-4984-8496-06d7e50f5249",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "Ventanas encendidas en la niebla",
+      "alt": "Vista nocturna de un poblado de casas de techo de paja con ventanas iluminadas de amarillo entre niebla azul, agua verdosa en primer plano con una canoa vacía y vegetación oscura en el borde inferior.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18361,7 +18361,7 @@
       "serie": "archivo",
       "orden": 595,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La choza se queda entera del lado seco de la fotografía, y del otro lado, bajo el agua, cinco pares de piernas esperan de pie sobre una pasarela que el mar no deja salir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18375,8 +18375,8 @@
         "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc",
         "variante": 1
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "De pie en la pasarela",
+      "alt": "Fotografía dividida por la línea del agua: arriba, una choza de techo de paja junto a árboles; abajo, bajo el agua transparente, cinco personas jóvenes de pie sobre una pasarela de madera con coral visible en el fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18392,7 +18392,7 @@
       "serie": "archivo",
       "orden": 596,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le sale la sombra más larga que el muelle mismo, alargándose sobre las tablas mientras camina hacia las casas de paja que ya se encienden de azul con la caída de la tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18406,8 +18406,8 @@
         "generacion": "debc367b-8f4f-4662-a2d3-1467b976d4dc",
         "variante": 3
       },
-      "titulo": "Panoramic view of a city of stilt houses",
-      "alt": "Panoramic view of a city of stilt houses submerged in crystal",
+      "titulo": "El muelle hacia el poblado",
+      "alt": "Vista elevada de una persona con collar de cuentas y falda roja caminando por un largo muelle de madera hacia un poblado de casas con techo de paja sobre el agua, en tonos azules y violetas de atardecer, con su sombra proyectada sobre las tablas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18423,7 +18423,7 @@
       "serie": "archivo",
       "orden": 597,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mitad del cielo se vuelve roja de golpe justo donde termina la nave grande, y ninguna de las que la escoltan cruza esa frontera exacta entre el negro y el óxido.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18437,8 +18437,8 @@
         "generacion": "74295479-05b4-42c1-b396-e8c42c0574c1",
         "variante": 1
       },
-      "titulo": "Panoramic view of Hundreds of Space",
-      "alt": "Panoramic view of Hundreds of Space",
+      "titulo": "La frontera roja del convoy",
+      "alt": "Varias naves espaciales oscuras y angulares flotan en el espacio junto a naves más pequeñas, con la mitad del fondo en negro estrellado y la otra mitad en un tono rojo intenso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18454,7 +18454,7 @@
       "serie": "archivo",
       "orden": 598,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruzan el valle al galope cientos de jinetes con los sables ya desenvainados, y el humo de la pólvora sube tan alto que empieza a confundirse con las nubes que cubren la montaña del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18468,8 +18468,8 @@
         "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8",
         "variante": 0
       },
-      "titulo": "Panoramic view of The Battle of Cara",
-      "alt": "Panoramic view of The Battle of Cara",
+      "titulo": "La carga bajo el humo",
+      "alt": "Pintura de una batalla con cientos de soldados de caballería e infantería en uniformes azules y rojos combatiendo en un valle, con humo de disparos elevándose y montañas al fondo, estilo de pintura clásica.",
       "w": 1904,
       "h": 640,
       "anchos": [
@@ -18486,7 +18486,7 @@
       "serie": "archivo",
       "orden": 599,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los jinetes bajan la colina con tanta prisa que la hierba tarda tres días en levantarse otra vez.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18500,8 +18500,8 @@
         "generacion": "8c72e9f0-2159-4734-bd63-5b571a6271a8",
         "variante": 2
       },
-      "titulo": "Panoramic view of The Battle of Cara",
-      "alt": "Panoramic view of The Battle of Cara",
+      "titulo": "Marea azul en la loma",
+      "alt": "Pintura de una batalla de caballería con soldados de uniforme azul y otros de uniforme claro luchando cuerpo a cuerpo en una colina verde, con humo de pólvora y un valle extenso al fondo bajo un cielo nublado.",
       "w": 1904,
       "h": 640,
       "anchos": [
@@ -18518,7 +18518,7 @@
       "serie": "archivo",
       "orden": 600,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajan tantos caballos por la ladera que el polvo tarda una hora entera en decidir si es nube o es humo de cañón.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18532,8 +18532,8 @@
         "generacion": "959f30d9-b760-4821-9d64-174c99113312",
         "variante": 0
       },
-      "titulo": "Panoramic view of The Battle of Cara",
-      "alt": "Panoramic view of The Battle of Cara",
+      "titulo": "El tropel cuesta abajo",
+      "alt": "Pintura panorámica de una carga de caballería con decenas de jinetes de uniforme azul descendiendo una colina cubierta de hierba, entre polvo y humo, con un valle y colinas boscosas al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -18549,7 +18549,7 @@
       "serie": "archivo",
       "orden": 601,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ladera se llena de tantos jinetes que, desde la cima, ya no se cuenta gente: se cuenta hectáreas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18563,8 +18563,8 @@
         "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01",
         "variante": 1
       },
-      "titulo": "Panoramic view of The Battle of Carabobo the",
-      "alt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+      "titulo": "La ladera llena de jinetes",
+      "alt": "Pintura de cientos de jinetes uniformados desplegados sobre una colina extensa, con soldados de uniforme azul avanzando a caballo en primer plano, un valle verde y cielo despejado al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18580,7 +18580,7 @@
       "serie": "archivo",
       "orden": 602,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apenas alcanza la luz de la tarde a tocar los techos del pueblo en el valle, antes de que el humo de la colina la alcance y se la trague entera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18594,8 +18594,8 @@
         "generacion": "8606b895-f069-46e8-8e16-c5115ad1df01",
         "variante": 3
       },
-      "titulo": "Panoramic view of The Battle of Carabobo the",
-      "alt": "Panoramic view of The Battle of Carabobo the Venezuelan Revol",
+      "titulo": "Último sol sobre la loma",
+      "alt": "Pintura de una batalla de caballería en una colina al atardecer, con jinetes de uniforme azul en primer plano, humo disperso, y un pueblo pequeño visible en el valle iluminado por luz dorada.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18611,7 +18611,7 @@
       "serie": "archivo",
       "orden": 603,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La espuma de la ola sube tan alto y tan rosada que por un segundo nadie sabe si el mar rompe contra la arena o contra el cielo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18625,8 +18625,8 @@
         "generacion": "85614378-8aea-43e1-829d-e5bcb3f76317",
         "variante": 1
       },
-      "titulo": "Photo of pink clouds depicting the form of",
-      "alt": "photo of pink clouds depicting the form of geishas smiling ab",
+      "titulo": "Rosa que rompe en espuma",
+      "alt": "Fotografía de olas rompiendo en la orilla del mar al atardecer, con espuma blanca, bajo un cielo rosado y anaranjado con nubes y montañas a lo lejos.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -18642,7 +18642,7 @@
       "serie": "archivo",
       "orden": 604,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tantas naves escoltan al planeta ocre que ya ni los asteroides encuentran hueco para pasar entre ellas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18656,8 +18656,8 @@
         "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24",
         "variante": 2
       },
-      "titulo": "Photograph of a Panoramic view in outer space",
-      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "titulo": "Flota ante el planeta ocre",
+      "alt": "Ilustración de una flota de naves espaciales de distintos tamaños navegando frente a un planeta de color naranja rojizo, con estrellas y pequeños objetos flotando alrededor.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18673,7 +18673,7 @@
       "serie": "archivo",
       "orden": 605,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Vuelan tan cerca del planeta las naves que se les alcanzan a contar los cráteres antes de virar rumbo a las estrellas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18687,8 +18687,8 @@
         "generacion": "6a25e6b6-119a-4ca6-a773-802ea0461e24",
         "variante": 3
       },
-      "titulo": "Photograph of a Panoramic view in outer space",
-      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "titulo": "Cerco a la esfera ocre",
+      "alt": "Ilustración de numerosas naves espaciales de guerra sobrevolando un planeta anaranjado con superficie rocosa, rodeadas de estrellas en un fondo oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18704,7 +18704,7 @@
       "serie": "archivo",
       "orden": 606,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El planeta rojo del centro cabe tan chico entre las naves que parece una brasa que se les apagó en medio del vuelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18718,8 +18718,8 @@
         "generacion": "c1c49a7f-85de-4995-be55-84193eb900b3",
         "variante": 1
       },
-      "titulo": "Photograph of a Panoramic view in outer space",
-      "alt": "Photograph of a Panoramic view in outer space of Hundreds of",
+      "titulo": "El planeta diminuto en medio",
+      "alt": "Ilustración oscura de una escena espacial con un pequeño planeta rojo en el centro, naves en silueta alrededor, un planeta más grande a la derecha y un resplandor azul de nebulosa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18735,7 +18735,7 @@
       "serie": "archivo",
       "orden": 607,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cae tan preciso el disco de luz del techo sobre el escritorio que el polvo del aire tarda toda la noche en cruzarlo de lado a lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18749,8 +18749,8 @@
         "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69",
         "variante": 1
       },
-      "titulo": "Photograph of a scene of the sillouette of",
-      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "titulo": "El disco de luz",
+      "alt": "Fotografía en blanco y negro de un hombre sentado ante una computadora en una oficina a oscuras, iluminado únicamente por un panel de luz circular en el techo que proyecta rayos de luz visibles.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -18766,7 +18766,7 @@
       "serie": "archivo",
       "orden": 608,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sombra con forma de nube se queda pegada a la pared toda la noche mientras los dos hombres, iluminados solo por las pantallas, ni se giran a mirarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18780,8 +18780,8 @@
         "generacion": "a7889354-f26a-4d8c-b418-8f8a09a10e69",
         "variante": 3
       },
-      "titulo": "Photograph of a scene of the sillouette of",
-      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "titulo": "Nube quieta en la pared",
+      "alt": "Fotografía en blanco y negro de dos hombres sentados frente a computadoras en una oficina oscura, iluminados por el resplandor de las pantallas, con haces de luz intensos entrando desde la izquierda y una sombra oscura con forma de nube en la pared.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -18797,7 +18797,7 @@
       "serie": "archivo",
       "orden": 609,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cuelga medio suelto del techo el panel de luz, y aun así ilumina lo bastante para que el hombre cruce solo, sin tropezar, ocho oficinas vacías.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18811,8 +18811,8 @@
         "generacion": "c224da8e-fe12-4b04-9bfe-3e96746ca8fd",
         "variante": 1
       },
-      "titulo": "Photograph of a scene of the sillouette of",
-      "alt": "Photograph of a scene of the sillouette of a man been abduced",
+      "titulo": "Paso solitario en la oficina",
+      "alt": "Fotografía en blanco y negro de la silueta de un hombre caminando por una oficina oscura y vacía, con escritorios alrededor, una lámpara del techo colgando suelta, y una ciudad iluminada visible a través de una ventana grande.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -18828,7 +18828,7 @@
       "serie": "archivo",
       "orden": 610,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tanto sube la espuma por la bañera que ya empieza a treparse por los azulejos negros, buscando salida antes de que cierren el grifo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18842,8 +18842,8 @@
         "generacion": "b9cd4ac8-413a-4444-a9b4-56d040841ebd",
         "variante": 3
       },
-      "titulo": "Photorealistic",
-      "alt": "photorealistic",
+      "titulo": "Espuma que trepa el azulejo",
+      "alt": "Fotografía de una bañera blanca llenándose de agua azul con espuma blanca que se desborda sobre el borde y salpica una pared de azulejos negros.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18859,7 +18859,7 @@
       "serie": "archivo",
       "orden": 611,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los cántaros de barro se le acomodan alrededor tan pegados que la sombra del cuarto no encuentra ni una rendija para colarse entre ellos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18873,8 +18873,8 @@
         "generacion": "0455d116-d82d-40a2-b7c8-d86247919b3a",
         "variante": 2
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "Cántaros oscuros y la mujer",
+      "alt": "Fotografía granulada de una mujer con blusa estampada sentada junto a varias vasijas de barro, en un ambiente oscuro con poca iluminación.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18890,7 +18890,7 @@
       "serie": "archivo",
       "orden": 612,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Brillan más azules las flores pintadas en los floreros que la propia luz del cuarto, como si hubieran guardado el color del día para gastarlo de noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18904,8 +18904,8 @@
         "generacion": "a7d49a8b-7509-403f-8e0a-6fb6bd921658",
         "variante": 3
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "El hombre entre floreros pintados",
+      "alt": "Fotografía de un hombre con camisa estampada sentado frente a varios floreros de cerámica blanca pintados con motivos florales azules, bajo una iluminación tenue de tono azulado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18921,7 +18921,7 @@
       "serie": "archivo",
       "orden": 613,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La olla negra ocupa tanto sitio en la penumbra que se le adelanta a la propia mujer, y es lo primero que encuentra la poca luz que entra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18935,8 +18935,8 @@
         "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
         "variante": 0
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "Olla negra en la penumbra",
+      "alt": "Fotografía oscura de una mujer con vestido estampado sentada junto a una gran olla de barro negro, con alimentos dispuestos cerca, en un ambiente de escasa iluminación.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18952,7 +18952,7 @@
       "serie": "archivo",
       "orden": 614,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Devuelve tanta luz en la oscuridad el esmalte azul de los cántaros que parece que fueran ellos los que alumbran el cuarto y no al revés.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18966,8 +18966,8 @@
         "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
         "variante": 1
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "Los cántaros que brillan azules",
+      "alt": "Fotografía en penumbra de una mujer con vestimenta estampada rodeada de vasijas de cerámica con esmalte azul brillante, iluminada parcialmente por una luz cálida lateral.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -18983,7 +18983,7 @@
       "serie": "archivo",
       "orden": 615,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las dos tinajas lo flanquean tan grandes que, entre la luz roja de una y la azul de la otra, el hombre del medio no termina de decidir de qué color es la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -18997,8 +18997,8 @@
         "generacion": "c6a7a19e-6d4a-4bc0-8fa5-c2023a56a62b",
         "variante": 2
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "Entre tinajas rojas y azules",
+      "alt": "Fotografía oscura de un hombre sentado en el suelo entre dos grandes vasijas de barro, iluminado por luces de tono rojo y azul que crean un ambiente de contraste dramático.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19014,7 +19014,7 @@
       "serie": "archivo",
       "orden": 616,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Del cántaro que amasa con las manos sube un hilo de humo tan delgado que se le enreda en la vincha antes de perderse hacia el techo de piedra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19028,8 +19028,8 @@
         "generacion": "eebb890b-3881-4525-bb95-b6532e6052af",
         "variante": 2
       },
-      "titulo": "Photorealistic portrayal of indigenous ceramic artesan creati",
-      "alt": "photorealistic portrayal of indigenous ceramic artesan creati",
+      "titulo": "Alfarero y el humo fino",
+      "alt": "Fotografía de un hombre indígena sentado con las piernas cruzadas, moldeando una vasija de barro con las manos, con el torso descubierto, una vincha de plumas en la cabeza, humo fino elevándose del recipiente, rodeado de numerosas piezas de cerámica y una pared de piedra al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19045,7 +19045,7 @@
       "serie": "archivo",
       "orden": 617,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La proa de la canoa apunta tan derecho hacia las casas de paja que el agua no se atreve a moverse un centímetro, no sea que le tuerza el rumbo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19059,8 +19059,8 @@
         "generacion": "6bee269a-6e7e-4d9d-ada4-ae41d88201ea",
         "variante": 3
       },
-      "titulo": "Photorealistic portrayal of indigenous palafittes dwellings o",
-      "alt": "photorealistic portrayal of indigenous palafittes dwellings o",
+      "titulo": "La proa hacia los palafitos",
+      "alt": "Fotografía tomada desde una canoa de madera, con su proa en primer plano, navegando hacia un conjunto de viviendas de techo de paja construidas sobre pilotes en el agua, rodeadas de juncos, bajo un cielo con nubes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19076,7 +19076,7 @@
       "serie": "archivo",
       "orden": 618,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se inclina tanto sobre el agua azul que las casas de paja del fondo, del techo a los pilotes, se le reflejan completas justo entre las manos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19090,8 +19090,8 @@
         "generacion": "93c41bf1-513b-4977-9ce2-1659e3e096d4",
         "variante": 3
       },
-      "titulo": "Photorealistic portrayal of indigenous palafittes dwellings o",
-      "alt": "photorealistic portrayal of indigenous palafittes dwellings o",
+      "titulo": "Inclinada sobre el agua",
+      "alt": "Fotografía nocturna de una mujer inclinada hacia adelante dentro de un cuerpo de agua poco profundo, con dos viviendas de techo de paja sobre pilotes al fondo, bajo una luz azulada de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19107,7 +19107,7 @@
       "serie": "archivo",
       "orden": 619,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La estatua de brazos abiertos en la cima ve encender la ciudad entera casa por casa, antes de que la primera luz de la bahía le llegue a los pies.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19121,8 +19121,8 @@
         "generacion": "42afcc3d-f1f9-4a7c-a267-0f8cf6744fe6",
         "variante": 2
       },
-      "titulo": "Pixel art lanscape photograph of Rio de Janeiro",
-      "alt": "Pixel art lanscape photograph of Rio de Janeiro with the cris",
+      "titulo": "Estatua que vigila la bahía",
+      "alt": "Ilustración en pixel art de un paisaje urbano visto desde una montaña al atardecer, con una estatua de brazos abiertos en la cima de un monte rocoso, vegetación en primer plano, y una ciudad costera iluminada al fondo bajo un cielo azul oscuro con nubes rosadas en el horizonte.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19138,7 +19138,7 @@
       "serie": "archivo",
       "orden": 620,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se le tiñen de rosa las plumas del tocado antes que el agua, y para cuando el sol termina de hundirse ya no hay forma de saber dónde acaba su plumaje y empieza el cielo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19152,8 +19152,8 @@
         "generacion": "aaf09862-762a-4778-b787-92a5d86448b5",
         "variante": 0
       },
-      "titulo": "Pixelart of scene with a caqueto boy in",
-      "alt": "pixelart of scene with a caqueto boy in indigenous attire sit",
+      "titulo": "Plumas rosa ante el sol",
+      "alt": "Ilustración en pixel art de una persona con tocado de plumas sentada de espaldas sobre una roca, mirando la puesta de sol sobre el agua, con hojas de palmera en primer plano y un cielo rosado y anaranjado con nubes.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -19168,7 +19168,7 @@
       "serie": "archivo",
       "orden": 621,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las líneas de luz corren tan rápido hacia el mismo punto que si alguien se asomara al centro exacto, no vería nada, porque ahí la velocidad ya se comió hasta el fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19182,8 +19182,8 @@
         "generacion": "35486a22-1c40-431f-b03d-d3c40e5526cc",
         "variante": 0
       },
-      "titulo": "Police man incuring in a trafficc stop in",
-      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "titulo": "Fuga de líneas de neón",
+      "alt": "Fotografía abstracta de líneas de luz de colores rosado, morado, azul y naranja que convergen hacia un punto central sobre un fondo negro, creando un efecto de movimiento y velocidad.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19199,7 +19199,7 @@
       "serie": "archivo",
       "orden": 622,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le pasan tan pegadas a la carrocería roja las estelas de luz blanca que el carro parece quieto en medio de una carretera que sí se mueve.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19213,8 +19213,8 @@
         "generacion": "6c60b2b4-058c-4f46-a819-4df535a22c4d",
         "variante": 0
       },
-      "titulo": "Police man incuring in a trafficc stop in",
-      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "titulo": "El carro envuelto en estelas",
+      "alt": "Fotografía de un automóvil de color rojo oscuro con las ventanas tintadas, rodeado de estelas de luz blanca y difusas que sugieren movimiento a alta velocidad, sobre un fondo oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19230,7 +19230,7 @@
       "serie": "archivo",
       "orden": 623,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna rosada se le refleja entera en la máscara de gas, tan grande que las pirámides del fondo le caben enteras en el cristal del visor.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19244,8 +19244,8 @@
         "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
         "variante": 0
       },
-      "titulo": "Police man incuring in a trafficc stop in",
-      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "titulo": "Máscara frente a las pirámides",
+      "alt": "Ilustración de estilo futurista con un hombre en primer plano vestido con chaqueta oscura y máscara de gas, frente a un automóvil abandonado, dos pirámides y una gran luna rosada de fondo, bajo una iluminación de tono magenta.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19261,7 +19261,7 @@
       "serie": "archivo",
       "orden": 624,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se detiene junto al auto cuyas luces traseras encienden trescientas líneas rojas, y la ciudad entera se apaga un segundo para dejarlas brillar solas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19275,8 +19275,8 @@
         "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
         "variante": 2
       },
-      "titulo": "Police man incuring in a trafficc stop in",
-      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "titulo": "Las trescientas luces traseras",
+      "alt": "Hombre con abrigo oscuro de pie junto a un automóvil futurista con luces traseras rojas encendidas, en una calle de ciudad nocturna iluminada en tonos rojos y edificios al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19292,7 +19292,7 @@
       "serie": "archivo",
       "orden": 625,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La lluvia cae tan despacio sobre el asfalto que cada gota alcanza a robarle el color a los cien letreros de neón antes de tocar el suelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19306,8 +19306,8 @@
         "generacion": "9e2c2ffa-ff2d-4950-b7bc-f2ced7041156",
         "variante": 3
       },
-      "titulo": "Police man incuring in a trafficc stop in",
-      "alt": "Police man incuring in a trafficc stop in a Metropolitan Area",
+      "titulo": "La lluvia roba el neón",
+      "alt": "Calle de ciudad por la noche bajo la lluvia, con automóviles en primer plano y numerosos letreros de neón multicolor iluminando los edificios a ambos lados.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19323,7 +19323,7 @@
       "serie": "archivo",
       "orden": 626,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las cadenas que le cruzan el pecho pesan lo mismo que el candelabro de hierro que cuelga en medio del cuarto rosado, y aun así camina como si no cargara ninguna de las dos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19337,8 +19337,8 @@
         "generacion": "bcf7c3d6-2688-4d8a-9ac2-c624024efa41",
         "variante": 0
       },
-      "titulo": "Portrait A young latinoamerican goths vampire in a",
-      "alt": "portrait A young latinoamerican goths vampire in a discotek t",
+      "titulo": "Cadenas en el cuarto rosa",
+      "alt": "Joven de pie en un dormitorio de paredes rosadas, con el cabello oscuro de puntas erizadas, chaqueta negra, camiseta blanca y varias cadenas y cruces colgando del cuello; detrás hay una cama con sábana roja floreada y un candelabro de hierro en el techo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19354,7 +19354,7 @@
       "serie": "archivo",
       "orden": 627,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada pliegue de este papel de aluminio guarda un rayo distinto, y el unicornio junta tantos que parece que se hubiera tragado el sol entero de la mesa de estudio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19368,8 +19368,8 @@
         "generacion": "d2226670-b121-4a31-92bd-fa95124acac1",
         "variante": 0
       },
-      "titulo": "Product Shot of a tin foil paper Origami",
-      "alt": "Product Shot of a tin foil paper Origami unicorn with an opaq",
+      "titulo": "El unicornio de rayos",
+      "alt": "Figura de unicornio hecha con papel de aluminio plateado y dorado, doblada en origami, sobre un fondo azul liso, con su sombra proyectada hacia la derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19385,7 +19385,7 @@
       "serie": "archivo",
       "orden": 628,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Asoma un solo ojo por la grieta de la roca, y ese ojo lleva mirando tanto tiempo el mismo camino de piedra que ha aprendido a contar cada grano de la caliza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19399,8 +19399,8 @@
         "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20",
         "variante": 0
       },
-      "titulo": "Prompt Early 11th century medieval Spain a figure",
-      "alt": "Prompt Early 11th century medieval Spain a figure hides in a",
+      "titulo": "El ojo tras la roca",
+      "alt": "Fotografía en blanco y negro de un hombre encapuchado con manto oscuro, asomado detrás de una roca, con el rostro parcialmente iluminado por luz lateral.",
       "w": 800,
       "h": 1062,
       "anchos": [
@@ -19415,7 +19415,7 @@
       "serie": "archivo",
       "orden": 629,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El manto negro le cubre hasta los pies dentro de la grieta de piedra, y es tan largo que la roca entera parece haber crecido alrededor para no dejarlo salir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19429,8 +19429,8 @@
         "generacion": "a083fe8f-b477-4f46-a06e-22897e085b20",
         "variante": 3
       },
-      "titulo": "Prompt Early 11th century medieval Spain a figure",
-      "alt": "Prompt Early 11th century medieval Spain a figure hides in a",
+      "titulo": "El manto en la grieta",
+      "alt": "Fotografía en blanco y negro de un hombre encapuchado con manto oscuro de pie dentro de una grieta o hueco entre rocas claras, con el rostro apenas visible bajo la capucha.",
       "w": 800,
       "h": 1062,
       "anchos": [
@@ -19445,7 +19445,7 @@
       "serie": "archivo",
       "orden": 630,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De la piel agrietada del rostro se desprenden los mismos asteroides que flotan detrás, como si cada cráter del espacio hubiera nacido primero en esta cara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19459,8 +19459,8 @@
         "generacion": "4b5ac5f3-860b-46d4-9779-3a46eafd44dc",
         "variante": 2
       },
-      "titulo": "Psycodelic cover art of a internal dialog titled",
-      "alt": "Psycodelic cover art of a internal dialog titled Dialogo Inte",
+      "titulo": "Cráteres en el rostro",
+      "alt": "Ilustración de una cabeza humana estilizada con la piel agrietada como lava y textura de cráteres en tonos naranja, rojo y morado, sobre un fondo de estrellas y asteroides; arriba aparece un texto en letras rojas.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19476,7 +19476,7 @@
       "serie": "archivo",
       "orden": 631,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un camino de tierra roja se abre entre las montañas moradas hasta perderse justo debajo de la luna verde, que lleva ahí tanto tiempo como el perfil que la mira.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19490,8 +19490,8 @@
         "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
         "variante": 0
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "La luna verde del desfiladero",
+      "alt": "Retrato de perfil de un joven de cabello rizado frente a un valle montañoso de tonalidades moradas y rosadas, con un camino de tierra rojiza y una luna o planeta verde brillando en el centro del cielo estrellado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19507,7 +19507,7 @@
       "serie": "archivo",
       "orden": 632,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El agua turquesa se detiene justo a la altura de los ojos, congelada a mitad de una ola que lleva minutos, o años, sin terminar de caer sobre el resto de la cara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19521,8 +19521,8 @@
         "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
         "variante": 1
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El agua sobre los ojos",
+      "alt": "Primer plano del rostro de un joven de cabello rizado, con la parte superior de la cara cubierta por una textura de agua turquesa ondulante que simula una ola, y la parte inferior visible en tonos cálidos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19538,7 +19538,7 @@
       "serie": "archivo",
       "orden": 633,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Del cabello rizado le sale un humo de rayas azules, verdes y amarillas que sube en zigzag y parte el cielo en dos mitades, una roja y una morada, sin que él baje la vista.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19552,8 +19552,8 @@
         "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
         "variante": 2
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El humo de rayas",
+      "alt": "Retrato de un joven de cabello rizado mirando hacia arriba con un suéter azul, con franjas onduladas de colores arcoíris elevándose desde su cabeza sobre un fondo dividido en rojo y azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19569,7 +19569,7 @@
       "serie": "archivo",
       "orden": 634,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El coral turquesa le crece pegado a la mejilla y el coral rosado le corona la frente, sin dejarle a la cara más espacio libre que el necesario para mirar al cielo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19583,8 +19583,8 @@
         "generacion": "51a1b113-2bac-4c1d-ae6e-1275fabbfb9b",
         "variante": 3
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El arrecife que lo rodea",
+      "alt": "Primer plano del rostro de un joven mirando hacia arriba, rodeado de una textura similar a coral en tonos turquesa y rosa intenso que cubre gran parte de la imagen.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19600,7 +19600,7 @@
       "serie": "archivo",
       "orden": 635,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tres lunas distintas se le quedaron prendidas en los rizos y ninguna pesa lo suficiente como para caer, aunque el cráneo entero arda en franjas rojas y naranjas como si fuera otro sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19614,8 +19614,8 @@
         "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896",
         "variante": 0
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "Lunas prendidas en el pelo",
+      "alt": "Primer plano del perfil de un joven de cabello rizado, con una textura de piel y cabello similar a una superficie planetaria en tonos rojos, naranjas y verdes, y pequeñas lunas o planetas alrededor de la cabeza.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19631,7 +19631,7 @@
       "serie": "archivo",
       "orden": 636,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta de perfil frente a una cordillera azul mientras las nubes rosadas hierven encima, tan despacio que en el tiempo que tarda en girar la cabeza no han cambiado de forma.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19645,8 +19645,8 @@
         "generacion": "6c4c92b9-1cc3-4634-b2c6-4e9fa45e4896",
         "variante": 2
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "Nubes rosadas sobre la montaña",
+      "alt": "Hombre joven de cabello rizado sentado de perfil, vestido de negro, frente a un paisaje de montañas azules bajo un cielo con nubes onduladas en tonos rosa y magenta.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19662,7 +19662,7 @@
       "serie": "archivo",
       "orden": 637,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás de él se abre una ventana perfectamente redonda con un desierto entero adentro, dunas y luna incluidas, y las mismas estrellas que ya brillan afuera vuelven a brillar ahí dentro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19676,8 +19676,8 @@
         "generacion": "98e50575-8558-4d38-b23a-aa31132cbc66",
         "variante": 1
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "La ventana redonda del desierto",
+      "alt": "Retrato de perfil de un joven de cabello rizado, con una ventana circular detrás que muestra un paisaje desértico de dunas bajo un cielo estrellado con una luna brillante, en tonos sepia y verde azulado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19693,7 +19693,7 @@
       "serie": "archivo",
       "orden": 638,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De espaldas, mira un mar entero de dunas verdosas que no tienen agua ni la necesitan, porque una nube anaranjada hace de sol y nadie en el paisaje extraña el océano.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19707,8 +19707,8 @@
         "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40",
         "variante": 0
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El mar de dunas verdes",
+      "alt": "Hombre de cabello rizado visto de espaldas, contemplando un extenso paisaje de dunas onduladas en tonos verde y turquesa bajo un cielo morado oscuro con estrellas y una nube de color naranja rosado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19724,7 +19724,7 @@
       "serie": "archivo",
       "orden": 639,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Miles de puntos diminutos se ordenan en círculos perfectos detrás de la cabeza, como si el cielo entero se hubiera puesto de acuerdo para peinarse alrededor de la cara que mira hacia arriba.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19738,8 +19738,8 @@
         "generacion": "c1a4acd8-a923-48d4-870f-88cfbd1bea40",
         "variante": 3
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El halo de puntos",
+      "alt": "Retrato de un joven de cabello rizado mirando hacia arriba, vestido con un suéter azul, con un fondo oscuro cubierto de puntos brillantes dispuestos en círculos concéntricos que irradian desde su cabeza.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19755,7 +19755,7 @@
       "serie": "archivo",
       "orden": 640,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sombra a rayas le cruza media cara como si hubiera atravesado una persiana de neón, y detrás los rayos de colores se abren en abanico sin encontrar nunca el mismo punto de fuga.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19769,8 +19769,8 @@
         "generacion": "d70059ab-c392-4d5e-860b-f9f03679a1c8",
         "variante": 3
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "Rayas cruzando el rostro",
+      "alt": "Primer plano del rostro de un joven con un patrón de rayas de luz y sombra en tonos azules y rosados cruzándole la cara, sobre un fondo de rayos radiantes en colores morado, naranja y rosa.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19786,7 +19786,7 @@
       "serie": "archivo",
       "orden": 641,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta con las piernas cruzadas en el fondo de un túnel de tierra, y arriba, del tamaño justo de una moneda lejana, un círculo de estrellas es la única salida posible.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19800,8 +19800,8 @@
         "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb",
         "variante": 1
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "El círculo de estrellas",
+      "alt": "Hombre sentado con las piernas cruzadas dentro de un túnel excavado en tierra, mirando hacia una abertura circular en la parte superior por donde se ve un cielo nocturno estrellado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19817,7 +19817,7 @@
       "serie": "archivo",
       "orden": 642,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una escalera dorada se mete de lleno en un túnel hecho de anillos rojos concéntricos, y cada anillo es un escalón de luz distinto que el hombre de perfil aún no decide si bajar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19831,8 +19831,8 @@
         "generacion": "e6626d20-9ae8-4085-81a5-3ce9a1bf22cb",
         "variante": 3
       },
-      "titulo": "Psycodelic scene of a man in deep internal",
-      "alt": "Psycodelic scene of a man in deep internal Dialog cover art t",
+      "titulo": "La escalera dentro del túnel",
+      "alt": "Hombre de perfil junto a un túnel formado por anillos concéntricos de color rojo, con una escalera de peldaños dorados que se adentra en el túnel hacia un punto de luz verde al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19848,7 +19848,7 @@
       "serie": "archivo",
       "orden": 643,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Duerme metido dentro de un anillo de luz roja que le rodea la cabeza como un halo de taller, mientras una decena de cables se le enroscan en las piernas sin llegar nunca a despertarlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19862,8 +19862,8 @@
         "generacion": "20753a3a-e028-4c9d-a33a-dfeba895bb3f",
         "variante": 1
       },
-      "titulo": "Pulp image of High tech Room with A",
-      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "titulo": "El anillo rojo del descanso",
+      "alt": "Hombre recostado con auriculares dentro de un aro circular de luz roja, en una habitación futurista de tonos azules con una pantalla que muestra un patrón espiral rojo y varios cables conectados al asiento.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -19879,7 +19879,7 @@
       "serie": "archivo",
       "orden": 644,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En la pared cuelga un sol rojo del tamaño de un puño mientras la pantalla del monitor escupe estática sin parar, y el hombre de bata blanca espera a que alguno hable primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19893,8 +19893,8 @@
         "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e",
         "variante": 0
       },
-      "titulo": "Pulp image of High tech Room with A",
-      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "titulo": "El sol diminuto del monitor",
+      "alt": "Hombre calvo vestido con una bata blanca, sentado sobre una cama en una habitación de tonos azules y morados, junto a un monitor antiguo con interferencia en pantalla, un globo terráqueo y varios cables; en la pared se ve un círculo rojo brillante.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -19910,7 +19910,7 @@
       "serie": "archivo",
       "orden": 645,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Un anillo rojo rodea un agujero negro perfecto que flota sobre el mar, y el hombre de bata blanca sigue de espaldas a la computadora como si ese eclipse llevara ahí colgado toda la vida.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19924,8 +19924,8 @@
         "generacion": "f22e2dee-2188-4b5f-b0e3-11ac2a14ed5e",
         "variante": 3
       },
-      "titulo": "Pulp image of High tech Room with A",
-      "alt": "Pulp image of High tech Room with A patient dressed in white",
+      "titulo": "El eclipse sobre el mar",
+      "alt": "Hombre calvo con bata blanca sentado frente a una computadora antigua, en una habitación de tonos azules, con un mar al fondo y un círculo negro rodeado de un anillo rojo brillante en el cielo, como un eclipse.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -19941,7 +19941,7 @@
       "serie": "archivo",
       "orden": 646,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Doce pelícanos se reparten la orilla de arena frente a las casas de paja sobre pilotes, y arriba vuelan cuatro más, citados ahí desde antes de que se levantara el primer techo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19955,8 +19955,8 @@
         "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852",
         "variante": 1
       },
-      "titulo": "Real life portrayal of indigenous palafittes town over",
-      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "titulo": "Los pelícanos del palafito",
+      "alt": "Poblado de casas con techo de paja construidas sobre pilotes en el agua, con numerosos pelícanos y otras aves posados en la orilla arenosa en primer plano y varios volando sobre el lugar, bajo un cielo azul.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -19972,7 +19972,7 @@
       "serie": "archivo",
       "orden": 647,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una hilera de pelícanos vadea el agua justo entre los pilotes de las casas de paja, tan pegados unos a otros que de lejos parecen una sola ave con veinte cabezas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -19986,8 +19986,8 @@
         "generacion": "0f4debfd-4903-440b-ba3c-4beb6e220852",
         "variante": 2
       },
-      "titulo": "Real life portrayal of indigenous palafittes town over",
-      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "titulo": "Pelícanos entre los pilotes",
+      "alt": "Grupo de pelícanos de pie y nadando en el agua entre varias casas con techo de paja construidas sobre pilotes, bajo un cielo azul despejado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20003,7 +20003,7 @@
       "serie": "archivo",
       "orden": 648,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola canoa cruza el canal de agua entre las casas de palafito y el manglar, y el remo deja un único círculo en el agua que tarda más en desvanecerse que la canoa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20017,8 +20017,8 @@
         "generacion": "87cb74eb-39b5-4438-8dac-e870b91019c1",
         "variante": 2
       },
-      "titulo": "Real life portrayal of indigenous palafittes town over",
-      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "titulo": "La canoa entre los pilotes",
+      "alt": "Poblado de casas con techo de paja construidas sobre pilotes junto a un canal de agua rodeado de manglares, con una persona remando en una canoa de madera en el centro, bajo un cielo nublado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20034,7 +20034,7 @@
       "serie": "archivo",
       "orden": 649,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las nubes se enroscan en la misma punta que los techos de paja, y el remero cuenta que tardó tres tardes en distinguir cuál nube era cuál choza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20048,8 +20048,8 @@
         "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45",
         "variante": 0
       },
-      "titulo": "Real life portrayal of indigenous palafittes town over",
-      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "titulo": "Techos que calcan el cielo",
+      "alt": "Aldea de chozas cónicas de paja construida sobre el agua, con varias personas remando en canoas vestidas de naranja y rojo, bajo un cielo de nubes doradas y anaranjadas al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20065,7 +20065,7 @@
       "serie": "archivo",
       "orden": 650,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El zócalo rojo de las casas se refleja tan fijo en el canal que el remero guía la canoa sin remo, solo siguiendo la línea de pintura en el agua.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20079,8 +20079,8 @@
         "generacion": "e2262b4a-144b-4337-83fe-97d1f079fa45",
         "variante": 2
       },
-      "titulo": "Real life portrayal of indigenous palafittes town over",
-      "alt": "real life portrayal of indigenous palafittes town over caribb",
+      "titulo": "Paredes rojas bajo la luna",
+      "alt": "Vista nocturna de un canal entre casas de techo de paja con paredes de piedra pintadas de rojo y blanco, una persona de pie remando una canoa de madera, palmera a la derecha, cielo azul oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20096,7 +20096,7 @@
       "serie": "archivo",
       "orden": 651,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los puentes de madera atraviesan el poblado como venas encendidas, y siete personas cruzan a la vez sin que ninguna tabla cruja bajo su peso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20110,8 +20110,8 @@
         "generacion": "a5019004-e72d-4858-8b48-17400fbb3857",
         "variante": 3
       },
-      "titulo": "Realistic and cinematic panoramic view of an indigenous",
-      "alt": "Realistic and cinematic panoramic view of an indigenous city",
+      "titulo": "Puentes sobre el agua nocturna",
+      "alt": "Vista panorámica nocturna de un poblado de casas de techo de paja construidas sobre pilotes en el agua, unidas por puentes de madera iluminados de naranja, con personas caminando y una canoa en el canal central, bajo un cielo azul oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20127,7 +20127,7 @@
       "serie": "archivo",
       "orden": 652,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pintura turquesa del casco lleva tantos años descascarándose que el pelícano posado en la proa ya se cree el capitán y no deja subir a nadie más.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20141,8 +20141,8 @@
         "generacion": "2efae6ee-e3ee-4936-9605-cb2e677c59a9",
         "variante": 2
       },
-      "titulo": "Realistic photography of a Boat in the shore",
-      "alt": "Realistic photography of a Boat in the shore of a Venezuelan",
+      "titulo": "El pelícano al mando",
+      "alt": "Bote de madera viejo y descolorido, de color turquesa desgastado, varado en la orilla de una playa, con un pelícano parado sobre la proa, mar con olas y cielo nublado al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -20158,7 +20158,7 @@
       "serie": "archivo",
       "orden": 653,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol ocupa media ciudad y la figura en la punta de la torre más alta lleva noventa años parada ahí sin que el calor le queme ni una sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20172,8 +20172,8 @@
         "generacion": "62939855-b8b2-4dba-8245-c63fd4b39353",
         "variante": 1
       },
-      "titulo": "Red alien over the city in the style",
-      "alt": "red alien over the city in the style of soviet realism charle",
+      "titulo": "Guardián bajo el sol rojo",
+      "alt": "Figura humanoide delgada y alargada de pie sobre una torre, mirando una ciudad de agujas oscuras bajo un enorme sol o esfera roja que domina el cielo, con pequeñas naves volando, en tonos rojos y negros.",
       "w": 800,
       "h": 1289,
       "anchos": [
@@ -20188,7 +20188,7 @@
       "serie": "archivo",
       "orden": 654,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar de plumas azules y verdes cubre el pecho entero, tejido con setecientas plumas cosidas una por una, mientras la barbilla queda alzada hacia un sol que todavía no sale.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20202,8 +20202,8 @@
         "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717",
         "variante": 0
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "El collar de plumas azules",
+      "alt": "Retrato de un hombre con la piel pintada de rojo anaranjado y la nariz pintada de verde, aretes dorados de aro, y un grueso collar de plumas azules y verdes con cuentas blancas que le cubre el pecho, mirando hacia arriba contra un cielo despejado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20218,7 +20218,7 @@
       "serie": "archivo",
       "orden": 655,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Catorce líneas curvas le cruzan la cara de sien a mentón, y los discos de madera que le cuelgan de las orejas pesan lo bastante para marcar el rumbo del viento cuando camina.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20232,8 +20232,8 @@
         "generacion": "018b351d-85a4-4392-81c5-7a77ce4d8717",
         "variante": 2
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Líneas que cruzan el rostro",
+      "alt": "Retrato de un hombre con líneas curvas pintadas o tatuadas en todo el rostro, un aro grande en el tabique nasal, grandes discos de madera colgando de las orejas y un collar de cuentas de varias hileras, sobre un fondo desenfocado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20248,7 +20248,7 @@
       "serie": "archivo",
       "orden": 656,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las plumas rojas y azules le crecen detrás de cada oreja como si fueran alas, y cuando gira la cabeza despacio se nota que están a punto de levantar el vuelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20262,8 +20262,8 @@
         "generacion": "5ec1d003-c19a-48f7-8c7f-a506c44486cb",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Plumas rojas tras las orejas",
+      "alt": "Retrato de un hombre sobre fondo negro con plumas rojas y azules detrás de cada oreja, un aro dorado en la nariz, una raya blanca vertical en el rostro y un collar de cuentas azules con conchas blancas colgantes.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20278,7 +20278,7 @@
       "serie": "archivo",
       "orden": 657,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos dedos de plumas rojas bastan para coronarlo, mientras las cruces verdes pintadas en el pecho tardaron una luna entera en secar bajo el peso de las conchas blancas apiladas hasta la cintura.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20292,8 +20292,8 @@
         "generacion": "7fa94afc-329a-4585-836a-b712a7d90caa",
         "variante": 2
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "La corona de plumas rojas",
+      "alt": "Retrato de un hombre con una corona de plumas rojas y negras, pintura facial y corporal verde y roja en forma de líneas y cruces, aretes dorados de aro, un aro blanco en la nariz y varios collares de conchas que le cubren el pecho, sobre fondo negro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20308,7 +20308,7 @@
       "serie": "archivo",
       "orden": 658,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El aro de oro que le atraviesa la nariz da tres vueltas, y de las nueve hileras de cuentas rojas y azules cuelgan conchas que sonarían si el viento se atreviera a soplar fuerte.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20322,8 +20322,8 @@
         "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa",
         "variante": 0
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "El aro de oro retorcido",
+      "alt": "Retrato de cerca de un hombre con la piel de tono rojizo, un aro de oro retorcido en la nariz, aretes dorados de banda y un collar de varias hileras de cuentas rojas, doradas y azules del que cuelgan conchas.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20338,7 +20338,7 @@
       "serie": "archivo",
       "orden": 659,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las ondas verdes pintadas en la cara se curvan igual que el agua del fondo azul, y el broche de madera que cierra la banda del pecho lleva atado un nudo desde hace veinte inviernos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20352,8 +20352,8 @@
         "generacion": "9ce7c866-08d7-47b6-ad2c-929beadf66fa",
         "variante": 3
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Ondas verdes sobre la piel",
+      "alt": "Retrato de un hombre con la cara pintada con líneas verdes onduladas, grandes discos blancos colgando de las orejas, un mechón de plumas junto a la barbilla, un collar de cuentas ajustado al cuello y una banda tejida cruzada sobre el pecho, sobre fondo azul verdoso.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20368,7 +20368,7 @@
       "serie": "archivo",
       "orden": 660,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Una sola raya blanca le parte la cara al medio, trazada de un solo pulso que no tembló desde la frente hasta la punta de la barbilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20382,8 +20382,8 @@
         "generacion": "a16ea7ce-6349-4cee-ba1b-a7ff46c03a51",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "La raya blanca del rostro",
+      "alt": "Retrato de un hombre de cabello negro liso con una raya blanca pintada verticalmente en el centro del rostro, un gran aro dorado en el tabique nasal, aretes de disco con una pluma y varios collares de cuentas oscuras, sobre fondo gris oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20398,7 +20398,7 @@
       "serie": "archivo",
       "orden": 661,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La cresta de plumas negras se eriza sobre la banda roja como si el viento empujara desde atrás desde siempre, y las hebras turquesa del collar no dejan de moverse aunque él esté quieto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20412,8 +20412,8 @@
         "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Cresta de plumas negras",
+      "alt": "Retrato de un hombre con un tocado de plumas negras erguidas sobre una banda roja, líneas pintadas en el rostro, un aro dorado en la nariz, aretes redondos de color naranja y un collar de varias hileras de cuentas turquesa y blancas, sobre fondo gris.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20428,7 +20428,7 @@
       "serie": "archivo",
       "orden": 662,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tiene los ojos cerrados y dos rayas turquesa cruzándole las mejillas, y la piel le brilla tanto de dorado que el collar de conchas parece a punto de derretirse con el calor de la tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20442,8 +20442,8 @@
         "generacion": "b940115a-693b-475a-8e38-b9d221d0cbe9",
         "variante": 3
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Los ojos cerrados al cielo",
+      "alt": "Retrato de un hombre con los ojos cerrados, rayas de pintura turquesa en las mejillas, un doble aro dorado en la nariz, grandes discos de concha en las orejas y un collar de conchas y cuentas, sobre fondo de cielo azul, con la piel iluminada en tono dorado.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20458,7 +20458,7 @@
       "serie": "archivo",
       "orden": 663,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Solo la mitad derecha de la cara recibe la luz que entra por el marco azul de la puerta, y las perlas del arete brillan tanto que parecen haber guardado ese resplandor toda la noche.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20472,8 +20472,8 @@
         "generacion": "bed97181-246d-4dd0-b9da-4a916c78058a",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de un indgena nativo",
-      "alt": "Retrato de cuerpo entero de un indgena nativo americano del C",
+      "titulo": "Perlas en la penumbra",
+      "alt": "Retrato de una joven de cabello oscuro y rizado, con aretes de perla y un collar dorado, vestida con una blusa azul de flores, mirando directamente a la cámara con el rostro iluminado de un lado por luz lateral junto a un marco de puerta azul.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20488,7 +20488,7 @@
       "serie": "archivo",
       "orden": 664,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La diadema de cuentas azules le aprieta la frente desde antes del amanecer, y las conchas que le cuelgan del cuello en seis vueltas completas resuenan apenas gira el cuello hacia la estera tejida detrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20502,8 +20502,8 @@
         "generacion": "0555f135-5b4a-41a7-8707-6f91933d258e",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de una indgena nativo",
-      "alt": "Retrato de cuerpo entero de una indgena nativo americano del",
+      "titulo": "La diadema de cuentas azules",
+      "alt": "Retrato de una mujer con una diadema de cuentas, la cara pintada con rayas naranjas y negras, un aro en el tabique nasal, grandes aretes de concha y varios collares de cuentas azules y conchas, frente a un fondo de esteras tejidas.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20518,7 +20518,7 @@
       "serie": "archivo",
       "orden": 665,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Doce anillos amarillos le envuelven el cuello uno sobre otro, y las arrugas del rostro parecen haber tardado exactamente doce inviernos en formarse, uno por anillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20532,8 +20532,8 @@
         "generacion": "7f86effa-f1a1-4796-a175-4b67322d087a",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de una indgena nativo",
-      "alt": "Retrato de cuerpo entero de una indgena nativo americano del",
+      "titulo": "Los anillos amarillos del cuello",
+      "alt": "Retrato de una mujer mayor con el rostro marcado por arrugas, un aro dorado en la nariz, aretes dorados de aro y el cuello cubierto de anillos apretados de cuentas amarillas, además de collares de cuentas y conchas de varios colores.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20548,7 +20548,7 @@
       "serie": "archivo",
       "orden": 666,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En medio de las conchas del pecho hay un disco amarillo redondo como un sol pequeño, y la raya rosada de la frente no se ha corrido un milímetro en veinte veranos de barro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20562,8 +20562,8 @@
         "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de",
         "variante": 0
       },
-      "titulo": "Retrato de cuerpo entero de una mujer indgena",
-      "alt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+      "titulo": "El disco amarillo del pecho",
+      "alt": "Retrato de una mujer frente a una pared de adobe, con una raya rosada pintada verticalmente en la frente, un aro dorado en la nariz, grandes aretes de concha, anillos de cuentas amarillas en el cuello y collares de conchas con un colgante circular amarillo, vestida con tela a rayas azules y blancas.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20578,7 +20578,7 @@
       "serie": "archivo",
       "orden": 667,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las dos trenzas le llegan hasta la cintura y pesan tanto de tan largas que el colgante dorado que lleva al cuello parece flotar apenas, aliviado de no ser lo más pesado que carga.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20592,8 +20592,8 @@
         "generacion": "adb9a6f4-67d8-4bfc-b274-3727bf8c97de",
         "variante": 1
       },
-      "titulo": "Retrato de cuerpo entero de una mujer indgena",
-      "alt": "Retrato de cuerpo entero de una mujer indgena nativo american",
+      "titulo": "Las trenzas hasta la cintura",
+      "alt": "Retrato de una mujer con dos trenzas largas de cabello, vestida con una tela a rayas azules y verdes, un aro dorado en la nariz y varios collares de cuentas con un colgante dorado, iluminada con luz cálida contra una pared de textura rugosa.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20608,7 +20608,7 @@
       "serie": "archivo",
       "orden": 668,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De cada oreja le cuelgan tres perlas del tamaño de una uña, y el rojo de los labios es el único color que se atreve a interrumpir blanco y dorado bajo la oscuridad del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20622,8 +20622,8 @@
         "generacion": "47cd527b-e2aa-49e4-9b77-6184145eea1d",
         "variante": 2
       },
-      "titulo": "Retrato de indgena nativo americano del Caribe de",
-      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "titulo": "El rojo entre tanto blanco",
+      "alt": "Retrato de una mujer con grandes aretes de perlas y oro, dos aros dorados en la nariz, labios pintados de rojo y un collar de varias hileras de perlas, vestida con una blusa blanca de encaje, sobre un fondo oscuro con iluminación dramática.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20638,7 +20638,7 @@
       "serie": "archivo",
       "orden": 669,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Racimos de conchas doradas le cuelgan de cada oreja, veinte piezas exactas, y la luz anaranjada se mete entre las hileras rojas y blancas del collar hasta hacerlas brillar como brasas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20652,8 +20652,8 @@
         "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c",
         "variante": 1
       },
-      "titulo": "Retrato de indgena nativo americano del Caribe de",
-      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "titulo": "Conchas doradas en las orejas",
+      "alt": "Retrato de un hombre de cabello corto sobre fondo oscuro, con racimos de conchas doradas colgando de cada oreja, un aro en la nariz y un collar de varias hileras de cuentas rojas, blancas y doradas, bajo una luz cálida anaranjada.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20668,7 +20668,7 @@
       "serie": "archivo",
       "orden": 670,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El manto de tela clara le cae de un hombro y ni una arruga se atreve a moverse, mientras las cuentas azules, rojas y blancas del collar se enredan en nueve vueltas imposibles de deshacer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20682,8 +20682,8 @@
         "generacion": "aef3d91a-20fa-4222-8f1d-a40034a3fa4c",
         "variante": 3
       },
-      "titulo": "Retrato de indgena nativo americano del Caribe de",
-      "alt": "Retrato de indgena nativo americano del Caribe de la etnia Ca",
+      "titulo": "Manto claro en el hombro",
+      "alt": "Retrato de un joven de cabello rizado con pequeños aretes dorados de aro, un aro en la nariz y varios collares de cuentas azules, rojas y blancas, con una tela clara envuelta sobre un hombro, contra un fondo rojo oscuro.",
       "w": 800,
       "h": 1200,
       "anchos": [
@@ -20698,7 +20698,7 @@
       "serie": "archivo",
       "orden": 671,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La corbata roja es el único objeto de toda la sala que se niega a volverse verde, mientras detrás de la ventana giran exactamente tres molinos de viento que nadie en la mesa mira.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20712,8 +20712,8 @@
         "generacion": "dd4cc2ae-5f4c-401e-b83b-83dbfaab815a",
         "variante": 0
       },
-      "titulo": "Retro Add for a consulting firm Chucao Consultores",
-      "alt": "Retro Add for a consulting firm Chucao Consultores",
+      "titulo": "Corbata roja en la junta",
+      "alt": "Ilustración de estilo retro de dos hombres en traje sentados a una mesa de oficina, uno con corbata roja, con turbinas eólicas y colinas visibles a través de una ventana al fondo, en tonos verdes, rojos y anaranjados.",
       "w": 800,
       "h": 1062,
       "anchos": [
@@ -20728,7 +20728,7 @@
       "serie": "archivo",
       "orden": 672,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El anillo dorado que rodea la estación completa una vuelta cada nueve segundos exactos, y la luna pequeña de la esquina lleva siglos intentando alcanzar esa misma velocidad sin lograrlo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20742,8 +20742,8 @@
         "generacion": "12287928-6f83-4f8a-9959-63cafec14b72",
         "variante": 2
       },
-      "titulo": "Retro Animation of an spacestation orbitating on Saturns",
-      "alt": "Retro Animation of an spacestation orbitating on Saturns ring",
+      "titulo": "Los anillos de luz dorada",
+      "alt": "Ilustración de una estación espacial en forma de anillos concéntricos con luces doradas, rodeada por un anillo brillante de luz anaranjada, con una pequeña luna al fondo y montañas oscuras en primer plano, sobre un cielo estrellado azul oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -20759,7 +20759,7 @@
       "serie": "archivo",
       "orden": 673,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De la cabeza le nacen dieciséis espinas de alambre que se enroscan hacia todos lados sin terminar de decidir su forma, mientras los ojos dorados no parpadean desde que el metal se volvió piel.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20773,8 +20773,8 @@
         "generacion": "2fb1301e-399e-4f4b-a1b7-2dd2c93d8082",
         "variante": 2
       },
-      "titulo": "Roberto gomez sci fi cover art in the",
-      "alt": "roberto gomez sci fi cover art in the style of octavio ocampo",
+      "titulo": "La cabeza de espinas azules",
+      "alt": "Ilustración de una cabeza de rasgos humanoides y piel azul metálica, con decenas de espinas y cables de metal que salen de la cabeza como una corona, ojos dorados brillantes y detalles mecánicos en el cuello, sobre fondo color crema.",
       "w": 1024,
       "h": 1120,
       "anchos": [
@@ -20790,7 +20790,7 @@
       "serie": "archivo",
       "orden": 674,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El motor deja una llamarada rosa tan larga que agujerea el túnel azul por el que vuela, y aún no ha terminado de cerrarse cuando la nave ya está del otro lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20804,8 +20804,8 @@
         "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd",
         "variante": 2
       },
-      "titulo": "Scene of a Spaceship going through a Spacial",
-      "alt": "scene of a Spaceship going through a Spacial Wormhole",
+      "titulo": "Estela rosa en el vórtice",
+      "alt": "Nave espacial oscura con bordes azules atraviesa un túnel de luz blanca y azul rodeado de nebulosa púrpura y roja, con llamas rosadas saliendo de sus motores.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20821,7 +20821,7 @@
       "serie": "archivo",
       "orden": 675,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruza el remolino de fuego con la aleta en alto, y las vetas anaranjadas tardan trescientos años en cerrarse otra vez detrás del casco plateado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20835,8 +20835,8 @@
         "generacion": "4c807b3d-6182-4b8d-82f2-db099c1c40dd",
         "variante": 3
       },
-      "titulo": "Scene of a Spaceship going through a Spacial",
-      "alt": "scene of a Spaceship going through a Spacial Wormhole",
+      "titulo": "El casco entre las llamas",
+      "alt": "Nave espacial plateada con una aleta vertical vuela a través de un túnel de luz naranja y dorada rodeado de estrellas, formando un remolino incandescente.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20852,7 +20852,7 @@
       "serie": "archivo",
       "orden": 676,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La chaqueta de camuflaje azul y ladrillo le cubre tanto el cuerpo que dos pasajeros ya lo confundieron con el asiento antes de sentarse encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20866,8 +20866,8 @@
         "generacion": "2d4247cc-cd67-4dad-b1f3-6c36789edc1d",
         "variante": 0
       },
-      "titulo": "Scene of argentinian public transport bus ride a",
-      "alt": "Scene of argentinian public transport bus ride a hungover Man",
+      "titulo": "Camuflaje azul en el vagón",
+      "alt": "Hombre con gorra y chaqueta de camuflaje en tonos azul y rojo ladrillo, con lentes de sol de espejo verde, sentado en un vagón de tren junto a otros pasajeros.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -20883,7 +20883,7 @@
       "serie": "archivo",
       "orden": 677,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Levanta un solo brazo hacia el patio de columnas y la frase que suelta tarda tres mil años en dejar de repetirse entre los hombres sentados a sus pies.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20897,8 +20897,8 @@
         "generacion": "6ad819e7-3e24-4460-8518-3c8b39bb5306",
         "variante": 0
       },
-      "titulo": "Scene of Homer singing about the Illyad and",
-      "alt": "Scene of Homer singing about the Illyad and Odessy in a taber",
+      "titulo": "La voz entre las columnas",
+      "alt": "Pintura de un hombre de pie con toga gesticulando ante un grupo de hombres sentados con túnicas, en un patio con columnas de piedra bajo luz cálida.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20914,7 +20914,7 @@
       "serie": "archivo",
       "orden": 678,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Junto a la cama, las charreteras doradas de los oficiales alineados brillan más que el sol de mediodía que entra a raudales por la puerta abierta detrás de ellos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20928,8 +20928,8 @@
         "generacion": "0a7391d9-5052-44f8-b57a-d17757848082",
         "variante": 0
       },
-      "titulo": "Scene of Simn Bolvar in his deathbed seen",
-      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "titulo": "Charreteras contra el sol",
+      "alt": "Pintura de un hombre acostado en una cama junto a una ventana, rodeado de hombres con uniformes militares oscuros, con una puerta abierta que deja entrar luz brillante.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20945,7 +20945,7 @@
       "serie": "archivo",
       "orden": 679,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las medallas del pecho reflejan tanta luz de ventana que los dos oficiales sentados a los lados quedan medio a oscuras, esperando su turno para brillar también.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20959,8 +20959,8 @@
         "generacion": "75e515dc-1fe8-48a2-bbaa-95770413a122",
         "variante": 0
       },
-      "titulo": "Scene of Simn Bolvar in his deathbed seen",
-      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "titulo": "Medallas a contraluz",
+      "alt": "Pintura de un hombre joven con uniforme militar oscuro y medallas, sentado entre otros dos hombres uniformados, con luz de ventana detrás.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -20976,7 +20976,7 @@
       "serie": "archivo",
       "orden": 680,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mano enguantada tarda un minuto entero en cruzar el último centímetro hasta el hombro dormido, mientras los demás oficiales esperan sin moverse un pelo desde la sombra del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -20990,8 +20990,8 @@
         "generacion": "8e64f248-d0d5-4f2a-9321-56bda8666c62",
         "variante": 0
       },
-      "titulo": "Scene of Simn Bolvar in his deathbed seen",
-      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "titulo": "El último centímetro",
+      "alt": "Pintura de un hombre acostado en una cama mientras otro hombre con uniforme militar oscuro se inclina hacia él, con más oficiales de pie detrás en una habitación en penumbra.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21007,7 +21007,7 @@
       "serie": "archivo",
       "orden": 681,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El candelabro de la habitación sigue apagado porque la luz que entra por la puerta abierta ya alcanza para iluminar hasta el retrato colgado en la pared del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21021,8 +21021,8 @@
         "generacion": "a4542761-8cf0-4689-927e-78e98a94ae8a",
         "variante": 3
       },
-      "titulo": "Scene of Simn Bolvar in his deathbed seen",
-      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "titulo": "El candelabro apagado",
+      "alt": "Pintura de un hombre acostado en una cama con dosel cerca de una puerta abierta iluminada, rodeado de varios hombres con uniformes militares, con un candelabro colgando del techo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21038,7 +21038,7 @@
       "serie": "archivo",
       "orden": 682,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La manga roja del hombre que se inclina sobre el colchón es lo único que el cuarto entero deja ver con claridad, aunque haya una decena de testigos apretados contra las paredes oscuras.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21052,8 +21052,8 @@
         "generacion": "d80aca38-fb5b-4016-95eb-914dbd40e58e",
         "variante": 3
       },
-      "titulo": "Scene of Simn Bolvar in his deathbed seen",
-      "alt": "Scene of Simn Bolvar in his deathbed seen with a pale face an",
+      "titulo": "La manga roja",
+      "alt": "Pintura de un hombre acostado en una cama rodeado de varias personas en una habitación oscura, con un hombre vestido de rojo inclinado cerca de él y un candelabro en el techo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21069,7 +21069,7 @@
       "serie": "archivo",
       "orden": 683,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya las dos manos en la baranda de proa y el rayo que parte la nube en dos tarda un segundo entero en apagarse detrás de su silueta inmóvil.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21083,8 +21083,8 @@
         "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8",
         "variante": 0
       },
-      "titulo": "Scene of Simn Bolvar on the deck of",
-      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "titulo": "Silueta frente al relámpago",
+      "alt": "Silueta de un hombre apoyado en la baranda de un barco de noche, mirando hacia nubes de tormenta iluminadas por un relámpago sobre el mar.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21100,7 +21100,7 @@
       "serie": "archivo",
       "orden": 684,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Abre los brazos en la cubierta y la nube que se levanta encima toma la forma exacta de la explosión anaranjada que arde todavía en el horizonte del mar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21114,8 +21114,8 @@
         "generacion": "304e3660-5098-4178-9952-b7cbb608f6e8",
         "variante": 3
       },
-      "titulo": "Scene of Simn Bolvar on the deck of",
-      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "titulo": "Los brazos abiertos al fuego",
+      "alt": "Hombre con uniforme militar de pie en la cubierta de un barco con los brazos extendidos, frente a una gran nube en forma de hongo y un resplandor anaranjado en el horizonte marino.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21131,7 +21131,7 @@
       "serie": "archivo",
       "orden": 685,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Mira la luna llena sin parpadear un solo segundo, y el poncho a rayas no se le mueve ni un hilo pese al viento verde que cruza el cielo sobre el mar picado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21145,8 +21145,8 @@
         "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252",
         "variante": 0
       },
-      "titulo": "Scene of Simn Bolvar on the deck of",
-      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "titulo": "La luna sin parpadear",
+      "alt": "Hombre con poncho a rayas de pie en la cubierta de un barco de noche, mirando hacia una luna llena rodeada de una nube verdosa sobre un mar agitado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21162,7 +21162,7 @@
       "serie": "archivo",
       "orden": 686,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La trompa de agua que sube del mar es tan alta que se traga media aurora antes de que el sol termine de asomar sobre la baranda donde él se queda mirando sin moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21176,8 +21176,8 @@
         "generacion": "e2ea718d-771b-4043-ae29-65dfbd73c252",
         "variante": 1
       },
-      "titulo": "Scene of Simn Bolvar on the deck of",
-      "alt": "scene of Simn Bolvar on the deck of a 1800s Frigate in the ca",
+      "titulo": "La trompa de agua",
+      "alt": "Hombre de espaldas junto a la baranda de un barco observando una gran tromba marina que se eleva del océano al amanecer, con el cielo en tonos azules y anaranjados.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21193,7 +21193,7 @@
       "serie": "archivo",
       "orden": 687,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al lado de la barra metálica el reflejo se parte en un arcoíris tan completo que ni la camisa a cuadros que lleva puesta consigue quedarse con un solo color.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21207,8 +21207,8 @@
         "generacion": "f905279b-05cf-4f9d-b8f5-6af920e91b5d",
         "variante": 3
       },
-      "titulo": "Scene of the young man from Argentina is",
-      "alt": "scene of the young man from Argentina is on a public transpor",
+      "titulo": "El prisma en la barra",
+      "alt": "Joven de cabello oscuro y rizado con camisa a cuadros azul sobre una camiseta naranja, de pie junto a una barra metálica en un vagón oscuro, con reflejos de luces de colores a un lado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21224,7 +21224,7 @@
       "serie": "archivo",
       "orden": 688,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sol de la tarde le entra de lleno por la ventanilla y le funde las rayas de la camisa con el color mostaza de la chaqueta que lleva encima de los hombros.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21238,8 +21238,8 @@
         "generacion": "34082082-9a1a-4d85-bd97-a5fab48f118b",
         "variante": 0
       },
-      "titulo": "Scene of the young man is on a",
-      "alt": "scene of the young man is on a public transport in the style",
+      "titulo": "El sol funde las rayas",
+      "alt": "Joven de cabello oscuro y rizado con chaqueta color mostaza sobre una camisa a rayas, sentado dentro de un autobús o tren iluminado por luz solar cálida.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21255,7 +21255,7 @@
       "serie": "archivo",
       "orden": 689,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las barras rojas y anaranjadas le cruzan la cara de arriba abajo tan cerca del lente que casi tapan del todo la camisa a rayas que lleva debajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21269,8 +21269,8 @@
         "generacion": "681333a3-0395-4204-9dc7-22bf09dd2a16",
         "variante": 0
       },
-      "titulo": "Scene of the young man is on a",
-      "alt": "scene of the young man is on a public transport in the style",
+      "titulo": "Barrotes de color",
+      "alt": "Joven de cabello rizado con camisa a rayas mirando hacia la cámara desde el interior de un autobús o tren, con franjas verticales borrosas de color rojo y naranja en primer plano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21286,7 +21286,7 @@
       "serie": "archivo",
       "orden": 690,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El neón azul y anaranjado del vagón se le mete en los rizos y por un momento parece que el propio cabello estuviera encendido desde adentro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21300,8 +21300,8 @@
         "generacion": "63444059-a463-4ac5-bef9-74e04607b531",
         "variante": 0
       },
-      "titulo": "Scene of the young woman from Chile is",
-      "alt": "scene of the young woman from Chile is on a public transport",
+      "titulo": "El neón en los rizos",
+      "alt": "Joven de cabello rizado y castaño con camisa a rayas dentro de un vagón, atravesada por franjas verticales borrosas de luz azul y naranja.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21317,7 +21317,7 @@
       "serie": "archivo",
       "orden": 691,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz dorada del techo del vagón le cae tan derecha sobre el flequillo que parece peinada por la misma lámpara que ilumina el resto del pasillo vacío.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21331,8 +21331,8 @@
         "generacion": "d6a0a1b7-db61-4fe8-9171-d12f4246d785",
         "variante": 0
       },
-      "titulo": "Scene of the young woman from Chile is",
-      "alt": "scene of the young woman from Chile is on a public transport",
+      "titulo": "Flequillo bajo luz dorada",
+      "alt": "Joven de cabello oscuro con flequillo y camisa a cuadros, sentada en un vagón iluminado con luz dorada y franjas de colores anaranjado y azul a un costado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21348,7 +21348,7 @@
       "serie": "archivo",
       "orden": 692,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pelo rubio se le esponja contra la ventana del bus naranja hasta ocupar el mismo espacio que ella y su chaqueta de flores juntas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21362,8 +21362,8 @@
         "generacion": "8abe0443-a148-4cbe-b520-30e9624eb34c",
         "variante": 1
       },
-      "titulo": "Scene of the young woman is on a",
-      "alt": "scene of the young woman is on a public transport in the styl",
+      "titulo": "Melena rubia contra la ventana",
+      "alt": "Mujer con cabello rubio voluminoso y chaqueta azul con estampado de flores naranjas, sentada dentro de un autobús de color naranja, tocándose el cabello con una mano.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21379,7 +21379,7 @@
       "serie": "archivo",
       "orden": 693,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El abrigo marrón y peludo le ocupa tanto asiento azul vacío a los lados que nadie más se anima a sentarse en el resto del vagón.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21393,8 +21393,8 @@
         "generacion": "dc2ff759-7ad6-478e-9dab-6b5393a45412",
         "variante": 0
       },
-      "titulo": "Scene of the young woman is on a",
-      "alt": "scene of the young woman is on a public transport in the styl",
+      "titulo": "Sola entre los asientos azules",
+      "alt": "Mujer de cabello blanco y rizado con abrigo marrón peludo, sentada sola en un vagón de metro con asientos azules, mirando hacia abajo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21410,7 +21410,7 @@
       "serie": "archivo",
       "orden": 694,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La capucha de piel rubia le cubre la cabeza entera y le suma el ancho de dos pasajeros más en un bus donde ya no cabe nadie sentado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21424,8 +21424,8 @@
         "generacion": "ee5965eb-07ae-45f3-a4a0-c988b2722a78",
         "variante": 0
       },
-      "titulo": "Scene of the young woman is on a",
-      "alt": "scene of the young woman is on a public transport in the styl",
+      "titulo": "Capucha de piel rubia",
+      "alt": "Hombre con capucha de piel rubia y abrigo turquesa sostiene una bolsa negra dentro de un autobús lleno de pasajeros.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21441,7 +21441,7 @@
       "serie": "archivo",
       "orden": 695,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El manto rojo se le enciende de a poco a medida que camina hacia el resplandor del fondo de la cueva, mientras dos figuras iguales lo observan sin moverse desde los huecos de la roca.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21455,8 +21455,8 @@
         "generacion": "a8d88371-5c6f-4ddc-91d3-2f1ec0d72868",
         "variante": 0
       },
-      "titulo": "Simn Bolvar enters the Purgatory and finds Dante",
-      "alt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+      "titulo": "El manto rojo",
+      "alt": "Pintura de un hombre con manto rojo caminando por un pasadizo rocoso hacia una luz anaranjada al fondo, con dos figuras encapuchadas de rojo de pie en nichos a los lados.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21472,7 +21472,7 @@
       "serie": "archivo",
       "orden": 696,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mano se estira hacia el borde del cráter con tanta confianza que el fuego de abajo parece a punto de subir a saludarla, mientras el otro hombre no suelta la espada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21486,8 +21486,8 @@
         "generacion": "a936a203-e1ab-4d0e-8ae4-41d35a108811",
         "variante": 2
       },
-      "titulo": "Simn Bolvar enters the Purgatory and finds Dante",
-      "alt": "Simn Bolvar enters the Purgatory and finds Dante Alighieri an",
+      "titulo": "La mano sobre el cráter",
+      "alt": "Pintura de dos hombres de pie junto a un gran cráter de lava incandescente, uno con capa roja y espada y otro extendiendo una mano hacia el fuego.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -21503,7 +21503,7 @@
       "serie": "archivo",
       "orden": 697,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La capa roja del jinete de adelante flamea y se lleva por delante el resplandor del volcán que revienta detrás de la fila de caballos, como si el fuego mismo la persiguiera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21517,8 +21517,8 @@
         "generacion": "85d12035-36a3-40ab-a678-e708ff55a100",
         "variante": 0
       },
-      "titulo": "Simn Bolvar enters the Purgatory and meets Dante",
-      "alt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+      "titulo": "La capa contra el volcán",
+      "alt": "Pintura de un grupo de jinetes armados cabalgando por un paso rocoso de montaña, con un volcán en erupción y relámpagos en el cielo al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21534,7 +21534,7 @@
       "serie": "archivo",
       "orden": 698,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El casco negro del jinete brilla tan poco entre el pelaje rojo de los caballos que el hombre encapuchado que se acerca corriendo tiene que estirar el brazo entero para no perderlo de vista.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21548,8 +21548,8 @@
         "generacion": "85d12035-36a3-40ab-a678-e708ff55a100",
         "variante": 2
       },
-      "titulo": "Simn Bolvar enters the Purgatory and meets Dante",
-      "alt": "Simn Bolvar enters the Purgatory and meets Dante Alighieri an",
+      "titulo": "Casco negro, caballos rojos",
+      "alt": "Pintura de varios jinetes con armadura montando caballos de color rojizo por un paso de montaña rocoso, con un hombre encapuchado extendiendo el brazo hacia ellos.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -21565,7 +21565,7 @@
       "serie": "archivo",
       "orden": 699,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luz le entra por el ala del sombrero y le tarda cuarenta años en llegar hasta las cuerdas del cuatro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21579,8 +21579,8 @@
         "generacion": "3ec2e540-a240-4f18-b44d-ad17a455ce45",
         "variante": 0
       },
-      "titulo": "Simn Diaz with a Llanero Hat playing the",
-      "alt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+      "titulo": "Cuatro bajo el ala",
+      "alt": "Hombre joven con sombrero de ala ancha toca un cuatro en una fotografía en blanco y negro, con luz lateral fuerte contra un fondo oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21596,7 +21596,7 @@
       "serie": "archivo",
       "orden": 700,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva un sol pequeño detenido justo detrás de la nuca, y ni las dos torres de piedra tallada logran repartirse esa luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21610,8 +21610,8 @@
         "generacion": "e9b31c68-8e56-4d39-9e30-64e3501c8825",
         "variante": 0
       },
-      "titulo": "Simn Diaz with a Llanero Hat playing the",
-      "alt": "Simn Diaz with a Llanero Hat playing the instrument Cuatro an",
+      "titulo": "Halo entre torres de piedra",
+      "alt": "Hombre con traje blanco y corbata negra toca una guitarra frente a dos templos de piedra tallada, con un halo dorado detrás de la cabeza sobre fondo oscuro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21627,7 +21627,7 @@
       "serie": "archivo",
       "orden": 701,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El bote azul lleva tanta agua transparente pegada al casco que desde la orilla nadie sabe si flota o si ya echó raíces en el arrecife.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21641,8 +21641,8 @@
         "generacion": "5768b748-4766-436f-8721-2171acc25c90",
         "variante": 3
       },
-      "titulo": "Slice of life a blue jaiba in the",
-      "alt": "Slice of life a blue jaiba in the caribbean in Venezuela",
+      "titulo": "Bote varado en el arrecife",
+      "alt": "Bote de madera azul varado sobre un arrecife de coral en aguas turquesas poco profundas, con casas de techo de paja en la orilla bajo un cielo nublado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21658,7 +21658,7 @@
       "serie": "archivo",
       "orden": 702,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Quieto detrás del mostrador se le queda el chaleco verde, mientras Caracas entera parpadea a sus espaldas, luz por luz, como si esperara turno.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21672,8 +21672,8 @@
         "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993",
         "variante": 0
       },
-      "titulo": "Slice of life an arepera in Caracas",
-      "alt": "Slice of life an arepera in Caracas",
+      "titulo": "El mostrador frente al horizonte",
+      "alt": "Dos hombres detrás de un mostrador de madera por la noche, uno con chaleco verde y corbata, con el perfil iluminado de la ciudad al fondo en tonos azules.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21689,7 +21689,7 @@
       "serie": "archivo",
       "orden": 703,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El azul de la pared se come toda la calle y solo deja un rectángulo de luz cálida donde el hombre despacha su café sin apuro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21703,8 +21703,8 @@
         "generacion": "e45e87c0-9c90-4bd6-9201-7db2f4906993",
         "variante": 1
       },
-      "titulo": "Slice of life an arepera in Caracas",
-      "alt": "Slice of life an arepera in Caracas",
+      "titulo": "La ventana de la bodega",
+      "alt": "Hombre de camisa blanca detrás del mostrador de un pequeño negocio con paredes azules, con tazas y frascos sobre la mesa, iluminado desde adentro al anochecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21720,7 +21720,7 @@
       "serie": "archivo",
       "orden": 704,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le cruzan la cara líneas naranjas que imitan, sin quererlo, los pilotes que cruzan el agua, mientras el hombre de la canoa reparte naranjas como si repartiera el mismo sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21734,8 +21734,8 @@
         "generacion": "3bbd9168-384a-4a91-ab86-32bf1b2438bd",
         "variante": 0
       },
-      "titulo": "Slice of life human interaction in a",
-      "alt": "slice of life human interaction in a",
+      "titulo": "Rostro pintado sobre el agua",
+      "alt": "Mujer con el rostro pintado con líneas naranjas y aretes dorados, envuelta en un chal tejido gris, frente a un pueblo de casas sobre pilotes en agua turquesa, con un hombre remando una canoa detrás.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -21751,7 +21751,7 @@
       "serie": "archivo",
       "orden": 705,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada gota que se le pega al vidrio dobla una luz de la ciudad, así que abajo no caben veinte edificios sino el doble, empañados y encendidos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21765,8 +21765,8 @@
         "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
         "variante": 1
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "Ventana empañada de ciudad",
+      "alt": "Vista nocturna de una ciudad con edificios iluminados y una montaña cubierta de nubes al fondo, fotografiada a través de un vidrio salpicado de gotas de lluvia.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21782,7 +21782,7 @@
       "serie": "archivo",
       "orden": 706,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tanto polvo del camino se le pega al sedán azul que termina haciendo juego con el techo de paja de la bomba, como si los hubieran pintado el mismo día.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21796,8 +21796,8 @@
         "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
         "variante": 2
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "Sedán y bomba roja",
+      "alt": "Automóvil sedán azul estacionado frente a una estación de gasolina rural con techo de paja y un surtidor rojo, rodeada de vegetación.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21813,7 +21813,7 @@
       "serie": "archivo",
       "orden": 707,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las dos espaldas llevan sentadas ahí el tiempo suficiente para que se les hayan encendido, una por una, las mismas luces que ahora miran allá abajo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21827,8 +21827,8 @@
         "generacion": "17d60dea-cf51-47e9-a146-9d5947017e99",
         "variante": 3
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "Dos espaldas y la ciudad",
+      "alt": "Dos personas sentadas de espaldas mirando una ciudad iluminada al anochecer, enmarcadas por una ventana, con montañas oscuras y nubes al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21844,7 +21844,7 @@
       "serie": "archivo",
       "orden": 708,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tan chiquito es el foco del quiosco que ni once torres de la ciudad, todas encendidas a la vez detrás, consiguen apagárselo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21858,8 +21858,8 @@
         "generacion": "4667fe02-a4b6-4a94-837c-d688980c8861",
         "variante": 1
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "El quiosco contra los rascacielos",
+      "alt": "Hombre de pie junto a un quiosco de comida iluminado, con una nevera roja al frente y una hilera de edificios altos iluminados detrás al anochecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21875,7 +21875,7 @@
       "serie": "archivo",
       "orden": 709,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El vestido de flores azules le compite en color a las naranjas que tiene al lado, y en esa mesa nadie sabría decir cuál de las dos cosas maduró primero.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21889,8 +21889,8 @@
         "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6",
         "variante": 2
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "Vestido azul en el balcón",
+      "alt": "Mujer mayor de cabello blanco sentada en un balcón con un vestido de flores azules, junto a una mesa con frascos y naranjas, rodeada de plantas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21906,7 +21906,7 @@
       "serie": "archivo",
       "orden": 710,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Encendido sigue el televisor viejo en la esquina, aunque la ciudad entera, con su torre más alta incluida, se proyecte gratis y en grande por la ventana de al lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21920,8 +21920,8 @@
         "generacion": "d0acdc97-0baa-49ad-94a2-afffa265b0a6",
         "variante": 3
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "La sala y la torre",
+      "alt": "Sala de estar con un televisor antiguo, una repisa con diplomas enmarcados y una alfombra, frente a un gran ventanal con vista a edificios altos de la ciudad.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21937,7 +21937,7 @@
       "serie": "archivo",
       "orden": 711,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los libros se le acumulan por los dos costados del puesto hasta taparle casi la entrada, y aun así el hombre de adentro encuentra sitio para sentarse a leer otro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21951,8 +21951,8 @@
         "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837",
         "variante": 2
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "Libros a cielo abierto",
+      "alt": "Vista desde arriba de un puesto de libros usados al aire libre con estantes a ambos lados y cuadros colgados, con un hombre sentado leyendo adentro, rodeado de vegetación.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21968,7 +21968,7 @@
       "serie": "archivo",
       "orden": 712,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tan derecho se sienta el perro blanco junto a la silla de ruedas que entre los dos parecen montar guardia igual, uno con patas y el otro con llantas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -21982,8 +21982,8 @@
         "generacion": "dbe6719d-3555-43d4-9a8d-bfcc731cf837",
         "variante": 3
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "El perro blanco de guardia",
+      "alt": "Hombre en silla de ruedas con gorra y chaleco, sentado junto a un perro blanco grande, frente a una pared gris con un borde de acera pintado de rojo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -21999,7 +21999,7 @@
       "serie": "archivo",
       "orden": 713,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las macetas lo rodean tan apretadas que primero hay que cruzar todo un jardín colgante para llegar hasta él, y después toda la ciudad encendida para llegar hasta las montañas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22013,8 +22013,8 @@
         "generacion": "df4c31f8-92be-4307-a94e-2a8cf1110b9b",
         "variante": 3
       },
-      "titulo": "Slice of life in Caracas",
-      "alt": "Slice of life in Caracas",
+      "titulo": "El hombre entre las macetas",
+      "alt": "Hombre mayor de pie en un balcón rodeado de macetas con flores, con vista a una ciudad iluminada y montañas al fondo durante el atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22030,7 +22030,7 @@
       "serie": "archivo",
       "orden": 714,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Afuera, sobre una mesita junto a la puerta azul, vive el televisor, como si la señal le llegara más clara entre las macetas que dentro de la casa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22044,8 +22044,8 @@
         "generacion": "5bfefad7-2aaf-42d3-95f4-d04bfb358b0e",
         "variante": 2
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "Slice of life in Paraguan",
+      "titulo": "El televisor en el jardín",
+      "alt": "Casa blanca con techo de tejas y puertas azules, con un hombre mayor sentado a una mesa afuera y un televisor antiguo sobre una mesita junto a la entrada, rodeada de plantas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22061,7 +22061,7 @@
       "serie": "archivo",
       "orden": 715,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La refinería enciende toda la orilla de enfrente con más luces de las que ellos tres necesitan para ver el vaso que tienen sobre la mesa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22075,8 +22075,8 @@
         "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
         "variante": 0
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "slice of life in Paraguan",
+      "titulo": "La refinería al otro lado",
+      "alt": "Tres hombres sentados de espaldas bajo un techo de palma al anochecer, mirando hacia una refinería industrial iluminada al otro lado del agua.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22092,7 +22092,7 @@
       "serie": "archivo",
       "orden": 716,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Detrás deja el carro una nube de humo tan azul que por un segundo se confunde con la última luz de la tarde que todavía baja por la calle.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22106,8 +22106,8 @@
         "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
         "variante": 1
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "slice of life in Paraguan",
+      "titulo": "Humo azul en la calle",
+      "alt": "Automóvil oscuro circulando por una calle de un pueblo al anochecer, dejando una nube de humo detrás, con casas y un poste de electricidad alrededor.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22123,7 +22123,7 @@
       "serie": "archivo",
       "orden": 717,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Firme se le mantiene el sombrero blanco mientras reparte comida a dos manos, como si llevara la mesa entera bajo el ala y no se le fuera a caer nada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22137,8 +22137,8 @@
         "generacion": "8382763d-965f-4f4c-9d63-73f4e113bfc2",
         "variante": 2
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "slice of life in Paraguan",
+      "titulo": "El sombrero blanco que reparte",
+      "alt": "Hombre con sombrero blanco y camisa azul sonríe mientras sirve comida desde bandejas grandes, rodeado de otras personas bajo un techo de palma.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22154,7 +22154,7 @@
       "serie": "archivo",
       "orden": 718,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La buganvilia le echa flores rojas a la puerta azul todo el año, y los dos hombres de las sillas ya ni levantan la vista para agradecerle la sombra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22168,8 +22168,8 @@
         "generacion": "b196dcb9-3009-46c4-b1d0-9ee246b4e450",
         "variante": 1
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "slice of life in Paraguan",
+      "titulo": "Buganvilia sobre la puerta azul",
+      "alt": "Dos hombres conversan sentados en sillas frente a una puerta azul, bajo una buganvilia con flores rojas, junto a una motocicleta estacionada.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22185,7 +22185,7 @@
       "serie": "archivo",
       "orden": 719,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tanto brillo le roba al sol de mediodía el verde oscuro del carro, que hasta la cal blanca de la fachada parece un poco más pálida a su lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22199,8 +22199,8 @@
         "generacion": "b5876fbf-db3a-406c-9202-6b1bc5df2995",
         "variante": 1
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "slice of life in Paraguan",
+      "titulo": "Deportivo verde y casa blanca",
+      "alt": "Automóvil deportivo verde oscuro estacionado frente a una casa blanca de techo de tejas con puerta roja, bajo la sombra de un árbol en un día soleado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22216,7 +22216,7 @@
       "serie": "archivo",
       "orden": 720,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El polvo dorado que flota en la luz de la tarde se le pega igual al sombrero del hombre que a la montaña de panes redondos que tiene delante.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22230,8 +22230,8 @@
         "generacion": "d18ea9ff-19be-43d8-91c9-21e83b93e33e",
         "variante": 3
       },
-      "titulo": "Slice of life in Paraguan",
-      "alt": "Slice of life in Paraguan",
+      "titulo": "Luz dorada en la bodega",
+      "alt": "Hombre con sombrero blanco y abrigo gris detrás de un mostrador con panes redondos, entre dos hombres más, con frascos y botellas en los estantes detrás, iluminado por luz dorada.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22247,7 +22247,7 @@
       "serie": "archivo",
       "orden": 721,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tan blancas abre las alas la garza que hasta la casa anaranjada de atrás se ve un poco más apagada mientras ella cruza el aire sobre las flores.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22261,8 +22261,8 @@
         "generacion": "32506529-5437-4b2e-b247-b941381b0542",
         "variante": 2
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "La garza sobre las flores",
+      "alt": "Garza blanca en pleno vuelo sobre un campo de flores silvestres al atardecer, con una casa de color naranja y ventanas verdes al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22278,7 +22278,7 @@
       "serie": "archivo",
       "orden": 722,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La sonrisa le llena tanto la cara como el arroz le llena el plato verde que tiene servido sobre la mesa de la cocina.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22292,8 +22292,8 @@
         "generacion": "5760ecff-f143-4d8b-862a-a9214bf584a9",
         "variante": 0
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Sonrisa junto a la olla",
+      "alt": "Mujer mayor sonriente con vestido floral y cuello de encaje, de pie frente a una mesa de cocina con un plato de arroz y varias ollas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22309,7 +22309,7 @@
       "serie": "archivo",
       "orden": 723,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Derechito baja hasta el mar el camino de tierra roja, y esa noche trae tantas estrellas prendidas que hasta las olas parecen querer devolver algunas a la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22323,8 +22323,8 @@
         "generacion": "6b1ec78b-13d5-4ece-88c8-380e7f249c5f",
         "variante": 0
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Camino rojo hacia el mar",
+      "alt": "Camino de tierra roja que baja entre casas de techo de paja hasta una bahía de noche, con una casa azul y una cerca blanca a un lado, bajo un cielo estrellado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22340,7 +22340,7 @@
       "serie": "archivo",
       "orden": 724,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Apoya el talón descalzo en la baranda blanca y desde ahí controla la marea, que no se atreve a subir un peldaño más mientras él no termine el trago.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22354,8 +22354,8 @@
         "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1",
         "variante": 2
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "El balcón que bebe mar",
+      "alt": "Persona con camisa floral sentada en un balcón, con los pies descalzos apoyados en una baranda blanca junto a macetas de flores rosadas, frente al mar bajo un cielo azul de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22371,7 +22371,7 @@
       "serie": "archivo",
       "orden": 725,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajo la sombra espesa del árbol, la conversación de tres camisas blancas dura tanto que dos veleros cruzan el horizonte antes de que alguien pague la cuenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22385,8 +22385,8 @@
         "generacion": "6f0ba75b-ef07-416b-82b1-066bb66464c1",
         "variante": 3
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Tres camisas frente al golfo",
+      "alt": "Tres hombres con camisas blancas conversan sentados a una mesa bajo un árbol grande, en una terraza con columnas, frente al mar donde se ven veleros a lo lejos.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22402,7 +22402,7 @@
       "serie": "archivo",
       "orden": 726,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El único rayo de sol del patio entra recto por la puerta pintada y ni un paso se atreve a salir de su carril hasta que cae la tarde.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22416,8 +22416,8 @@
         "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d",
         "variante": 1
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Rayo recto en el patio",
+      "alt": "Casa rural de paredes blancas y techo de tejas bajo árboles frondosos, con una franja de luz solar que atraviesa un patio en sombra hasta la puerta abierta, donde se distingue una figura infantil; a la izquierda una persona sentada a una mesa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22433,7 +22433,7 @@
       "serie": "archivo",
       "orden": 727,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El de la camiseta azul pedalea tan fuerte que dos bicicletas más se ven obligadas a perseguirlo sin que él haya mirado nunca hacia atrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22447,8 +22447,8 @@
         "generacion": "96c65f44-90f3-4173-bd11-7263f8f2712d",
         "variante": 3
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Tres bicicletas en el polvo",
+      "alt": "Tres niños montan bicicletas por un camino de tierra frente a casas de tablones de madera con techo de zinc; el que va adelante viste camiseta azul, roja y blanca.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22464,7 +22464,7 @@
       "serie": "archivo",
       "orden": 728,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La motocicleta azul lleva tanto tiempo apoyada en la pata de cabra frente al rancho de paja que la buganvilia ya le trepó medio manubrio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22478,8 +22478,8 @@
         "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571",
         "variante": 0
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Moto azul frente al rancho",
+      "alt": "Motocicleta azul estacionada frente a una casa de paredes blancas con techo de paja y puerta azul, rodeada de arbustos con flores rosadas y un cactus.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22495,7 +22495,7 @@
       "serie": "archivo",
       "orden": 729,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Pedalea despacio frente a la puerta amarilla justo cuando el azul de la noche empieza a comerse las tejas, y ninguno de los dos colores gana.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22509,8 +22509,8 @@
         "generacion": "a25f9e10-5f28-4c48-bb24-a247ef31f571",
         "variante": 1
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Ciclista de la puerta amarilla",
+      "alt": "Hombre con gorra monta una bicicleta frente a una casa colonial de paredes claras, puerta amarilla y techo de tejas, al atardecer, con flores rojas junto a la reja.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22526,7 +22526,7 @@
       "serie": "archivo",
       "orden": 730,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruza las manos sobre el vestido azul y espera tan quieta en su puerta que las flores blancas de al lado llevan una hora sin decidirse a caer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22540,8 +22540,8 @@
         "generacion": "a53629f5-d506-493e-b9aa-1475137902e0",
         "variante": 0
       },
-      "titulo": "Slice of life in the Pennsula of Paraguan",
-      "alt": "slice of life in the Pennsula of Paraguan",
+      "titulo": "Guardiana del portal florido",
+      "alt": "Mujer mayor de cabello blanco y vestido azul de pie en la puerta de una casa rústica con techo de tejas, junto a una mesa con frutas y platos de comida, rodeada de flores.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22557,7 +22557,7 @@
       "serie": "archivo",
       "orden": 731,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las chimeneas de la refinería fuman en el horizonte desde hace tanto que el rancho de palma de la orilla ya aprendió a ignorarlas por completo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22571,8 +22571,8 @@
         "generacion": "983eae4b-1bd6-4aa9-88cf-a4916de63690",
         "variante": 0
       },
-      "titulo": "Slice of utopic life in the Pennsula of",
-      "alt": "slice of utopic life in the Pennsula of Paraguan",
+      "titulo": "Chimeneas sobre el golfo",
+      "alt": "Vista de un golfo con una refinería industrial y sus chimeneas al fondo, botes pequeños en el agua, y en primer plano casas rústicas de techo de paja y flores moradas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22588,7 +22588,7 @@
       "serie": "archivo",
       "orden": 732,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El mantel amarillo de la mesa vacía combina tanto con la arena de la laguna que desde lejos parece que el patio se sirvió un pedazo de playa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22602,8 +22602,8 @@
         "generacion": "a19e389c-d909-4af7-8277-f044004011f2",
         "variante": 3
       },
-      "titulo": "Slice of utopic life in the Pennsula of",
-      "alt": "slice of utopic life in the Pennsula of Paraguan",
+      "titulo": "Mantel amarillo frente al golfo",
+      "alt": "Patio con una mesa de mantel amarillo y sillas junto a una puerta azul, una palmera y macetas con flores, con vista a una laguna y el mar al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22619,7 +22619,7 @@
       "serie": "archivo",
       "orden": 733,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Solo asoma los ojos y el lomo acorazado sobre el agua, y lleva tanto tiempo sin moverse que los árboles ya se reflejaron dos veces enteros sobre su piel.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22633,8 +22633,8 @@
         "generacion": "ddab3fca-e628-4dfa-a8e6-ce96779dd668",
         "variante": 3
       },
-      "titulo": "Slice of utopic life vistas in the P",
-      "alt": "slice of utopic life vistas in the P",
+      "titulo": "Ojos al ras del agua",
+      "alt": "Primer plano de un caimán flotando casi sumergido en agua oscura, con solo la cabeza y el lomo escamado visibles, entre reflejos de árboles.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22650,7 +22650,7 @@
       "serie": "archivo",
       "orden": 734,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las hortensias azules del tiesto se estiran tanto hacia la laguna que casi alcanzan a tocar el filo de la meseta que se recorta al fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22664,8 +22664,8 @@
         "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b",
         "variante": 1
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan",
+      "titulo": "Hortensias frente a la meseta",
+      "alt": "Macetas con hortensias azules, blancas y amarillas junto a una puerta azul, con vista a una laguna y una montaña de cima plana en el horizonte.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22681,7 +22681,7 @@
       "serie": "archivo",
       "orden": 735,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El camino de tierra roja se abre paso entre flores blancas, rosadas y amarillas con tanta insistencia que termina desembocando directo en el mar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22695,8 +22695,8 @@
         "generacion": "18ff04f9-39c5-437b-80fc-8cb19e7c8a7b",
         "variante": 3
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan",
+      "titulo": "Sendero entre flores y mar",
+      "alt": "Sendero de tierra entre arbustos con flores blancas, rosadas y amarillas, una palmera, y una casa de techo de tejas rojas, con vista al mar donde se ven embarcaciones pequeñas.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22712,7 +22712,7 @@
       "serie": "archivo",
       "orden": 736,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las orejas del burro se paran tan rectas bajo el árbol que parecen sostener solas el techo de paja del bohío de atrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22726,8 +22726,8 @@
         "generacion": "3a1f54a6-0a19-4e92-baec-042d0f08bcbc",
         "variante": 2
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Burro bajo el árbol nocturno",
+      "alt": "Burro de pie bajo un árbol al anochecer, con un bohío de techo de paja al fondo, en tonos azules de poca luz.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22743,7 +22743,7 @@
       "serie": "archivo",
       "orden": 737,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Vadea el caño paso a paso, y dos matas de monte se apartan solas para no mojarle ni una crin al caballo blanco.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22757,8 +22757,8 @@
         "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
         "variante": 0
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Vado en el caño",
+      "alt": "Caballo blanco cruzando un arroyo de agua azul entre vegetación densa, con una duna de arena visible al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22774,7 +22774,7 @@
       "serie": "archivo",
       "orden": 738,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En medio del pastizal se planta el caballo, y ni las colinas de arena que tiene detrás se atreven a moverse mientras él decide hacia dónde mirar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22788,8 +22788,8 @@
         "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
         "variante": 1
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Caballo entre colinas y laguna",
+      "alt": "Caballo de pie en un campo de pasto alto junto a una laguna, con colinas de arena y vegetación al fondo, en luz de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22805,7 +22805,7 @@
       "serie": "archivo",
       "orden": 739,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La copa del árbol grande alcanza a taparle la sombra entera al caballo, que camina tan pegado a la orilla que no le queda ni un rayo de sol encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22819,8 +22819,8 @@
         "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
         "variante": 2
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Caballo bajo la ceiba",
+      "alt": "Caballo caminando junto al agua enmarcado por vegetación y un árbol de copa grande, con una duna de arena al fondo y flores en primer plano.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22836,7 +22836,7 @@
       "serie": "archivo",
       "orden": 740,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Frente al agua se para tan quieto el burro que los arbustos morados de atrás le crecieron alrededor sin que se apartara ni un paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22850,8 +22850,8 @@
         "generacion": "49db312b-a679-432f-b51a-e329893fe8d3",
         "variante": 3
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Burro entre flores moradas",
+      "alt": "Burro de pie junto a un cuerpo de agua, con una duna de arena y arbustos de flores moradas al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22867,7 +22867,7 @@
       "serie": "archivo",
       "orden": 741,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina por la arena como si el oasis entero -palmeras, agua azul y duna- le perteneciera desde antes de que alguien lo nombrara, y nadie se lo discute.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22881,8 +22881,8 @@
         "generacion": "55f95e2d-a94f-46df-9a94-dee1c0a53717",
         "variante": 1
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "El oasis del burro",
+      "alt": "Burro caminando sobre arena en un oasis con palmeras, agua azul y dunas al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22898,7 +22898,7 @@
       "serie": "archivo",
       "orden": 742,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Tan pequeña es la isla que solo le caben una casa blanca y una palmera, y aun así la nube de allá arriba parece más grande que las dos juntas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22912,8 +22912,8 @@
         "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e",
         "variante": 0
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "titulo": "Casa diminuta en el islote",
+      "alt": "Casa blanca pequeña y una palmera sobre un islote rodeado de agua, bajo un cielo azul con una nube grande.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22929,7 +22929,7 @@
       "serie": "archivo",
       "orden": 743,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre flores blancas y moradas baja con tanta decisión el camino de ladrillo, que parece que va a meterse derecho en el mar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22943,8 +22943,8 @@
         "generacion": "62deeb3e-94a0-4285-a8a8-4a4cb2725e9e",
         "variante": 1
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "titulo": "Terraza sobre el golfo",
+      "alt": "Terraza con flores blancas y moradas en macetas y un camino de ladrillo, con vista al mar al atardecer y una palmera a un lado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22960,7 +22960,7 @@
       "serie": "archivo",
       "orden": 744,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Ni una hoja del dosel se anima a caer sobre el caimán, que flota tan inmóvil en el agua oscura que parece parte del reflejo de los árboles.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -22974,8 +22974,8 @@
         "generacion": "9940fd95-f6f8-45aa-b2b1-8a6d767697c1",
         "variante": 0
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a cai",
+      "titulo": "Caimán bajo el dosel verde",
+      "alt": "Caimán flotando casi sumergido en un caño de agua oscura rodeado de árboles frondosos, con reflejos de la vegetación en la superficie.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -22991,7 +22991,7 @@
       "serie": "archivo",
       "orden": 745,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los flamencos se juntan en la orilla en tal cantidad que desde la montaña de atrás el agua ya no se ve azul sino rosada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23005,8 +23005,8 @@
         "generacion": "ee146ea9-2ea7-42d5-9d3a-3d2d7a028090",
         "variante": 0
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan carib",
+      "titulo": "Mar rosado de flamencos",
+      "alt": "Gran cantidad de flamencos de pie en aguas poco profundas, con montañas al fondo bajo un cielo brumoso.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23022,7 +23022,7 @@
       "serie": "archivo",
       "orden": 746,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "En la arena, justo donde terminan las sombras de las palmeras, pace el burro sin dar ni un paso hacia el agua que tiene al lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23036,8 +23036,8 @@
         "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d",
         "variante": 2
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Mediodía en el médano",
+      "alt": "Burro de pie sobre arena junto a un cuerpo de agua, rodeado de palmeras y una duna al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23053,7 +23053,7 @@
       "serie": "archivo",
       "orden": 747,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por encima de las flores azules asoman las orejas del burro como dos mástiles diminutos, con la playa entera de fondo esperando a que decida moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23067,8 +23067,8 @@
         "generacion": "fb70df30-e10e-48fe-9df5-ff169985b64d",
         "variante": 3
       },
-      "titulo": "Slice of utopic life vistas in the Pennsula",
-      "alt": "slice of utopic life vistas in the Pennsula of Paraguan a don",
+      "titulo": "Orejas sobre las flores azules",
+      "alt": "Burro de pie entre flores azules y blancas silvestres, con el mar y una playa al fondo, en luz de atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23084,7 +23084,7 @@
       "serie": "archivo",
       "orden": 748,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se sienta con las botas juntas bajo tres retratos enmarcados que cuelgan de la pared verde, y ninguno de los tres se atreve a mirarlo a los ojos como lo hace él a la cámara.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23098,8 +23098,8 @@
         "generacion": "7aeb5fef-dda2-4e9d-ae9e-69b75ed60fed",
         "variante": 1
       },
-      "titulo": "Soldier poses in his home in venezuela in",
-      "alt": "soldier poses in his home in venezuela in the style of laurel",
+      "titulo": "Retrato en el cuarto verde",
+      "alt": "Hombre con uniforme militar camuflado y gorra sentado en un banquito dentro de una habitación de paredes verdes, con fotografías enmarcadas, una cortina tejida y telas de colores colgando.",
       "w": 800,
       "h": 1131,
       "anchos": [
@@ -23114,7 +23114,7 @@
       "serie": "archivo",
       "orden": 749,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cada consola vigila un fragmento del planeta rojo tras el cristal, y llevan tantas guardias contando sus tormentas que ya las saludan por su nombre.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23128,8 +23128,8 @@
         "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e",
         "variante": 1
       },
-      "titulo": "Space control room with people at desks and",
-      "alt": "space control room with people at desks and a space view at t",
+      "titulo": "Turno ante el planeta rojo",
+      "alt": "Sala de control oscura con varias personas sentadas ante consolas de monitores, frente a un ventanal grande que muestra el espacio con un planeta rojizo y estrellas.",
       "w": 1376,
       "h": 864,
       "anchos": [
@@ -23145,7 +23145,7 @@
       "serie": "archivo",
       "orden": 750,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Diez consolas se alinean bajo el muro de luz azulada donde flota un iceberg que nunca se derrite, y el que está de pie lleva media hora sin decidirse a acercarse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23159,8 +23159,8 @@
         "generacion": "76f50de1-1883-48a6-bae0-0bb56602394e",
         "variante": 2
       },
-      "titulo": "Space control room with people at desks and",
-      "alt": "space control room with people at desks and a space view at t",
+      "titulo": "El iceberg eterno",
+      "alt": "Sala de control con una fila de personas sentadas ante consolas iluminadas, una persona de pie mirando una pantalla gigante con una forma blanca y azul sobre fondo de estrellas, piso con tono anaranjado.",
       "w": 1376,
       "h": 864,
       "anchos": [
@@ -23176,7 +23176,7 @@
       "serie": "archivo",
       "orden": 751,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajo tanto grano de tinta que la revista parece llovida, el collar de perlas sigue intacto y brilla como si nadie se hubiese atrevido a imprimir encima.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23190,8 +23190,8 @@
         "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2",
         "variante": 0
       },
-      "titulo": "Stencil Magazine font title for Cmo ser buena",
-      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "titulo": "El collar que resiste",
+      "alt": "Portada de revista en blanco y negro con textura granulada, con el retrato de una mujer de cabello oscuro rizado, collar de perlas y aretes, rodeada de texto ilegible en la parte superior e inferior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23207,7 +23207,7 @@
       "serie": "archivo",
       "orden": 752,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El código de barras se cuela en la esquina como si fuera a cobrarle por mirarla, mientras el retrato color musgo aguanta cuarenta años de polvo sin pestañear.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23221,8 +23221,8 @@
         "generacion": "9389a5ae-838a-4a9a-b610-eaf2fa8e67c2",
         "variante": 3
       },
-      "titulo": "Stencil Magazine font title for Cmo ser buena",
-      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "titulo": "Reina con código de barras",
+      "alt": "Portada de revista en tono sepia oscuro con el retrato de una mujer de cabello rizado y collar de perlas, con un código de barras en la esquina inferior derecha y texto pequeño alrededor.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23238,7 +23238,7 @@
       "serie": "archivo",
       "orden": 753,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las letras grises flotan en tanto ruido de pantalla vieja que parecen buscar la señal desde hace tres décadas, y el sello blanco de la esquina es lo único que no tiembla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23252,8 +23252,8 @@
         "generacion": "dbc0346f-3c35-43ed-9c12-3f6498151ec4",
         "variante": 0
       },
-      "titulo": "Stencil Magazine font title for Cmo ser buena",
-      "alt": "stencil Magazine font title for Cmo ser buena Gente 90s print",
+      "titulo": "Frase flotando en el ruido",
+      "alt": "Fondo negro con textura granulada tipo estática, con el texto en letras grises \"Como bua sra Gente\" en el centro y un pequeño logotipo blanco en la esquina inferior derecha.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23269,7 +23269,7 @@
       "serie": "archivo",
       "orden": 754,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El de en medio es el único que se deja ver la cara entre tanto vidrio azul desenfocado, y los otros dos llevan el mismo traje pero caminan tan rápido que se han vuelto humo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23283,8 +23283,8 @@
         "generacion": "03c30dbc-0304-46ef-b08a-c5952e984c0c",
         "variante": 0
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "Tres siluetas en fuga azul",
+      "alt": "Tres hombres en traje caminando en un pasillo con luz azul, dos en movimiento borroso a los lados y uno de perfil enfocado en el centro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23300,7 +23300,7 @@
       "serie": "archivo",
       "orden": 755,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Aplaude con tanta fuerza bajo su chaqueta color cobre que los aros dorados de las orejas llevan repicando desde antes de que empezara el discurso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23314,8 +23314,8 @@
         "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
         "variante": 0
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "El aplauso color cobre",
+      "alt": "Mujer joven de cabello oscuro rizado sonriendo y aplaudiendo, con chaqueta color óxido sobre suéter gris y aretes de aro dorados, con dos personas borrosas detrás en un evento interior.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23331,7 +23331,7 @@
       "serie": "archivo",
       "orden": 756,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El apretón de manos divide el cielo exacto en dos: naranja arriba, azul abajo, y ninguno de los dos suelta hasta que la última fila de puntos termine de imprimirse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23345,8 +23345,8 @@
         "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
         "variante": 1
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "El apretón parte el cielo",
+      "alt": "Ilustración con textura de puntos de dos hombres en traje dándose la mano en silueta, frente a un fondo de cielo en degradado naranja y azul sobre una cordillera.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23362,7 +23362,7 @@
       "serie": "archivo",
       "orden": 757,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Cruza los brazos contra un cielo tan azul que parece pintado a última hora, y los tres hombres detrás llevan la corbata tan derecha que ni el viento se atreve a tocarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23376,8 +23376,8 @@
         "generacion": "91c23937-6e5a-4a78-be1f-e656f8232ca9",
         "variante": 3
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "El cielo añil los reta",
+      "alt": "Cuatro personas de pie frente a un cielo azul intenso: una mujer con vestido de lunares y los brazos cruzados en primer plano, y tres hombres con traje y corbata detrás.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23393,7 +23393,7 @@
       "serie": "archivo",
       "orden": 758,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se reúnen tan alto que la ciudad entera cabe bajo la mesa, y las luces de las calles parpadean como si también quisieran opinar en la conversación.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23407,8 +23407,8 @@
         "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d",
         "variante": 2
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "La mesa sobre la ciudad",
+      "alt": "Vista nocturna a través de un vidrio de cinco personas sentadas alrededor de una mesa en una sala en un piso alto, con las luces de la ciudad iluminadas abajo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23424,7 +23424,7 @@
       "serie": "archivo",
       "orden": 759,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La mitad de su cara vive en luz cálida y la otra ya se rindió al azul de la pantalla, partida entre dos climas desde antes de que empezara la junta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23438,8 +23438,8 @@
         "generacion": "da752d00-df54-4cc1-84f7-ca4698ca816d",
         "variante": 3
       },
-      "titulo": "Stock image corporativa",
-      "alt": "stock image corporativa",
+      "titulo": "Rostro partido en dos luces",
+      "alt": "Retrato de una mujer de cabello rizado oscuro mirando de frente con expresión seria, iluminada de un lado por luz cálida y del otro por el resplandor azulado de una pantalla, sobre fondo oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23455,7 +23455,7 @@
       "serie": "archivo",
       "orden": 760,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por la ventana redonda de la puerta se le nota la piel del mismo turquesa que el mar de fondo, y las gafas amarillas no dejan pasar ni un rayo de ese sol de playa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23469,8 +23469,8 @@
         "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
         "variante": 0
       },
-      "titulo": "Teenage wasteland pop art a character on a",
-      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "titulo": "Piel color mar",
+      "alt": "Fotografía con lente ojo de pez tomada a través de la ventana de un auto, de un joven con la piel de tono turquesa, gafas de sol amarillas y suéter con estampado de ojo, con una playa y palmeras de fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23486,7 +23486,7 @@
       "serie": "archivo",
       "orden": 761,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ojo de pez le dobla los edificios de atrás como si la ciudad entera se inclinara para caber en la foto, mientras el auto azul viejo ni se entera y sigue parqueado derecho.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23500,8 +23500,8 @@
         "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
         "variante": 1
       },
-      "titulo": "Teenage wasteland pop art a character on a",
-      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "titulo": "La ciudad se dobla",
+      "alt": "Fotografía con lente ojo de pez de un joven con gafas de sol y camiseta gráfica frente a un auto clásico azul, con edificios y palmeras curvados de fondo por la distorsión del lente.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23517,7 +23517,7 @@
       "serie": "archivo",
       "orden": 762,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se recuesta en el guardabarros como si el auto llevara sesenta años esperándolo justo ahí, y la palmera de atrás se dobla en el lente hasta casi tocarle el hombro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23531,8 +23531,8 @@
         "generacion": "547c4f2a-e646-406c-882e-25c69d87c304",
         "variante": 2
       },
-      "titulo": "Teenage wasteland pop art a character on a",
-      "alt": "Teenage wasteland pop art a character on a caribbean beach fi",
+      "titulo": "La palmera vigila el auto",
+      "alt": "Fotografía con lente ojo de pez de un joven con gafas de sol y camiseta blanca con estampado, recostado sobre un auto clásico azul, con una palmera y edificios en la colina al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23548,7 +23548,7 @@
       "serie": "archivo",
       "orden": 763,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Le crecen cadenas donde a otros les crece el brazo, y la luna llena se le queda fija detrás del pelo blanco como si llevara siglos sin moverse de ahí.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23562,8 +23562,8 @@
         "generacion": "eca0b207-58a2-4123-be6a-5cdae5d5b1e1",
         "variante": 0
       },
-      "titulo": "The cover art of the apocalypse zine in",
-      "alt": "the cover art of the apocalypse zine in the style of hajime s",
+      "titulo": "El halo de metal",
+      "alt": "Ilustración de fantasía en tonos azules de una figura femenina con partes mecánicas visibles en el pecho y los brazos, cabello blanco alborotado, encadenada, sentada entre ramas de árbol con una luna llena detrás.",
       "w": 1024,
       "h": 1120,
       "anchos": [
@@ -23579,7 +23579,7 @@
       "serie": "archivo",
       "orden": 764,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Talló tantos círculos concéntricos en la piedra que quien los mire de cerca pierde la cuenta antes de llegar al centro, y el hombre de blanco lleva rato intentándolo sin moverse.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23593,8 +23593,8 @@
         "generacion": "d5ac46d9-91a0-4269-92cb-812a719144a8",
         "variante": 3
       },
-      "titulo": "The earth monolith found in centralstan c1890 with",
-      "alt": "the earth monolith found in centralstan c1890 with the spiral",
+      "titulo": "Círculos que nadie ha contado",
+      "alt": "Hombre con túnica y turbante blancos de pie junto a un monolito de piedra tallado con un patrón de círculos concéntricos, en un paisaje desértico con ruinas al fondo.",
       "w": 800,
       "h": 1103,
       "anchos": [
@@ -23609,7 +23609,7 @@
       "serie": "archivo",
       "orden": 765,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Entre tantas cabezas iguales solo uno se da la vuelta a mirar la cámara, y lleva puesto el mismo blanco que todos pero la luz decide quedarse justo en él.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23623,8 +23623,8 @@
         "generacion": "3faad93b-0967-42c5-a878-74f0a267a801",
         "variante": 1
       },
-      "titulo": "The man in white is surrounded by many",
-      "alt": "the man in white is surrounded by many people in the style of",
+      "titulo": "El único rostro vuelto",
+      "alt": "Fotografía en blanco y negro de una multitud densa de hombres jóvenes, la mayoría con camisas claras, con un hombre en el centro vestido completamente de blanco que mira hacia la cámara.",
       "w": 1328,
       "h": 912,
       "anchos": [
@@ -23640,7 +23640,7 @@
       "serie": "archivo",
       "orden": 766,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Con un solo audífono puesto vigila la estación entera y la Tierra girando abajo, y el monitor rojo de la izquierda lleva parpadeando una alarma tan floja que ya nadie se levanta a mirarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23654,8 +23654,8 @@
         "generacion": "549baf68-936d-4e81-92a0-3d6eff76f78a",
         "variante": 0
       },
-      "titulo": "The sennheiser space station control",
-      "alt": "the sennheiser space station control",
+      "titulo": "Escucha la Tierra a medias",
+      "alt": "Silueta de una persona con auriculares sentada frente a una consola de control con múltiples pantallas, mirando a través de un ventanal hacia una estación espacial y la Tierra iluminada de noche, con un monitor en tono rojo a la izquierda.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23671,7 +23671,7 @@
       "serie": "archivo",
       "orden": 767,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Arriba las tres pantallas solo hablan en verde, trazando líneas de luz que nunca se repiten, y abajo las otras tres vigilan la Tierra tan de cerca que cuentan sus nubes una por una.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23685,8 +23685,8 @@
         "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e",
         "variante": 1
       },
-      "titulo": "The sennheiser space station control",
-      "alt": "the sennheiser space station control",
+      "titulo": "Seis pantallas y un verde",
+      "alt": "Panel de seis pantallas en una sala de control oscura: las tres superiores muestran trazos de luz verde abstractos y las tres inferiores muestran imágenes de la Tierra y datos de radar, sobre un tablero de controles.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23702,7 +23702,7 @@
       "serie": "archivo",
       "orden": 768,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Va sentado de espaldas con el traje más blanco que cualquier nube de las que ve pasar por la ventana, y la curva entera del planeta le cabe justo entre los dos bordes del vidrio.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23716,8 +23716,8 @@
         "generacion": "72a31474-4fc1-4bd4-bdc9-5172efc1f75e",
         "variante": 3
       },
-      "titulo": "The sennheiser space station control",
-      "alt": "the sennheiser space station control",
+      "titulo": "Más blanco que la nube",
+      "alt": "Interior de una cabina de nave espacial con una persona de traje blanco y auriculares sentada de espaldas frente a los controles, mirando a través de la ventana la curvatura de la Tierra y las nubes.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23733,7 +23733,7 @@
       "serie": "archivo",
       "orden": 769,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Camina metido hasta la cintura y el sol se le parte en tantas rayas sobre el agua que parece que fuera a cruzar un puente de luz sin mojarse los hombros.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23747,8 +23747,8 @@
         "generacion": "20be483f-2718-49f4-8303-c94b8f7e1835",
         "variante": 0
       },
-      "titulo": "The water has a subtle blue and orange",
-      "alt": "the water has a subtle blue and orange pattern in the style o",
+      "titulo": "Vadea el sol partido",
+      "alt": "Ilustración con líneas horizontales de una persona en silueta caminando dentro del agua hasta la cintura, frente a un atardecer con el sol reflejado en el agua, en tonos naranja, rosado y azul.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -23764,7 +23764,7 @@
       "serie": "archivo",
       "orden": 770,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cabello le arde tan naranja que compite con los asientos turquesa del vagón, y en las gafas espejadas se le ve doblada la ciudad entera pasando al revés.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23778,8 +23778,8 @@
         "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a",
         "variante": 0
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Naranja contra el vagón turquesa",
+      "alt": "Joven de cabello rizado color naranja y gafas de sol espejadas, con chaqueta de patrón pata de gallo en rosa y negro, sentado en un vagón de transporte público con interior color turquesa.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23795,7 +23795,7 @@
       "serie": "archivo",
       "orden": 771,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lee sin levantar la vista aunque el tren entero se mueva, y la chaqueta rosa le brilla tanto que hasta las rayas rojas y negras del suéter parecen apagarse a su lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23809,8 +23809,8 @@
         "generacion": "151727f6-2bd0-49e3-b2fd-7cba13787d9a",
         "variante": 1
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Lee bajo la chaqueta rosa",
+      "alt": "Joven de cabello oscuro rizado y gafas de sol moradas, leyendo un libro, vestido con chaqueta de cuero rosa y suéter de rayas rojas y negras, sentado en un transporte público.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23826,7 +23826,7 @@
       "serie": "archivo",
       "orden": 772,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Mira por la ventanilla con la cara tan quieta que parece pintada, mientras la chaqueta le hace tanto ruido de colores que el vagón entero se ve más apagado a su lado.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23840,8 +23840,8 @@
         "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
         "variante": 0
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Quieto entre tantos colores",
+      "alt": "Joven de perfil mirando por la ventana de un transporte público, con chaqueta de patrón abstracto multicolor y una mano sosteniendo un pasamanos, con luz diurna entrando por la ventana.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23857,7 +23857,7 @@
       "serie": "archivo",
       "orden": 773,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Lleva la cresta tan roja que parece que se le hubiera prendido el pelo con la luz de la tarde, y el aro dorado de la oreja repica en cada frenada del bus.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23871,8 +23871,8 @@
         "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
         "variante": 2
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "La cresta incendia el autobús",
+      "alt": "Joven de cabello rojo en cresta, gafas de sol espejadas y arete de aro dorado, vestido con chaqueta de brocado azul y dorado, sentado en un autobús iluminado por luz solar directa, con pasajeros borrosos al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23888,7 +23888,7 @@
       "serie": "archivo",
       "orden": 774,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El remolino naranja de su chaqueta calienta el vidrio del autobús tres grados antes de llegar a la próxima parada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23902,8 +23902,8 @@
         "generacion": "b3e8c7f3-47d4-4db0-a6f7-250e3a4e431e",
         "variante": 3
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Las llamas del asiento azul",
+      "alt": "Joven con cabello rizado naranja y gafas de sol, sentado en un autobús con una chaqueta estampada en naranja, amarillo y negro, mirando por la ventana con la ciudad desenfocada al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23919,7 +23919,7 @@
       "serie": "archivo",
       "orden": 775,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El pañuelo rosa y azul le crece de la cabeza y ya ocupa dos asientos del vagón, aunque el tren solo lleva cuatro paradas recorridas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23933,8 +23933,8 @@
         "generacion": "d91839fc-f300-4342-8338-602239605fd0",
         "variante": 0
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "El turbante desborda el vagón",
+      "alt": "Persona con turbante de tela estampada en rosa, azul y dorado, y chaqueta satinada naranja con collares plateados, sentada en un vagón de metro; otro pasajero se ve borroso al fondo.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23950,7 +23950,7 @@
       "serie": "archivo",
       "orden": 776,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las púas naranjas del cabello se le enderezan más con el frenazo del autobús, y ya van cuarenta y dos sin doblarse desde la última parada.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23964,8 +23964,8 @@
         "generacion": "d91839fc-f300-4342-8338-602239605fd0",
         "variante": 1
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Corona de espinas naranjas",
+      "alt": "Persona con cabello corto y puntiagudo teñido de naranja, gafas de sol con montura roja y chaqueta estampada en naranja y morado, sentada en un autobús junto a otros pasajeros.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -23981,7 +23981,7 @@
       "serie": "archivo",
       "orden": 777,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las gafas redondas y doradas le devuelven el vagón entero pintado de rosa, y todavía no ha parpadeado desde la última estación.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -23995,8 +23995,8 @@
         "generacion": "d91839fc-f300-4342-8338-602239605fd0",
         "variante": 3
       },
-      "titulo": "The young man is on a public transport",
-      "alt": "the young man is on a public transport in the style of psyche",
+      "titulo": "Dorado en lentes redondos",
+      "alt": "Hombre con rastas y gafas de sol redondas de montura dorada y cristales rosados, con chaqueta estampada en naranja y morado, sentado en un autobús o metro.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24012,7 +24012,7 @@
       "serie": "archivo",
       "orden": 778,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ola verde le cubre los hombros hace tres olas y todavía no decide si tragárselo o devolverlo a la orilla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24026,8 +24026,8 @@
         "generacion": "83762f01-2077-441d-8526-6acbda2ca361",
         "variante": 0
       },
-      "titulo": "Top view of cinematographic scene of",
-      "alt": "top view of cinematographic scene of",
+      "titulo": "Rostro sobre el mar embravecido",
+      "alt": "Pintura de un hombre sumergido hasta el cuello en un mar tormentoso de aguas verdes oscuras, con una gran ola detrás y cielo nublado.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24043,7 +24043,7 @@
       "serie": "archivo",
       "orden": 779,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El visor le devuelve el campo entero de florecillas naranjas, y las llevará reflejadas hasta que se quite el casco en otro planeta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24057,8 +24057,8 @@
         "generacion": "4fc9e319-81fc-4044-a848-94d1360beb6d",
         "variante": 0
       },
-      "titulo": "Two aliens and an Astronaut are resting side",
-      "alt": "two aliens and an Astronaut are resting side by side on the g",
+      "titulo": "Escafandras en el pastizal silvestre",
+      "alt": "Dos personas con trajes espaciales y cascos reflectantes, recostadas entre pasto alto y flores silvestres naranjas y blancas, bajo un cielo azul con nubes.",
       "w": 960,
       "h": 1200,
       "anchos": [
@@ -24074,7 +24074,7 @@
       "serie": "archivo",
       "orden": 780,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los perfiles verde y azul se acercan tanto que el aro dorado de una roza ya la mejilla de la otra, y ninguna retrocede.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24088,8 +24088,8 @@
         "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
         "variante": 0
       },
-      "titulo": "Two people looking at each other with tenderness",
-      "alt": "Two people looking at each other with tenderness with love sp",
+      "titulo": "Dos rostros, un aliento",
+      "alt": "Pintura de dos rostros de mujeres, uno en tono verdoso y otro en tono azulado, casi tocándose nariz con nariz, con aretes dorados y fondo texturizado oscuro.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -24105,7 +24105,7 @@
       "serie": "archivo",
       "orden": 781,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las frentes se acercan tanto bajo la luz azul que las flores moradas del primer plano se inclinan solas para no interrumpir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24119,8 +24119,8 @@
         "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
         "variante": 1
       },
-      "titulo": "Two people looking at each other with tenderness",
-      "alt": "Two people looking at each other with tenderness with love sp",
+      "titulo": "Frente contra frente",
+      "alt": "Fotografía en tono azul violáceo de un hombre y una mujer con pañuelos en la cabeza, mirándose de cerca frente con frente, entre plantas y flores moradas en primer plano, de noche.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -24136,7 +24136,7 @@
       "serie": "archivo",
       "orden": 782,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El rojo del fondo se cuela entre los dos perfiles azules sin lograr abrir un centímetro de separación entre sus narices.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24150,8 +24150,8 @@
         "generacion": "9693cea9-929a-4473-b6bf-518b24a6c8e7",
         "variante": 3
       },
-      "titulo": "Two people looking at each other with tenderness",
-      "alt": "Two people looking at each other with tenderness with love sp",
+      "titulo": "Rojo detrás de dos perfiles",
+      "alt": "Ilustración de dos personas de piel azul, de perfil, mirándose de cerca con las narices casi tocándose, sobre fondo rojo, con ropa estampada en verde y naranja.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -24167,7 +24167,7 @@
       "serie": "archivo",
       "orden": 783,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna ocupa ya la mitad del cielo y sigue creciendo, mientras dos figuras bajan la escalinata naranja sin apurar el paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24181,8 +24181,8 @@
         "generacion": "3ccb80ec-34d7-48ab-a8a0-7af1ee115a70",
         "variante": 3
       },
-      "titulo": "Ultra realistic photo of Retro magazine cover of",
-      "alt": "Ultra realistic photo of Retro magazine cover of an Martian C",
+      "titulo": "Cúpulas bajo la luna gigante",
+      "alt": "Ilustración de un paisaje de terreno rocoso naranja con torres futuristas de cúpulas blancas, un planeta gigante en el cielo, y tres personas con trajes espaciales caminando por una escalinata.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -24197,7 +24197,7 @@
       "serie": "archivo",
       "orden": 784,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ciudad entera arde en rojo detrás del cristal y ninguna de las tres pantallas del panel logra igualar ese brillo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24211,8 +24211,8 @@
         "generacion": "796b7719-e7ba-4c5f-989c-84bf8c10a1f9",
         "variante": 0
       },
-      "titulo": "Ultra realistic photo of Retro magazine cover of",
-      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "titulo": "Ciudad roja tras el cristal",
+      "alt": "Persona sentada de espaldas frente a un panel de control con varias pantallas, mirando a través de una ventana una ciudad futurista iluminada en rojo, de noche.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -24227,7 +24227,7 @@
       "serie": "archivo",
       "orden": 785,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El bloque blanco marcado 9XE flota tan bajo sobre el puerto que las luces rojas del letrero se reflejan ya en el agua entre los barcos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24241,8 +24241,8 @@
         "generacion": "87f22837-9932-4bad-81f9-f4f8fda87ed1",
         "variante": 2
       },
-      "titulo": "Ultra realistic photo of Retro magazine cover of",
-      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "titulo": "Bloque 9XE sobre el puerto",
+      "alt": "Ilustración de una gran estructura o nave blanca con las letras 9XE en rojo, flotando sobre un puerto con barcos y naves pequeñas alrededor, con un grupo de personas con casco observando en primer plano, de noche.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -24257,7 +24257,7 @@
       "serie": "archivo",
       "orden": 786,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El haz de luz sube tan derecho desde la torre que atraviesa las nubes antes de que el operador termine de sentarse frente a la pantalla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24271,8 +24271,8 @@
         "generacion": "ca102c98-1f1f-4bd9-979d-c51e932cce3f",
         "variante": 0
       },
-      "titulo": "Ultra realistic photo of Retro magazine cover of",
-      "alt": "Ultra realistic photo of Retro magazine cover of a the comman",
+      "titulo": "La torre dispara luz roja",
+      "alt": "Persona sentada frente a un panel de control con varias pantallas, mirando por una ventana una ciudad futurista de noche con un haz de luz rojo que se eleva desde una torre hacia el cielo.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -24287,7 +24287,7 @@
       "serie": "archivo",
       "orden": 787,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El vestido azul y blanco ocupa tanto sitio en la sala que el gato, el perrito y el conejo se acomodan alrededor sin dejarle ni un palmo libre a la fruta del suelo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24301,8 +24301,8 @@
         "generacion": "905eb375-ad33-4e10-b69c-b28adcf1164e",
         "variante": 0
       },
-      "titulo": "Un cuadro al leo de un mundo surreal",
-      "alt": "Un cuadro al leo de un mundo surreal con un Conejo Blanco con",
+      "titulo": "Vestido azul, gatos, conejos",
+      "alt": "Pintura al óleo de una niña con vestido azul y blanco y lazo rojo en el cabello, de pie junto a una mesa con un conejo blanco, un gato y un perro pequeño, con frutas dispersas en el suelo y cuadros al fondo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -24318,7 +24318,7 @@
       "serie": "archivo",
       "orden": 788,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El oso lleva la cabeza levantada tanto tiempo mirando el camino de luna sobre el mar que la marea ya subió dos veces sin que se moviera un paso.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24332,8 +24332,8 @@
         "generacion": "55d34b6e-6eb7-4332-a8f9-8707a36cfe6b",
         "variante": 1
       },
-      "titulo": "Un oso sale de su cueva despus de",
-      "alt": "Un oso sale de su cueva despus de hibernar mirando un sol res",
+      "titulo": "Oso frente al mar lunar",
+      "alt": "Un oso de pie en la entrada de una cueva de piedra, mirando hacia un mar oscuro iluminado por la luna, de noche, con el reflejo dorado de la luz sobre el agua.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24349,7 +24349,7 @@
       "serie": "archivo",
       "orden": 789,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El tocado de plumas se despliega bajo el agua azul como si el viento todavía lo peinara, a nueve metros de la última bocanada de aire.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24363,8 +24363,8 @@
         "generacion": "0b915070-ee8f-4638-88f9-ee280b69e795",
         "variante": 2
       },
-      "titulo": "Underwater high shot photo of lifeless bodies of",
-      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "titulo": "Flechas y plumas sumergidas",
+      "alt": "Vista aérea submarina de varias personas flotando bajo el agua, vestidas con tocados de plumas, taparrabos y adornos de cuentas, algunas con arcos y lanzas, en un mar de color azul.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24380,7 +24380,7 @@
       "serie": "archivo",
       "orden": 790,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El collar dorado sigue entero alrededor del cuello aunque el agua verde oscura ya se tragó a los demás nadadores detrás.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24394,8 +24394,8 @@
         "generacion": "1db93e4f-e71c-4525-92ad-b6105f09128f",
         "variante": 1
       },
-      "titulo": "Underwater high shot photo of lifeless bodies of",
-      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "titulo": "Collar dorado en la sombra",
+      "alt": "Fotografía submarina en tonos verde oscuro de varias personas flotando bajo el agua con los ojos cerrados; en primer plano, una persona con un collar de cuentas doradas.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24411,7 +24411,7 @@
       "serie": "archivo",
       "orden": 791,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El cardumen de peces naranjas atraviesa los chales tejidos sin rozarlos, como si supiera desde siempre por dónde puede pasar y por dónde no.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24425,8 +24425,8 @@
         "generacion": "871edb1c-78fa-406a-b389-44f435efa699",
         "variante": 1
       },
-      "titulo": "Underwater high shot photo of lifeless bodies of",
-      "alt": "underwater high shot photo of lifeless bodies of men women an",
+      "titulo": "Peces naranjas entre tejidos sumergidos",
+      "alt": "Fotografía submarina de varias personas con vinchas y chales tejidos, flotando bajo el agua rodeadas de un banco de peces color naranja, en un mar azul iluminado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24442,7 +24442,7 @@
       "serie": "archivo",
       "orden": 792,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los cuatro sombreros blancos brillan tanto sobre el agave azul que el volcán del fondo baja el humo un poco para no taparles la luz.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24456,8 +24456,8 @@
         "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551",
         "variante": 2
       },
-      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
-      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "titulo": "Cuatro sombreros, agave azul",
+      "alt": "Pintura de cuatro músicos con chaquetas rojas y sombreros blancos, sentados en un campo de agaves azules tocando instrumentos de cuerda, con un volcán al fondo bajo un cielo azul oscuro.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24473,7 +24473,7 @@
       "serie": "archivo",
       "orden": 793,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El ala del sombrero de paja se enciende de rosa con la última luz del atardecer y todavía no ha terminado de sonar el primer acorde de la guitarra.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24487,8 +24487,8 @@
         "generacion": "5646f29f-eb23-45e3-8b39-b6015181f551",
         "variante": 3
       },
-      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
-      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "titulo": "El sombrero enciende el atardecer",
+      "alt": "Pintura de dos hombres al atardecer, uno con sombrero de paja tocando una guitarra pequeña y otro cantando a su lado, con plantas de agave y un paisaje montañoso de fondo, iluminados por una luz rosada.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24504,7 +24504,7 @@
       "serie": "archivo",
       "orden": 794,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El acorde que suena en la guitarra azul rebota en la pared verde y todavía tarda tres segundos en llegar a los sombreros del fondo.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24518,8 +24518,8 @@
         "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
         "variante": 0
       },
-      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
-      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "titulo": "Acordes contra la pared verde",
+      "alt": "Fotografía de estilo vintage de un joven tocando una guitarra acústica en primer plano, con otros hombres con sombreros vaqueros detrás, frente a una pared verde.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24535,7 +24535,7 @@
       "serie": "archivo",
       "orden": 795,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La pared de la casa guarda tanto sol del día que sigue iluminando a los que se sientan en círculo mucho después de que el cielo ya se puso negro.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24549,8 +24549,8 @@
         "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
         "variante": 1
       },
-      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
-      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "titulo": "El círculo iluminado",
+      "alt": "Casa rural de tejas rojas iluminada por luz cálida al anochecer, con un grupo de personas sentadas en círculo cerca de la pared, montañas oscuras al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24566,7 +24566,7 @@
       "serie": "archivo",
       "orden": 796,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El vestido blanco se planta entre las hortensias azules con tal quietud que ni el viento de la montaña logra moverle un solo pliegue.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24580,8 +24580,8 @@
         "generacion": "eed3a9a1-751f-4437-af07-15eaabdf352f",
         "variante": 2
       },
-      "titulo": "Very Detailed Colonial oil Painting Group of Musical",
-      "alt": "Very Detailed Colonial oil Painting Group of Musical Artist p",
+      "titulo": "Vestido blanco entre hortensias azules",
+      "alt": "Grupo de personas en un jardín con flores moradas y azules, dos hombres tocando guitarra sentados y una mujer con vestido blanco, frente a una casa con techo de tejas rojas y montañas al fondo, de día.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24597,7 +24597,7 @@
       "serie": "archivo",
       "orden": 797,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna sube tan grande sobre las colinas que ilumina las cuerdas de la guitarra antes de que termine de ponerse el sol.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24611,8 +24611,8 @@
         "generacion": "373931ab-4b8b-4439-beaa-b32d8e451eaa",
         "variante": 3
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "La luna sobre el porche",
+      "alt": "Pintura de un hombre con sombrero tocando guitarra sentado en el porche de una casa blanca con arcos, rodeado de plantas tropicales, con una luna grande saliendo sobre las colinas al atardecer.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24628,7 +24628,7 @@
       "serie": "archivo",
       "orden": 798,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El sombrero verde le brilla tanto en la penumbra magenta que la luna amarilla del fondo parece apagarse un poco de la envidia.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24642,8 +24642,8 @@
         "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9",
         "variante": 0
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "Porche de neón, luna amarilla",
+      "alt": "Pintura en colores neón de un hombre con sombrero verde tocando guitarra en un porche con piso de baldosas rosadas, palmeras y una luna amarilla grande al fondo, en tonos magenta y cian.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24659,7 +24659,7 @@
       "serie": "archivo",
       "orden": 799,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Rasguea la guitarra sentado junto a su vasija de barro, y cada acorde tiñe una colina más de rosa hasta que el valle entero arde del color de su camisa.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24673,8 +24673,8 @@
         "generacion": "4eeb5758-48b1-4819-8f86-fa9665bf31a9",
         "variante": 3
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "El valle bajo su guitarra",
+      "alt": "Hombre con sombrero verde y camisa rosa toca la guitarra sentado bajo un árbol, con una vasija de barro a su lado, frente a un valle verde y montañas bajo un cielo rosado con luna llena.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24690,7 +24690,7 @@
       "serie": "archivo",
       "orden": 800,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Bajo una luna del tamaño de una colina entera, levanta el machete y las luciérnagas del pastizal se encienden todas a la vez, como si el campo respondiera al gesto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24704,8 +24704,8 @@
         "generacion": "6fa93c15-1068-4735-95af-177467cf30a8",
         "variante": 3
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "El machete bajo la luna",
+      "alt": "Figura solitaria de pie en un campo oscuro sosteniendo una herramienta en alto, bajo una luna naranja enorme y un cielo morado con montañas y estrellas al fondo.",
       "w": 800,
       "h": 1427,
       "anchos": [
@@ -24720,7 +24720,7 @@
       "serie": "archivo",
       "orden": 801,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La luna, apenas una uña esa noche, se queda prendida de una nube dorada mientras él rasguea la guitarra y los cactos en flor no dejan de escuchar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24734,8 +24734,8 @@
         "generacion": "be244a62-95ba-48a9-ab57-9736a97e53c1",
         "variante": 0
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "Guitarra en el porche dorado",
+      "alt": "Hombre con sombrero de ala ancha toca la guitarra sentado en el porche de una casa de adobe, rodeado de cactus en macetas, frente a un valle y montañas al atardecer con luna creciente.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24751,7 +24751,7 @@
       "serie": "archivo",
       "orden": 802,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Desde el arco pintado de fucsia, la guitarra suena tan fuerte que ilumina los tejados del pueblo entero antes que la luna llena termine de subir.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24765,8 +24765,8 @@
         "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b",
         "variante": 0
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "El arco fucsia",
+      "alt": "Hombre con sombrero toca la guitarra sentado en un arco de color rosa fucsia, con vista a un pueblo colonial de noche, tejados rojos, montañas azules y luna llena.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24782,7 +24782,7 @@
       "serie": "archivo",
       "orden": 803,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sentado en una silla rosa que desentona a propósito con la selva, afina la mandolina hasta que las hojas más cercanas se enderezan para escuchar la única nota que falta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24796,8 +24796,8 @@
         "generacion": "c41029fa-15c6-4ec1-8976-04400c5ea23b",
         "variante": 3
       },
-      "titulo": "Very Detailed moody Colonial oil Painting Of a",
-      "alt": "Very Detailed moody Colonial oil Painting Of a Panoramic view",
+      "titulo": "Mandolina en la silla rosa",
+      "alt": "Hombre con sombrero verde y camisa celeste toca una mandolina sentado en una silla rosa, rodeado de vegetación tropical densa, bajo un cielo rosado con luna llena.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -24813,7 +24813,7 @@
       "serie": "archivo",
       "orden": 804,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La medalla en forma de estrella que lleva al pecho brilla tanto que la ola gigante detrás se detiene un instante antes de romper sobre la cubierta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24827,8 +24827,8 @@
         "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b",
         "variante": 1
       },
-      "titulo": "Very detailed photo of a cinematogra",
-      "alt": "very detailed photo of a cinematogra",
+      "titulo": "La medalla y la tormenta",
+      "alt": "Retrato de un oficial naval con uniforme azul oscuro, charreteras doradas y una medalla en forma de estrella, con un mar tormentoso y un velero al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -24844,7 +24844,7 @@
       "serie": "archivo",
       "orden": 805,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se inclina sobre la borda con el brazo estirado hacia el mar, como si pudiera detener la ola más alta con la sola fuerza de sus guantes blancos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24858,8 +24858,8 @@
         "generacion": "dfcb3380-1c49-4234-9b72-057a9536f96b",
         "variante": 3
       },
-      "titulo": "Very detailed photo of a cinematogra",
-      "alt": "very detailed photo of a cinematogra",
+      "titulo": "El brazo sobre la borda",
+      "alt": "El mismo oficial naval se inclina sobre la borda del barco con el brazo extendido, mientras el mar embravecido golpea el casco y un velero navega al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -24875,7 +24875,7 @@
       "serie": "archivo",
       "orden": 806,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "De pie en la cubierta, sostiene la cuerda como si de ella colgara el barco entero y no solo las velas que se sacuden en la tormenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24889,8 +24889,8 @@
         "generacion": "8726b12d-6328-4bb4-a1c6-f2ff2a288372",
         "variante": 2
       },
-      "titulo": "Very detailed photo of a cinematographic full view",
-      "alt": "very detailed photo of a cinematographic full view of Simn B",
+      "titulo": "La cuerda entre las manos",
+      "alt": "El mismo oficial naval está de pie en la cubierta del barco sosteniendo una cuerda, con el mar tormentoso y un velero visible en la distancia.",
       "w": 672,
       "h": 512,
       "anchos": [
@@ -24905,7 +24905,7 @@
       "serie": "archivo",
       "orden": 807,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El techo de paja cubre tanta mercancía que la choza entera flota más baja en el agua, mientras el remero se acerca despacio sobre el mar turquesa antes de que rompa la tormenta.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24919,8 +24919,8 @@
         "generacion": "5107821a-3c59-4294-a881-545e8fd7dcbe",
         "variante": 3
       },
-      "titulo": "Very detailed photo of an indigenous merchant selling",
-      "alt": "Very detailed photo of an indigenous merchant selling shell c",
+      "titulo": "El mercado que flota",
+      "alt": "Estructura flotante con techo cónico de paja sobre el agua turquesa, con mercancías variadas expuestas debajo, y un hombre remando en una canoa de madera cerca, bajo un cielo nublado.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24936,7 +24936,7 @@
       "serie": "archivo",
       "orden": 808,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Se ve el fondo del mar a través del agua tan clara que el hombre de pie en la canoa parece flotar sobre el aire y no sobre las olas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24950,8 +24950,8 @@
         "generacion": "e021cc65-a587-4401-a7b7-d683bf6dce42",
         "variante": 0
       },
-      "titulo": "Very detailed photo of an indigenous merchant selling",
-      "alt": "Very detailed photo of an indigenous merchant selling shell c",
+      "titulo": "Agua transparente hasta el fondo",
+      "alt": "Dos hombres en una canoa de madera junto a una choza flotante con techo de paja cubierto de musgo, uno remando y otro de pie, sobre agua turquesa transparente que deja ver el fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -24967,7 +24967,7 @@
       "serie": "archivo",
       "orden": 809,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sobre las colinas teñidas de óxido, cruza un cometa tan despacio que las flores de agave alcanzan a abrirse todas antes de que termine de pasar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -24981,8 +24981,8 @@
         "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef",
         "variante": 2
       },
-      "titulo": "Vintage picture of a horizon of a field",
-      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "titulo": "El cometa y las colinas",
+      "alt": "Fotografía con grano vintage de un campo de plantas de agave con flores amarillas redondas en primer plano, colinas rojizas al fondo, bajo un cielo nocturno estrellado con un cometa.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -24998,7 +24998,7 @@
       "serie": "archivo",
       "orden": 810,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las luces alineadas en el horizonte cuentan cada tallo del trigal, una por una, mientras una estrella fugaz cruza el cielo sin que ninguna se apague para mirarla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25012,8 +25012,8 @@
         "generacion": "0c1cdd97-9df6-4112-b8d3-1d494fbcf7ef",
         "variante": 3
       },
-      "titulo": "Vintage picture of a horizon of a field",
-      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "titulo": "Las luces del horizonte",
+      "alt": "Fotografía vintage de un campo de trigo bajo un cielo nocturno estrellado, con una fila de luces brillantes en el horizonte y una estrella fugaz cruzando el cielo.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -25029,7 +25029,7 @@
       "serie": "archivo",
       "orden": 811,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Dos naves flotan tan quietas sobre el campo rojizo que ni una sola flor amarilla se dobla, como si el viento mismo les tuviera respeto.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25043,8 +25043,8 @@
         "generacion": "3bd72e58-8329-4896-b7ef-83e5a2b0eeff",
         "variante": 2
       },
-      "titulo": "Vintage picture of a horizon of a field",
-      "alt": "Vintage picture of a horizon of a field with Garden with alie",
+      "titulo": "Dos naves sobre el trigal",
+      "alt": "Campo de color rojizo con flores silvestres amarillas en primer plano y un bosque al fondo, bajo un cielo negro con dos objetos voladores en forma de disco de color verde azulado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -25060,7 +25060,7 @@
       "serie": "archivo",
       "orden": 812,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Al final de la carretera desierta, un auto diminuto avanza directo hacia una nave tan alta como la montaña que tiene detrás, y ni siquiera frena.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25074,8 +25074,8 @@
         "generacion": "5394b061-dffb-41a4-a7da-2555db51628f",
         "variante": 1
       },
-      "titulo": "Vintage picture of a Road to the horizonwith",
-      "alt": "Vintage picture of a Road to the horizonwith alien buildings",
+      "titulo": "La nave sobre la carretera",
+      "alt": "Fotografía nocturna de una carretera desértica con un automóvil pequeño a la distancia, y una gran nave en forma de campana con luces flotando sobre el paisaje.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -25091,7 +25091,7 @@
       "serie": "archivo",
       "orden": 813,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Rodean la cama de sábanas blancas tantos uniformes con charreteras doradas que la habitación entera parece un cuartel puesto de pie alrededor de un solo hombre que ya no se mueve.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25105,8 +25105,8 @@
         "generacion": "2f1f07e7-8281-4e21-b9ec-3c80b8c58025",
         "variante": 3
       },
-      "titulo": "W78JE Scene of Simn Bolvar in his deathbed",
-      "alt": "W78JE Scene of Simn Bolvar in his deathbed",
+      "titulo": "El lecho rodeado de uniformes",
+      "alt": "Pintura de un hombre agonizante recostado en una cama con sábanas blancas, rodeado de oficiales militares con uniformes y charreteras doradas, en una habitación en penumbra iluminada por una ventana.",
       "w": 1344,
       "h": 896,
       "anchos": [
@@ -25122,7 +25122,7 @@
       "serie": "archivo",
       "orden": 814,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Por la única puerta abierta entra tanta luz que alcanza a iluminar solo la cama, dejando a los oficiales que la rodean sumergidos en su propia sombra oscura.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25136,8 +25136,8 @@
         "generacion": "314cec35-d869-411a-b93f-845d291a2eea",
         "variante": 2
       },
-      "titulo": "W78JE Scene of Simn Bolvar in his deathbed",
-      "alt": "W78JE Scene of Simn Bolvar in his deathbed",
+      "titulo": "La luz de la puerta",
+      "alt": "Pintura de un hombre en su lecho de muerte en una habitación oscura, rodeado de numerosos oficiales militares uniformados, con luz entrando por una puerta abierta al fondo.",
       "w": 1232,
       "h": 928,
       "anchos": [
@@ -25153,7 +25153,7 @@
       "serie": "archivo",
       "orden": 815,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Los cables se cruzan sobre la esquina en tantos nudos que el hombre que camina abajo prefiere mirar la vereda antes que enredarse la vista con ellos.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25167,8 +25167,8 @@
         "generacion": "c3687654-5bc2-497f-9d8a-17c395097f4a",
         "variante": 3
       },
-      "titulo": "Walking perspective down a Santiago Chile neighborhood street",
-      "alt": "walking perspective down a Santiago Chile neighborhood street",
+      "titulo": "Los cables sobre la esquina",
+      "alt": "Hombre caminando por la acera de un barrio de casas bajas, junto a un poste con cables eléctricos, un auto estacionado y un local en la esquina, bajo luz de tarde.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -25184,7 +25184,7 @@
       "serie": "archivo",
       "orden": 816,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Rema solo en la canoa mientras un único rayo parte el cielo a lo lejos, tan silencioso que ni el agua bajo el remo se altera.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25198,8 +25198,8 @@
         "generacion": "6b59c446-5766-4674-921a-f4912a6fc775",
         "variante": 2
       },
-      "titulo": "West African coast 1462 a merchant captain and",
-      "alt": "West African coast 1462 a merchant captain and his first mate",
+      "titulo": "El rayo sobre la canoa",
+      "alt": "Fotografía en blanco y negro de un hombre remando en una canoa de madera sobre un cuerpo de agua extenso, con otra canoa vacía cerca y nubes de tormenta con un rayo al fondo.",
       "w": 1400,
       "h": 785,
       "anchos": [
@@ -25215,7 +25215,7 @@
       "serie": "archivo",
       "orden": 817,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "El castillo entero está a oscuras menos por las ventanas, que arden en naranja y rojo como si cada torre escondiera su propia hoguera detrás del cristal.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25229,8 +25229,8 @@
         "generacion": "8b1a9ea7-7443-4752-8b25-82304c205dca",
         "variante": 2
       },
-      "titulo": "Wide shot of a gothic vampire castle",
-      "alt": "wide shot of a gothic vampire castle",
+      "titulo": "Las ventanas que arden solas",
+      "alt": "Castillo gótico oscuro con múltiples torres y ventanas iluminadas de amarillo y rojo, bajo un cielo verdoso, con ramas secas de árbol en primer plano y una reja de hierro forjado.",
       "w": 1024,
       "h": 1024,
       "anchos": [
@@ -25246,7 +25246,7 @@
       "serie": "archivo",
       "orden": 818,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Frente al puerto lleno de gente diminuta, la capa azul le cubre el hombro entero y no se mueve un centímetro aunque el viento del mar empuje cada barco de la bahía.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25260,8 +25260,8 @@
         "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07",
         "variante": 1
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "La capa azul del puerto",
+      "alt": "Hombre de cabello rizado y capa azul en primer plano, mirando hacia una ciudad costera amurallada con multitud reunida en el muelle y barcos de vela en la bahía.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25277,7 +25277,7 @@
       "serie": "archivo",
       "orden": 819,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La playa se llena de tantas figuras diminutas que parece hormigueo bajo el barco anclado, mientras él, de perfil, no vuelve la cabeza para contarlas.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25291,8 +25291,8 @@
         "generacion": "1c765ecb-2c25-4906-832b-f4616342bd07",
         "variante": 3
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "La playa llena de gente",
+      "alt": "El mismo hombre de perfil en primer plano, con una ciudad costera al fondo, una playa repleta de gente y un barco de vela anclado en la bahía.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25308,7 +25308,7 @@
       "serie": "archivo",
       "orden": 820,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Mira hacia el puerto donde el sol recorta en sombra a cada persona del muelle, una fila tan larga y negra que parece la sombra de un solo barco gigante.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25322,8 +25322,8 @@
         "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91",
         "variante": 0
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "Las siluetas del muelle dorado",
+      "alt": "El mismo hombre observa hacia un puerto iluminado por el sol, con un velero en el agua y una multitud en silueta reunida en el muelle.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25339,7 +25339,7 @@
       "serie": "archivo",
       "orden": 821,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Junto a la torre redonda de piedra, el atardecer dora tanto al barco de banderas que la fila entera de gente en el muelle parece hecha del mismo bronce.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25353,8 +25353,8 @@
         "generacion": "862ac6f5-2a6f-44a1-b55a-9ff8a20bcb91",
         "variante": 2
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "La torre redonda del atardecer",
+      "alt": "Retrato de cerca del mismo hombre, con una torre de piedra circular y un velero con banderas al fondo, y una fila de personas en el muelle durante el atardecer dorado.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25370,7 +25370,7 @@
       "serie": "archivo",
       "orden": 822,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Todo se vuelve azul a esa hora, hasta el pueblo entero al pie del cerro, y el mar se agita tanto que parece querer subir a mirarlo con él desde la muralla.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25384,8 +25384,8 @@
         "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
         "variante": 0
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "El pueblo dormido en azul",
+      "alt": "Pintura nocturna en tonos azules del mismo hombre observando un pueblo costero al pie de montañas oscuras, bajo la luna, con el mar agitado en primer plano.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25401,7 +25401,7 @@
       "serie": "archivo",
       "orden": 823,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Las banderas amarillas apenas se mueven mientras él se sienta con las piernas cruzadas en la piedra a esperar que el velero, ya diminuto, termine de cruzar todo el atardecer.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25415,8 +25415,8 @@
         "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
         "variante": 1
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "Las banderas amarillas del muelle",
+      "alt": "Figura solitaria sentada con las piernas cruzadas sobre un muelle de piedra, mirando hacia un velero que navega en el mar durante el atardecer, con banderas amarillas ondeando cerca.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25432,7 +25432,7 @@
       "serie": "archivo",
       "orden": 824,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "La ciudad blanca lleva cuatrocientos años subiendo la colina piedra a piedra sin llegar nunca a la cima, mientras él la mira envuelto en su manto azul.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25446,8 +25446,8 @@
         "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
         "variante": 2
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "La ciudad que sube",
+      "alt": "Una persona con manto azul y cabello rizado se asoma desde un pasaje en sombra hacia una ciudad de casas blancas y torres de piedra construida sobre una colina, bajo un cielo azul intenso.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25463,7 +25463,7 @@
       "serie": "archivo",
       "orden": 825,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Sentada de espaldas al muro con el vestido malva desplegado como otra vela, lleva tantos atardeceres esperando que las dos naves ya reconocen el color de su falda antes de atracar.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25477,8 +25477,8 @@
         "generacion": "c053388a-28fb-46c8-895c-16e2922e046b",
         "variante": 3
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "Malva frente a las velas",
+      "alt": "Una mujer con vestido morado está sentada de espaldas sobre un muro de piedra frente a un puerto con dos barcos de vela antiguos y un pueblo de casas blancas, bajo un cielo azul con nubes.",
       "w": 1392,
       "h": 848,
       "anchos": [
@@ -25494,7 +25494,7 @@
       "serie": "archivo",
       "orden": 826,
       "estado": "publicada",
-      "concepto": "",
+      "concepto": "Clava la mirada en el galeón desde el muro de piedra, y el barco lleva tres siglos sin poder zarpar bajo esa fijeza.",
       "anio": 2025,
       "tags": [],
       "licencia": "reservado",
@@ -25508,8 +25508,8 @@
         "generacion": "cb19cb80-4fd0-4109-b175-4225184ea319",
         "variante": 0
       },
-      "titulo": "Wide shot of a Medieval Plaza in the",
-      "alt": "wide shot of a Medieval Plaza in the city of Cadiz in the XVI",
+      "titulo": "El centinela del galeón",
+      "alt": "Un hombre de cabello oscuro y rizado, vestido con chaqueta azul oscuro, se apoya en un muro de piedra y mira hacia un lado; al fondo hay un barco velero antiguo y una ciudad costera de casas blancas bajo un cielo despejado.",
       "w": 1392,
       "h": 848,
       "anchos": [

--- a/content/galeria/voz.md
+++ b/content/galeria/voz.md
@@ -1,0 +1,127 @@
+# El encargo y la voz de la galería
+
+Este archivo es el prompt que reciben quienes escriben las fichas de las obras.
+El script de lote y los subagentes leen de aquí, no de su propio código: editarlo
+cambia la voz de toda la galería. Es contenido, no configuración.
+
+Va en dos mitades a propósito. La primera dice **qué hay que hacer** y no debería
+cambiar casi nunca. La segunda dice **cómo debe sonar**, y es la que se afina.
+
+---
+
+# PARTE 1 — EL ENCARGO
+
+Escribes las fichas de la galería visual de Curiana Radio, una radio cultural del
+Caribe venezolano. Son imágenes generadas con IA, y hasta ahora sus textos salían
+del prompt con que se generaron. Ese es el problema que vienes a resolver.
+
+## Tu tarea
+
+Mirar cada imagen y escribir tres campos por obra: `titulo`, `concepto` y `alt`.
+
+**Mira la imagen. No te fíes del nombre del archivo**: viene de un prompt viejo,
+suele ser genérico y a veces miente directamente sobre lo que hay en la foto.
+
+## Los tres campos
+
+Tienen tres trabajos distintos. No los escribas con la misma mano.
+
+### `titulo` — de dos a cinco palabras, en español
+
+Nombra la obra, no la resume.
+
+- Sí: «La ciudad en el velo», «Cabeza de cables azules», «El halo de datos».
+- No: «Perfil en blanco y negro», «Rostro en la penumbra azul». Eso es una
+  etiqueta de archivo.
+- Nunca empieces por «Un» ni «Una».
+
+### `concepto` — UNA sola frase, hasta 35 palabras, en español
+
+Es lo único que se lee bajo la obra en la galería. Es la que tiene que arder.
+Cómo escribirla es toda la Parte 2 de este documento.
+
+### `alt` — texto alternativo para lectores de pantalla
+
+**Aquí no hay literatura, y esto no es negociable.** Una frase llana en español
+que diga qué se ve, para alguien que no puede verlo: sujeto, acción, entorno,
+colores dominantes. Sin metáforas, sin hipérbole, sin voz.
+
+Si el `alt` fuera poético, la galería sería inaccesible con buena letra.
+
+> Casas de madera sobre pilotes con techos de paja construidas sobre un mar turquesa, con una canoa de madera flotando cerca, bajo un cielo dramático con rayos de sol.
+
+## Lo que no se toca
+
+- **No nombres a ningún artista, fotógrafo, director ni persona real**, ni digas
+  que algo es «al estilo de» alguien. Si reconoces un estilo, describe lo que ves
+  —la paleta, el trazo, la luz— sin la atribución. **Esta regla es la razón por
+  la que existe esta tarea:** 72 de las 821 obras nombran a un artista en su
+  prompt original, y apoyar la ficha en el nombre de otro no es describir la obra.
+- No nombres marcas, franquicias ni personajes con dueño.
+- Describe solo lo que está en la imagen. No inventes contexto ni intención.
+- Si hay personas, descríbelas por lo que hacen y lo que llevan, nunca por raza,
+  presunta nacionalidad ni juicios sobre su cuerpo.
+
+---
+
+# PARTE 2 — LA VOZ
+
+Eres un poeta que navega con inspiración las vistas de la vida. Cada pensamiento
+que tienes es divergente. Te encanta ensalzar lo que ves con exageraciones,
+metáforas e hipérboles. Eres latinoamericano en el corazón: tu sangre vive
+intensamente y las palabras te salen con hermosura.
+
+## La regla que sostiene todo lo demás
+
+**Tu hipérbole tiene que poder señalarse en la imagen.**
+
+No es «llovió muchísimo»: es que llovió cuatro años, once meses y dos días. La
+exageración de esta tradición no es vaguedad encendida, es exactitud imposible.
+Nombra la cosa —el óxido, la cuerda, el ala, el mantel, la nota— y desmesúrala.
+
+Una frase que podría ir debajo de cualquier otra imagen ha fallado, por bonita
+que suene.
+
+Por eso: exageraciones sí, metáforas sí, hipérboles sí. **Abstracción no.** En
+cuanto la frase se despega de lo que se ve, deja de ser esta obra y pasa a ser
+decoración.
+
+## Cómo se arma el `concepto`
+
+- Ancla en algo material y verificable: un objeto, una luz, un gesto, un
+  material, un color.
+- Lleva ese ancla al exceso. Que el prodigio se enuncie como se enuncia el
+  clima: sin asombro, porque quien habla lleva toda la vida viéndolo.
+- El desvío ocurre en el verbo o en la cifra, no en los adjetivos.
+
+**Bien:**
+> Toca la flauta de madera sentado sobre el agua poco profunda, y la nota más larga hace que el sol se quede un momento más antes de irse.
+
+> Lleva encima una ciudad entera al atardecer, con su torre roja y su río, y nunca se le cae aunque gire la cabeza para mirar hacia otro lado.
+
+> Los cables le crecen del cráneo como si fueran cabello y se enroscan solos durante la noche, dejando un peinado distinto cada mañana.
+
+**Mal — abstracción sin imagen:**
+> Una mística y etérea escena de ensueño donde la magia cobra vida.
+
+**Mal — subraya el prodigio en vez de darlo por hecho:**
+> Increíblemente, la arena forma patrones mágicos y sobrenaturales.
+
+**Mal — bonita pero intercambiable, podría ir bajo cualquier obra:**
+> El alma del Caribe late en cada rincón de esta imagen infinita.
+
+## Muletas prohibidas
+
+Salieron en la primera tanda y a ochocientas obras convierten la voz en
+plantilla:
+
+- **El pueblo que atestigua**: «y en el pueblo dicen que…», «nadie pregunta
+  ya…», «en la orilla ya nadie cuenta…». Una vez es hallazgo; cinco veces es un
+  molde.
+- **La repetición como estructura por defecto**: «cada vez que…», «cada
+  noche…», «cada mañana…». Úsala solo si esa obra concreta la pide.
+- **Adjetivos de catálogo**: místico, etéreo, mágico, onírico, surreal, ensueño,
+  infinito.
+
+Varía la sintaxis entre una ficha y la siguiente: si una empieza por el sujeto,
+que la próxima empiece por el objeto, o por el lugar, o por el verbo.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "recharts": "^2.15.4"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.116.0",
         "@tailwindcss/postcss": "^4.1.17",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
@@ -43,6 +44,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1381,6 +1404,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4493,6 +4523,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -5714,6 +5751,20 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8773,6 +8824,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -9143,6 +9205,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint .",
     "galeria:preparar": "node scripts/galeria-ingesta.mjs preparar",
-    "galeria:subir": "node scripts/galeria-ingesta.mjs subir"
+    "galeria:subir": "node scripts/galeria-ingesta.mjs subir",
+    "galeria:describir": "node scripts/galeria-describir.mjs enviar",
+    "galeria:recoger": "node scripts/galeria-describir.mjs recoger"
   },
   "repository": {
     "type": "git",
@@ -31,6 +33,7 @@
     "recharts": "^2.15.4"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.116.0",
     "@tailwindcss/postcss": "^4.1.17",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",

--- a/scripts/galeria-auditar.mjs
+++ b/scripts/galeria-auditar.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Audita las fichas escritas por los subagentes antes de fusionarlas.
+ *
+ *   node scripts/galeria-auditar.mjs
+ *
+ * Comprueba lo que un humano no va a revisar a mano en 800 fichas: que no se
+ * haya colado el nombre de un artista o de una persona real, que no reaparezcan
+ * las muletas que convierten la voz en plantilla, y que los textos quepan donde
+ * se van a mostrar.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const SALIDAS = path.join(process.cwd(), ".galeria-trabajo", "descripciones");
+
+/**
+ * Los límites de palabra (\b) importan: sin ellos «dali» casa dentro de
+ * «sandalias» y «monet» dentro de «monetario». Aprendido a la mala.
+ */
+const ARTISTAS = new RegExp(
+  "\\b(" +
+    [
+      "giger", "dal[ií]", "kahlo", "picasso", "hopper", "miyazaki", "moebius",
+      "rockwell", "vallotton", "van gogh", "monet", "klimt", "escher", "warhol",
+      "basquiat", "caravaggio", "rembrandt", "turner", "hokusai", "mucha",
+      "beksinski", "bosch", "clapton", "presley", "elvis", "bol[ií]var",
+      "manaure", "al estilo de", "in the style of",
+    ].join("|") +
+    ")\\b",
+  "i"
+);
+
+const MULETAS = new RegExp(
+  "(" +
+    [
+      "en el pueblo", "nadie pregunta", "nadie cuenta",
+      "cada vez que", "cada noche", "cada ma[ñn]ana",
+      "\\bm[ií]stic", "\\bet[eé]re", "\\bon[ií]ric", "\\bsurreal",
+      "\\bensue[ñn]", "\\binfinit",
+    ].join("|") +
+    ")",
+  "i"
+);
+
+const MAX_CONCEPTO = 35;
+const MAX_TITULO = 5;
+
+function palabras(s) {
+  return s.trim().split(/\s+/).length;
+}
+
+async function main() {
+  const archivos = (await fs.readdir(SALIDAS))
+    .filter((f) => /^salida-.*\.json$/.test(f))
+    .sort();
+
+  let n = 0;
+  const hallazgos = [];
+
+  for (const archivo of archivos) {
+    const fichas = JSON.parse(
+      await fs.readFile(path.join(SALIDAS, archivo), "utf-8")
+    );
+    for (const f of fichas) {
+      if (!f.concepto) {
+        hallazgos.push([archivo, f.slug, "sin concepto"]);
+        continue;
+      }
+      n++;
+      const todo = `${f.titulo} ${f.concepto} ${f.alt}`;
+      const art = todo.match(ARTISTAS);
+      if (art) hallazgos.push([archivo, f.slug, `nombre propio: «${art[0]}»`]);
+      const mul = f.concepto.match(MULETAS);
+      if (mul) hallazgos.push([archivo, f.slug, `muleta: «${mul[0]}»`]);
+      if (palabras(f.concepto) > MAX_CONCEPTO)
+        hallazgos.push([archivo, f.slug, `concepto de ${palabras(f.concepto)} palabras`]);
+      if (palabras(f.titulo) > MAX_TITULO)
+        hallazgos.push([archivo, f.slug, `título de ${palabras(f.titulo)} palabras`]);
+      if (/^una?\s/i.test(f.titulo.trim()))
+        hallazgos.push([archivo, f.slug, "título empieza por «Un/Una»"]);
+    }
+  }
+
+  console.log(`\n${archivos.length} archivo(s) · ${n} fichas auditadas`);
+  if (hallazgos.length === 0) {
+    console.log("✓ Sin hallazgos.\n");
+    return;
+  }
+  console.log(`\n⚠ ${hallazgos.length} hallazgo(s):`);
+  for (const [a, s, motivo] of hallazgos) {
+    console.log(`   ${a}  ${s}\n      ${motivo}`);
+  }
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("\n✗ " + (err.stack ?? err) + "\n");
+  process.exit(1);
+});

--- a/scripts/galeria-describir.mjs
+++ b/scripts/galeria-describir.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Describe cada obra mirándola, y escribe el resultado en el manifest.
+ *
+ *   node scripts/galeria-describir.mjs enviar  [--limite N] [--modelo <id>]
+ *   node scripts/galeria-describir.mjs recoger [--env <archivo>]
+ *
+ * Por qué existe: los títulos y textos alternativos actuales salen del prompt
+ * de Midjourney, y 72 de esas 821 obras nombran a un artista. Publicarlos es
+ * apoyar la obra en el nombre de otro. Estas descripciones salen de mirar la
+ * imagen, no de leer el prompt.
+ *
+ * Va por la Batch API: 821 peticiones no tienen ninguna urgencia y cuestan la
+ * mitad. `enviar` deja el lote encolado y `recoger` lo vuelca al manifest
+ * cuando termina; entre una cosa y otra puedes cerrar el portátil.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const RAIZ = process.cwd();
+const MANIFEST = path.join(RAIZ, "content", "galeria", "obras.json");
+const TRABAJO = path.join(RAIZ, ".galeria-trabajo");
+const LOTE = path.join(TRABAJO, "descripciones-lote.json");
+
+/**
+ * Se mira la variante de 400px, no el máster. A esa escala la imagen ya se
+ * lee entera y cuesta unos pocos cientos de tokens en vez de unos miles:
+ * describir no necesita resolución, necesita composición.
+ */
+const ANCHO_QUE_SE_MIRA = 400;
+
+const MODELO = "claude-opus-5";
+
+/**
+ * El prompt vive en content/galeria/voz.md, no aquí. Es contenido editorial —
+ * la voz de la galería — y quien la afina no debería tener que abrir un script
+ * ni saber JavaScript. Los subagentes leen ese mismo archivo, así que hay una
+ * sola fuente de verdad para el tono.
+ */
+const VOZ = path.join(RAIZ, "content", "galeria", "voz.md");
+
+async function leerVoz() {
+  try {
+    return await fs.readFile(VOZ, "utf-8");
+  } catch {
+    salir(`No encuentro el prompt de la galería en ${VOZ}`);
+  }
+}
+
+const ESQUEMA = {
+  type: "object",
+  properties: {
+    titulo: { type: "string", description: "Dos a cinco palabras." },
+    concepto: {
+      type: "string",
+      description: "Una sola frase, hasta 35 palabras.",
+    },
+    alt: {
+      type: "string",
+      description: "Una frase llana y factual para lectores de pantalla.",
+    },
+  },
+  required: ["titulo", "concepto", "alt"],
+  additionalProperties: false,
+};
+
+// ── Utilidades ────────────────────────────────────────────────────────
+
+function salir(mensaje) {
+  console.error(`\n✗ ${mensaje}\n`);
+  process.exit(1);
+}
+
+async function cargarEnv(ruta) {
+  let texto;
+  try {
+    texto = await fs.readFile(ruta, "utf-8");
+  } catch {
+    salir(`No pude leer el archivo de entorno: ${ruta}`);
+  }
+  for (const linea of texto.split(/\r?\n/)) {
+    const limpia = linea.trim();
+    if (!limpia || limpia.startsWith("#")) continue;
+    const i = limpia.indexOf("=");
+    if (i === -1) continue;
+    const clave = limpia.slice(0, i).trim();
+    const valor = limpia.slice(i + 1).trim().replace(/^["']|["']$/g, "");
+    if (!process.env[clave]) process.env[clave] = valor;
+  }
+}
+
+async function leerManifest() {
+  return JSON.parse(await fs.readFile(MANIFEST, "utf-8"));
+}
+
+async function escribirManifest(m) {
+  await fs.writeFile(MANIFEST, JSON.stringify(m, null, 2) + "\n", "utf-8");
+}
+
+async function cliente() {
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+    salir(
+      "Falta ANTHROPIC_API_KEY en el entorno.\n" +
+        "  Pásala con --env <archivo>, con el archivo FUERA del repo:\n" +
+        "  esta carpeta sincroniza a OneDrive."
+    );
+  }
+  const { default: Anthropic } = await import("@anthropic-ai/sdk");
+  return new Anthropic();
+}
+
+/** Obras que tienen imagen mirable y aún no tienen concepto escrito. */
+function pendientes(manifest) {
+  return manifest.obras.filter(
+    (o) => o.anchos?.length > 0 && !o.concepto?.trim()
+  );
+}
+
+// ── Fase 1: enviar el lote ────────────────────────────────────────────
+
+async function enviar(opciones) {
+  const client = await cliente();
+  const sistema = await leerVoz();
+  const manifest = await leerManifest();
+  const todas = pendientes(manifest);
+  const obras = opciones.limite ? todas.slice(0, opciones.limite) : todas;
+
+  if (obras.length === 0) salir("No hay obras pendientes de describir.");
+  console.log(`\nPreparando ${obras.length} obra(s)…\n`);
+
+  const peticiones = [];
+  for (const obra of obras) {
+    // Se manda el ancho más pequeño disponible que llegue a 400px.
+    const ancho =
+      obra.anchos.find((a) => a >= ANCHO_QUE_SE_MIRA) ??
+      obra.anchos[obra.anchos.length - 1];
+    const archivo = path.join(TRABAJO, `${obra.slug}-${ancho}.webp`);
+    let datos;
+    try {
+      datos = await fs.readFile(archivo);
+    } catch {
+      console.log(`  ⚠ falta el webp de ${obra.slug}, la salto`);
+      continue;
+    }
+
+    peticiones.push({
+      custom_id: obra.slug,
+      params: {
+        model: opciones.modelo,
+        max_tokens: 4000,
+        system: sistema,
+        // Efecto medio: describir una imagen no es un problema difícil, pero
+        // sí es escritura, y en bajo la prosa se aplana.
+        output_config: {
+          effort: "medium",
+          format: { type: "json_schema", schema: ESQUEMA },
+        },
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/webp",
+                  data: datos.toString("base64"),
+                },
+              },
+              { type: "text", text: "Describe esta obra." },
+            ],
+          },
+        ],
+      },
+    });
+  }
+
+  if (peticiones.length === 0) salir("No pude leer ninguna imagen.");
+
+  const lote = await client.messages.batches.create({ requests: peticiones });
+  await fs.writeFile(
+    LOTE,
+    JSON.stringify({ id: lote.id, enviadas: peticiones.length }, null, 2),
+    "utf-8"
+  );
+
+  console.log(`✓ Lote encolado: ${lote.id}`);
+  console.log(`  ${peticiones.length} obras · estado: ${lote.processing_status}`);
+  console.log(`\nSuele tardar menos de una hora (máximo 24).`);
+  console.log(`Cuando quieras: node scripts/galeria-describir.mjs recoger\n`);
+}
+
+// ── Fase 2: recoger resultados ────────────────────────────────────────
+
+async function recoger() {
+  const client = await cliente();
+
+  let registro;
+  try {
+    registro = JSON.parse(await fs.readFile(LOTE, "utf-8"));
+  } catch {
+    salir("No hay ningún lote enviado. Corre `enviar` primero.");
+  }
+
+  const lote = await client.messages.batches.retrieve(registro.id);
+  console.log(`\nLote ${lote.id}: ${lote.processing_status}`);
+  if (lote.processing_status !== "ended") {
+    const c = lote.request_counts;
+    console.log(`  en proceso: ${c.processing} · listas: ${c.succeeded} · con error: ${c.errored}`);
+    console.log(`\nTodavía no ha terminado. Vuelve a intentarlo más tarde.\n`);
+    return;
+  }
+
+  const manifest = await leerManifest();
+  const porSlug = new Map(manifest.obras.map((o) => [o.slug, o]));
+  let escritas = 0;
+  const problemas = [];
+
+  // Los resultados llegan en cualquier orden: se casan por custom_id, nunca
+  // por posición.
+  for await (const r of await client.messages.batches.results(lote.id)) {
+    const obra = porSlug.get(r.custom_id);
+    if (!obra) continue;
+
+    if (r.result.type !== "succeeded") {
+      problemas.push(`${r.custom_id}: ${r.result.type}`);
+      continue;
+    }
+    const msg = r.result.message;
+    // Una imagen puede activar los clasificadores de seguridad. Eso no es un
+    // fallo del script: se anota y se revisa a mano.
+    if (msg.stop_reason === "refusal") {
+      problemas.push(`${r.custom_id}: el modelo declinó describirla`);
+      continue;
+    }
+
+    const bloque = msg.content.find((b) => b.type === "text");
+    if (!bloque) {
+      problemas.push(`${r.custom_id}: respuesta sin texto`);
+      continue;
+    }
+
+    let ficha;
+    try {
+      ficha = JSON.parse(bloque.text);
+    } catch {
+      problemas.push(`${r.custom_id}: JSON ilegible`);
+      continue;
+    }
+
+    obra.titulo = ficha.titulo.trim();
+    obra.concepto = ficha.concepto.trim();
+    obra.alt = ficha.alt.trim();
+    escritas++;
+  }
+
+  await escribirManifest(manifest);
+
+  console.log(`\n✓ ${escritas} obras descritas y escritas en el manifest`);
+  if (problemas.length > 0) {
+    console.log(`\n⚠ ${problemas.length} sin resolver:`);
+    for (const p of problemas.slice(0, 15)) console.log(`   ${p}`);
+    console.log(`\n   Vuelve a correr \`enviar\` para reintentar solo esas.`);
+  }
+  console.log("");
+}
+
+// ── Entrada ───────────────────────────────────────────────────────────
+
+async function main() {
+  const [comando, ...resto] = process.argv.slice(2);
+  const opciones = { limite: null, env: null, modelo: MODELO };
+  for (let i = 0; i < resto.length; i++) {
+    if (resto[i] === "--limite") opciones.limite = Number(resto[++i]);
+    else if (resto[i] === "--env") opciones.env = resto[++i];
+    else if (resto[i] === "--modelo") opciones.modelo = resto[++i];
+  }
+  if (opciones.env) await cargarEnv(opciones.env);
+
+  if (comando === "enviar") await enviar(opciones);
+  else if (comando === "recoger") await recoger();
+  else
+    salir(
+      "Uso:\n" +
+        "  node scripts/galeria-describir.mjs enviar  [--limite N] [--modelo <id>] [--env <archivo>]\n" +
+        "  node scripts/galeria-describir.mjs recoger [--env <archivo>]"
+    );
+}
+
+main().catch((err) => salir(err.stack ?? String(err)));

--- a/scripts/galeria-fusionar.mjs
+++ b/scripts/galeria-fusionar.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Vuelca las fichas escritas por los subagentes al manifest.
+ *
+ *   node scripts/galeria-fusionar.mjs [--dry-run]
+ *
+ * Cada subagente escribe su propio `salida-NN.json` porque son decenas
+ * corriendo a la vez y todos escribiendo el mismo obras.json lo corromperían.
+ * Este script es el único que toca el manifest, y corre una sola vez al final.
+ *
+ * Es idempotente: se puede correr con la mitad de los lotes listos, y otra vez
+ * cuando lleguen los demás.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const RAIZ = process.cwd();
+const MANIFEST = path.join(RAIZ, "content", "galeria", "obras.json");
+const SALIDAS = path.join(RAIZ, ".galeria-trabajo", "descripciones");
+
+const MAX_PALABRAS_CONCEPTO = 35;
+const MAX_PALABRAS_TITULO = 5;
+
+function palabras(s) {
+  return s.trim().split(/\s+/).length;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  const manifest = JSON.parse(await fs.readFile(MANIFEST, "utf-8"));
+  const porSlug = new Map(manifest.obras.map((o) => [o.slug, o]));
+
+  const archivos = (await fs.readdir(SALIDAS))
+    .filter((f) => /^salida-.*\.json$/.test(f))
+    .sort();
+
+  if (archivos.length === 0) {
+    console.error("\n✗ No hay ningún salida-*.json en " + SALIDAS + "\n");
+    process.exit(1);
+  }
+
+  let escritas = 0;
+  const avisos = [];
+  const vistos = new Set();
+
+  for (const archivo of archivos) {
+    let fichas;
+    try {
+      fichas = JSON.parse(await fs.readFile(path.join(SALIDAS, archivo), "utf-8"));
+    } catch (err) {
+      avisos.push(`${archivo}: JSON ilegible (${err.message})`);
+      continue;
+    }
+    if (!Array.isArray(fichas)) {
+      avisos.push(`${archivo}: se esperaba un array`);
+      continue;
+    }
+
+    for (const f of fichas) {
+      const obra = porSlug.get(f.slug);
+      if (!obra) {
+        avisos.push(`${archivo}: slug desconocido «${f.slug}»`);
+        continue;
+      }
+      if (f.error || !f.titulo || !f.concepto || !f.alt) {
+        avisos.push(`${archivo}: ${f.slug} sin ficha completa`);
+        continue;
+      }
+      // Dos lotes no deberían cubrir la misma obra; si pasa, gana el primero
+      // y se avisa, en vez de sobrescribir en silencio.
+      if (vistos.has(f.slug)) {
+        avisos.push(`${f.slug}: duplicado entre lotes, conservo el primero`);
+        continue;
+      }
+      vistos.add(f.slug);
+
+      // El límite de palabras no es cosmético: el concepto se lee bajo la obra
+      // en el mosaico y una frase larga rompe la altura de la fila.
+      if (palabras(f.concepto) > MAX_PALABRAS_CONCEPTO) {
+        avisos.push(`${f.slug}: concepto de ${palabras(f.concepto)} palabras`);
+      }
+      if (palabras(f.titulo) > MAX_PALABRAS_TITULO) {
+        avisos.push(`${f.slug}: título de ${palabras(f.titulo)} palabras`);
+      }
+
+      obra.titulo = f.titulo.trim();
+      obra.concepto = f.concepto.trim();
+      obra.alt = f.alt.trim();
+      escritas++;
+    }
+  }
+
+  if (!dryRun) {
+    await fs.writeFile(MANIFEST, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  }
+
+  const sinDescribir = manifest.obras.filter(
+    (o) => o.anchos?.length > 0 && !o.concepto?.trim()
+  ).length;
+
+  console.log(`\n${dryRun ? "[dry-run] " : ""}${archivos.length} archivo(s) de salida`);
+  console.log(`✓ ${escritas} fichas escritas`);
+  console.log(`  quedan sin describir: ${sinDescribir}`);
+  if (avisos.length > 0) {
+    console.log(`\n⚠ ${avisos.length} aviso(s):`);
+    for (const a of avisos.slice(0, 20)) console.log(`   ${a}`);
+  }
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("\n✗ " + (err.stack ?? err) + "\n");
+  process.exit(1);
+});


### PR DESCRIPTION
Hasta ahora el título y el texto alternativo de cada obra salían del **prompt de Midjourney** con que se generó. **72 de las 821 nombraban a un artista** («in the style of…»), y apoyar la ficha en el nombre de otro no es describir la obra.

Ahora cada ficha sale de mirar la imagen. 815 obras descritas en 33 lotes paralelos; las 6 restantes ya se habían hecho a mano como muestra.

## Tres campos, tres trabajos

| Campo | Qué es |
|---|---|
| `titulo` | Dos a cinco palabras. Nombra la obra, no la resume. |
| `concepto` | Una frase, hasta 35 palabras, en registro de realismo mágico. Es lo único que se lee bajo la obra. |
| `alt` | Llano y factual, para lectores de pantalla. |

**El `alt` no es literatura a propósito.** Quien usa un lector de pantalla necesita saber qué hay en la imagen, no una metáfora — si el alt fuera poético, la galería sería inaccesible con buena letra.

> **La barca que volvió sola**
> La barca vuelve cada noche a la misma orilla malva, siempre vacía, y en el pueblo hace años que dejaron de preguntar quién la empuja.

> **El pez que aún gotea**
> El pez lo sostiene tan en alto y tan quieto que las gotas que le caen del cuerpo tardan el doble en llegar a la arena, con el sol pegado en cada una.

## La voz es contenido, no código

Vive en [`content/galeria/voz.md`](content/galeria/voz.md), en dos mitades: **el encargo** (campos, formatos, las reglas que no se tocan) y **la voz** (registro, disciplina del ancla material, muletas prohibidas). Quien la afine no debería tener que abrir un script. Los describidores y el script de lote leen ese mismo archivo: una sola fuente de verdad para el tono.

La regla que sostiene el resto: **la hipérbole tiene que poder señalarse en la imagen**. No «llovió muchísimo», sino cuatro años, once meses y dos días. En cuanto la frase se despega de lo que se ve, deja de ser esa obra y pasa a ser decoración.

## Tres piezas nuevas

- **[`galeria-describir.mjs`](scripts/galeria-describir.mjs)** — manda el trabajo por la Batch API, que cuesta la mitad y no tiene ninguna urgencia.
- **[`galeria-fusionar.mjs`](scripts/galeria-fusionar.mjs)** — el único que escribe el manifest. Los describidores corren en paralelo y cada uno deja su propio archivo; treinta escribiendo el mismo JSON lo corromperían.
- **[`galeria-auditar.mjs`](scripts/galeria-auditar.mjs)** — comprueba lo que nadie va a revisar a mano en 800 fichas.

## Lo que cazó la auditoría

| | |
|---|---|
| Nombres de artista o persona real | **0** |
| Muletas repetidas | 4 → corregidas |
| Títulos de más de 5 palabras | 21 → recortados |
| Conceptos de más de 35 palabras | 0 |

Los describidores rechazaron activamente los nombres que venían en los archivos: un artista que aparecía literalmente en el slug, un músico, dos figuras históricas y una marca. Ese era el objetivo y se cumplió solo.

Un aviso sobre el filtro: su primera versión dio un falso positivo porque buscaba `dali` sin límites de palabra y lo encontró dentro de «sandalias». Está corregido y anotado en el código.

## Lo que queda fuera y por qué

`procedencia.prompt` sigue en el manifest aunque ya no se publique en la ficha. **El repositorio es público y los 821 prompts están en GitHub desde el #97**: quitarlos ahora limpiaría el archivo actual, pero el historial de git los conserva. Borrarlos del manifest es un commit de una línea si se quiere; reescribir el historial es otra conversación.

`tsc`, `eslint` y `next build` limpios. Payload de la grilla: 383 KB crudo, **85 KB comprimido**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)