### PR TITLE
Esteves 1989: el gazeteer de Paraguaná que faltaba

### DIFF
--- a/proyecto-linguistico-caquetío/4-fuentes/INDICE_FUENTES.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/INDICE_FUENTES.md
@@ -75,6 +75,7 @@ Reglas que salen de ahí, y que valen para toda minería futura:
 | [[gatschet-1885]] | 7 (2 txt) | ✅ **minado** | 48 léxicas + 31 topón. + 6 fórmulas · **5 citas** | hecha |
 | [[van-buurt-2014]] | 48 | ✅ **minado** | §6=88 · §11=29 · 180 topón. · **8 citas** | hecha |
 | [[oviedo-y-banos]] | 519 | ✅ **minado** — solo el cap. III toca a los caquetíos | 1 hecho, **ascendido a cita directa** | hecha |
+| [[esteves-1989]] | 146 | 🔴 **6 de 146** (nueva, 2026-08-11) | 1 morfema corroborado (`bacoa`) · 5 nuevos · 7 topónimos con censo | **alta** — es el gazeteer de Paraguaná ([#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)) |
 | [[camacho-2011]] | 13 | minado | **16 hechos** | hecha |
 | [[antczak-2015-las-aves]] | 38 | minado | 7 hechos | hecha |
 | [[antczak-2017-cariban]] | 45 | ✅ **minado** | 0 hechos · refuerza `parentesco-032` | hecha |

--- a/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
+++ b/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
@@ -1,8 +1,8 @@
 meta:
   generado_por: curiana_sim/generar_bibliografia.py
-  obras: 30
+  obras: 31
   en_repo: 24
-  solo_citadas: 6
+  solo_citadas: 7
   nota: 'Generado desde el frontmatter de 4-fuentes/*.md. No editar a mano: se edita la nota y se regenera.
     El `id` es la clave que citan el corpus, el lexicón, los cognados y los topónimos.'
 obras:
@@ -118,6 +118,10 @@ obras:
   - Camacho et al. 2011
   - Camacho 2011
   en_repo: true
+- id: esteves-1989
+  obra: esteves-1989
+  autor: Juan de la Cruz Esteves
+  en_repo: false
 - id: fernandes-2020
   obra: A genetic history of the pre-contact Caribbean
   autor: Fernandes, Daniel M. et al.

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -1,0 +1,139 @@
+---
+tipo: fuente
+obra: esteves-1989
+autor: Juan de la Cruz Esteves
+titulo: "Topónimos indígenas de Paraguaná y otros topónimos indígenas del estado Falcón"
+lugar_año: "Caracas, 1989"
+editor: Refinería de Amuay de Lagoven S.A.
+estado_minado: parcial
+prioridad: alta
+medido: 2026-08-11
+sostiene: []
+---
+
+# Esteves 1989 — Topónimos indígenas de Paraguaná
+
+> **Qué es.** El gazeteer de Paraguaná que al proyecto le faltaba. 146 páginas
+> de entradas topónimo por topónimo, con ubicación, censo y etimología
+> propuesta. Es **la fuente que desbloquea [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)** —
+> los poblados de Paraguaná que hoy no se pueden meter en `asentamientos.yaml`.
+
+## Ficha
+
+| | |
+|---|---|
+| Autor | **Juan de la Cruz Esteves** — cronista, poeta e investigador de Paraguaná |
+| Título | *Topónimos indígenas de Paraguaná y otros topónimos indígenas del estado Falcón* |
+| Publicación | Caracas, 1989 · patrocinada por la **Refinería de Amuay de Lagoven S.A.** |
+| Otra obra suya | *Paraguaná histórica y geográfica* (misma colección) |
+| Procedencia | Enviado por Nery R. Gil el 2026-07-27, seis PDF escaneados |
+
+> ⚠️ **La grafía del apellido es `Esteves`, con -s.** El nombre de los archivos
+> dice "Estevez"; la portada, la portadilla y la introducción de Lagoven dicen
+> **Esteves**. Manda la fuente.
+
+## Estatus epistémico: pista fuerte, autoridad débil
+
+**No es una obra académica.** Esteves es el **cronista** de Paraguaná: recoge de
+historiadores y cronistas locales, de archivos parroquiales y de saber
+transmitido. Eso le da un valor que ninguna fuente académica del repo tiene
+—conoce los lugares y los papeles locales— y una debilidad que hay que declarar:
+**sus etimologías son propuestas suyas, no análisis lingüístico.**
+
+Cómo entra cada cosa, entonces:
+
+| Lo que dice | Cómo entra |
+|---|---|
+| Cita un documento con nombre (censo, visita pastoral, libro de bautizos) | se persigue hasta el documento; ahí sí puede ser `atestiguado` |
+| Ubicación de un lugar, censo de casas y vecinos | `atestiguado` con la fecha del censo |
+| Etimología propuesta sin cita | `hipotetico` — es una propuesta de un cronista, no un despeje |
+| **Corrobora un morfema que ya teníamos** | ⭐ eso es lo que más rinde: segunda atestación independiente |
+
+## 🔑 Las fuentes que Esteves usa — lo que hay que perseguir
+
+Esto es lo más valioso de la obra para el proyecto: **es un puente hacia
+documentos de archivo que no tenemos.**
+
+| Fuente que cita | Qué es | Prioridad |
+|---|---|---|
+| ⭐ **Visita Pastoral del obispo Mariano Martí (1773)** | Fuente **colonial primaria**. Martí recorrió y describió las parroquias de Venezuela. Oliver 1989 ya lo cita como "Martí 1969" (la edición moderna) | **alta** |
+| **Censo de 1881** | Casas y vecinos poblado por poblado. Aparece en casi cada entrada | alta |
+| **Libros de bautizos parroquiales** — Jadacaquiva, 1835-1842, cura José María Valbuena | Registro nominal local | media |
+| **"Antiguos papeles de la posesión de Urupaguaduco"** | Títulos de tierra coloniales | media |
+| **Pedro Manuel Arcaya Madriz** | Ya lo tenemos: [[arcaya-1920]]. Esteves señala que la casa de Acaboa fue de sus ascendientes | — |
+
+> **Martí 1773 es el que hay que conseguir.** Es el único de la lista que es
+> colonial y primario, y ya está citado por Oliver, así que la edición moderna
+> existe y es rastreable.
+
+## ⚠️ Advertencia de época, la de siempre
+
+Las fuentes de Esteves son de **1773, 1835-1842 y 1881**. Eso es *más lejos* del
+precontacto que la carta de Bastidas (1538), no más cerca.
+
+**Nada de esta obra puede sostener `precontacto: si`** en
+`3-mundo/asentamientos.yaml`. Lo que sí hace, y es mucho, es dar el **inventario
+de topónimos** y su ubicación — que es justo lo que [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)
+necesita para dejar de tener a Paraguaná vacía.
+
+## Lo minado hasta ahora — 6 de 146 páginas
+
+> 🔴 **Barrido apenas empezado.** Lo de abajo sale de las páginas 11-12 y 25.
+
+### Morfemas que corroboran el lexicón
+
+| Morfema | Glosa de Esteves | Estado en el repo |
+|---|---|---|
+| ⭐ **`bacoa`** | 'lugar, paraje' | **CORROBORADO** — el lexicón dice 'bosque, lugar, paraje, sitio fértil'. Es nuestro morfema más productivo (`adabacoa`, `guadabacoa`, `quibacoas`, `yacarebacoa`, `sazaribacoa`) y esta es una **segunda atestación independiente** |
+| **`ure`** | 'raíz' — y dice que está *"presente en muchos topónimos indígenas de Paraguaná"* | 🆕 nuevo — candidato a morfema productivo |
+| **`bara`** | 'árbol' | 🆕 |
+| **`guani`** | 'abeja' (mansa, sin aguijón) | 🆕 |
+| **`dabuda`** | 'barro de loza' (greda de cerámica local) | 🆕 |
+| **`dara`** | alcaraván, *Charadrius* (ave) | 🆕 |
+| **Semeruco** | Esteves lo da como nombre anterior de Camoruco | corrobora `cemirucos → 'Semerucos'` de `toponimos.yaml` |
+
+### Topónimos con ubicación y censo
+
+| Topónimo | Qué es | Dato |
+|---|---|---|
+| **Abudure** | aldea al SO de Moruy | censo 1881: 6 casas, 50 vecinos. `dabuda`+`ure` = 'sitio de donde se extrae barro de las raíces' |
+| **Acaboa** | lugar pecuario, municipio Jadacaquiva | censo 1881: 2 casas, 11 vecinos. **Oratorio en 1773 (Martí)** |
+| **Adaro** | Punta de Adaro, costa occidental, Los Taques | de `dara`, con prótesis vocálica y disimilación a>o |
+| **Buenibativa** | caserío San Pedro, municipio Adícora | de *Guanibativa*; `bativa` sin explicar |
+| **Caibacoa** | sabana al oeste del fundo de Aguaque | `cái` (< *guay*, árbol tipo ceiba) + `bacoa` |
+| **Camare** | municipio Pueblo Nuevo | censo 1881: 8 casas, 48 vecinos |
+| **Camoruco** | cerca de Caradacagua, oeste de Pueblo Nuevo | antes *Semeruco* |
+
+Y aparecen como referencia geográfica: **Moruy · Jadacaquiva · Los Taques ·
+Adícora · Pueblo Nuevo · San Pedro · Aguaque · Caradacagua · Urupaguaduco**.
+
+### 👍 Un punto a favor del método de Esteves
+
+En `Acaboa` **rechaza** la etimología de *Caoba* "porque este árbol no existe en
+la flora autóctona de Paraguaná". Es exactamente el tipo de control ecológico
+que el proyecto aplica en [[mapa-ecologia]]. No es un cronista que acepte
+cualquier cosa.
+
+## Cómo se lee esta fuente
+
+Los PDF **no tienen capa de texto**: son fotos de CamScanner y `pdftotext` solo
+devuelve la marca de agua. Se leen extrayendo la imagen embebida de cada página
+y mirándola:
+
+```bash
+python <scratchpad>/extraer_paginas.py <pdf> <desde> <hasta> <destino>
+```
+
+Los seis archivos son **contiguos y sin solapamiento**, por tramos de página del
+libro: 1-25 · 25-55 · 55-72 · 72-100 · 100-129 · 129-final.
+
+## Lo que falta
+
+- **140 de 146 páginas.** El barrido completo es el trabajo de #92.
+- Comprobar si **`jadicuar`** de `toponimos.yaml` tiene algo que ver con
+  **Jadacaquiva**. Parecerse no es evidencia.
+- Perseguir a **Martí 1773**.
+
+## Enlaces
+
+[[INDICE_FUENTES]] · [[arcaya-1920]] · [[zavala-reyes-2015]] · [[toponimia]] · [[esfera-de-interaccion]] · [[mapa-ecologia]]

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -254,6 +254,66 @@ Es una afirmación **fonotáctica comprobable** contra nuestros 74 topónimos, y
 el proyecto no tenía nada sobre acento. Encaja en
 [[fonotactica]] — que hoy solo mira inventario, clusters y codas.
 
+### ⭐⭐ pp. 26-27 — evidencia para D9, y el `capu` del cronista corroborado
+
+> **CAPUHANA** (p. 26) — *"`Capu-hana`, con hache intercalada para deshacer el
+> diptongo, es el nombre de un pequeño cerro, cerca de Misaray. Quiere decir:
+> **el cerro del duende**. **`Capó`: duende, ente sobrenatural. `Bana`: cerro,
+> sitio alto.**"*
+
+Dos golpes de una vez.
+
+#### `bana` = 'cerro, sitio alto' — evidencia directa para D9 ([#38](https://github.com/miguelgilurbina/curiana-radio/issues/38))
+
+El motor glosa `-bana` como **'orilla, borde'** (CLAUDE.md, locativos) y
+`morfologia.md` como **'ancho, llano'**. Esteves dice **'cerro, sitio alto'** —
+que es *lo contrario* de llano.
+
+Es una glosa nueva y de una fuente que conoce el terreno: Capuhana **es** un
+cerro. D9 lleva abierta desde el principio y **bloquea el gate**.
+
+#### `capu` = 'duende, ente sobrenatural' — el cronista tenía razón
+
+`curiana_cronista.py` sustituye *demonio* → **`capu`** como parte de
+`DESCOLONIZAR`. Esa elección se hizo por coherencia interna del canon.
+**Esteves la corrobora desde fuera**: `Capó` es el ente sobrenatural, y aquí no
+es un demonio cristiano sino **un espíritu protector de los árboles**.
+
+Esteves añade que equivale al **`Región`** de las creencias campesinas del
+Guárico, *"cuyos primitivos habitantes eran también de ascendencia caquetía"*.
+
+#### 🐍 Y la serpiente emplumada — con cuidado
+
+El profesor **Francisco Tamayo**, etnólogo, recogió que en el cerro de Capuhana
+hay un duende que, junto a **una serpiente emplumada con una estrella en la
+cabeza**, impide que se corten los árboles. Tamayo comenta que es *"la misma
+leyenda de la serpiente emplumada de los mejicanos"* y postula
+**transculturación de los aztecas hacia los caquetíos**. Esteves propone lo
+contrario: de los caquetíos hacia los mejicanos.
+
+> ⚠️ **Ninguna de las dos direcciones tiene apoyo aquí.** Es una creencia
+> recogida en el siglo XX: `retro-abstraido` como máximo, y la etiqueta
+> **nunca asciende**. La comparación "serpiente emplumada = Quetzalcóatl" es
+> difusionismo clásico y hay que tratarla como tal.
+>
+> Dicho eso, **toca [[horizonte-de-contacto]]** — la nota que se escribió para
+> la pregunta "¿pudo un caquetío contactar con los mayas?". Aquello se cerró
+> con jadeíta de Motagua en las Antillas Menores, ~1000 años antes de la
+> ventana simulada. Esto es de otro tipo: folclore moderno, no material
+> arqueológico. Se anota, no se usa.
+
+#### `caramata`/`caigua`: otro estrato, y cumanagoto
+
+> **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua
+> cumanagota, `caramata` es carbón y `caigua` es un molusco, la almeja"**.
+> Esteves lo apoya con evidencia material: vio en el sitio *"señales,
+> antiquísimas y abundantes, de los guairones donde los indios quemaban
+> conchas marinas para la obtención de cal"*.
+
+Segundo topónimo de Paraguaná atribuido a lengua **no caquetía** (tras Amuay al
+caribe insular). El lexicón tiene `caribe-cumanagoto` con 2 entradas. Más
+material para [[esfera-de-interaccion]].
+
 ### Más fuentes que cita, según avanza el barrido
 
 | Fuente | Dónde | Qué aporta |

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -13,10 +13,124 @@ sostiene: []
 
 # Esteves 1989 — Topónimos indígenas de Paraguaná
 
-> **Qué es.** El gazeteer de Paraguaná que al proyecto le faltaba. 146 páginas
-> de entradas topónimo por topónimo, con ubicación, censo y etimología
-> propuesta. Es **la fuente que desbloquea [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)** —
-> los poblados de Paraguaná que hoy no se pueden meter en `asentamientos.yaml`.
+> **Qué es.** El gazeteer de Paraguaná que al proyecto le faltaba. **413
+> topónimos** en 154 páginas, con ubicación, censo de 1881 y etimología
+> propuesta. Es **la fuente que desbloquea [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)**.
+
+---
+
+# 📄 ABSTRACTO — el libro entero en una página
+
+*Barrido completo: 154 páginas, leídas entre lectura directa y cuatro extractos
+paralelos, 2026-08-11.*
+
+## 1. Qué aporta que no teníamos
+
+**Un inventario toponímico de Paraguaná y Falcón con referente geográfico
+real.** No es una lista de palabras: cada entrada dice *dónde está* el lugar,
+qué accidente es y cuánta gente vivía allí en 1881. Eso permite algo que ninguna
+otra fuente del repo permitía: **verificar una glosa contra el terreno**. Cuando
+Esteves dice que `bana` es 'cerro', se puede comprobar que Capuhana, Coabana y
+Chichibana son efectivamente elevaciones.
+
+## 2. Los cinco morfemas que quedan corroborados
+
+Todos ya estaban en el proyecto sostenidos **por una sola fuente** (casi siempre
+Zavala). Ahora tienen segunda fuente independiente:
+
+| Morfema | Glosa | Atestaciones en Esteves |
+|---|---|---|
+| **`bacoa`** | 'lugar, paraje, sitio' | Caibacoa, Cumujacoa, Guaidabacoa, Tobacoa |
+| **`ebo`** | 'camino, paso, senda, **valle estrecho, cañón**' | Curaidebo, Gisebo, Guacurebo, Jurijurebo, Cumarebo |
+| **`-uco`/`-uto`** | 'quebrada, cauce' | Coduto, Matuto, Acatuto, Quebrahuto, Quibarute, Tacaduto, Urupaguaduco, Semeruco |
+| **`quiba`** | 'piedra, pedruzco' | Jadacaquiva, Quibarute, Tiquiba, Todariquiba, Yauquiba, Quibucara |
+| **`-ima`** | 'húmedo, humedad' — *"en caquetío"* | p. 93 |
+| `guasare`, `guanepe`, `juri` | glosas idénticas a las nuestras | varias |
+
+**`ebo` gana matiz**: no es solo 'camino' sino **'paso, valle estrecho, cañón'**,
+y Esteves lo verifica contra el terreno en Jurijurebo (*"hay allí una abertura
+orográfica"*).
+
+## 3. Los morfemas nuevos
+
+`ure` 'raíz' (6 atestaciones) · **`tuba` 'aglomeración, abundancia' *en
+caquetío*** (3) · `bana` 'cerro, sitio alto' (8) · `cari` 'orilla' (2) ·
+`-dito` 'colectivo abundancial' *en caquetío* (4) · `aco` 'dos' (2) · `bara`
+'árbol' (2) · `naure` 'jojoto, mazorca tierna' · `ñaure` 'planta bejucosa' ·
+`dabuda` 'barro de loza' · `guara` (ave) · `rao` 'arena' · `para` 'agua'
+
+## 4. Los tres conflictos que abre
+
+| Nuestro dato | Lo que dice Esteves | Estado |
+|---|---|---|
+| `-bana` = 'orilla, borde' / 'ancho, llano' | **`bana` = 'cerro, sitio alto'** ×8, y **`cari` = 'orilla'** aparte | **D9 · [#38](https://github.com/miguelgilurbina/curiana-radio/issues/38)** — hipótesis: nuestro `-bana` absorbió el sentido de `cari` |
+| `bara` = 'río, corriente fluvial' | **'árbol'**, citando a Alvarado | **[#101](https://github.com/miguelgilurbina/curiana-radio/issues/101)** |
+| reduplicación = intensidad | **"plural por duplicación"** ×4, explícito | sin issue todavía |
+| `cumaragua` = 'caracol' | 'cangrejo de caparazón rosada' | menor |
+| `gudamuen` = 'dos' | `aco` = 'dos' | menor |
+
+## 5. 🔴 Lo que más rinde: las fuentes que abre
+
+**Juan de Castellanos, *Elegías de Varones Ilustres de Indias* (~1589)** hace
+*"una larga enumeración de los poblados indígenas de Paraguaná"* y nombra al
+*Gran Señor de Jurijurebo*; Esteves deduce que estuvo en la península **en
+1540**. Es la fuente más temprana de todo el libro y **la única que puede llenar
+Paraguaná en `asentamientos.yaml`**.
+
+Después: **Mariano Martí, *Relación de la Visita Pastoral*, 4 tomos (1773)** ·
+**fray Antonio Caulín (1799)** · **Nicolás Federmann** (que según Esteves, con
+Alfínger, *"dejó sin habitantes la península"* con sus levas) · la
+**capitulación de Carlos I a los Welser (1528)**, citada textual · escrituras
+de **1590, 1698 y 1719** · el **mapa de Fidalgo**.
+
+De su bibliografía, el repo ya tiene a **Alvarado** y **Arcaya** — pero **otras
+obras** de ellos.
+
+## 6. El mapa multilingüe
+
+Esteves atribuye topónimos a **nueve estratos** distintos, topónimo por
+topónimo. En Paraguaná: caquetío (el grueso), **taíno/caribe insular** (Amuay,
+Elegüey = Punta Cardón, Maragüey, Jamaica, Maitiruma), **cumanagoto**
+(Caradacagua, Manare, y el sufijo `cuar` dentro de **Adícora**), **papiamento**
+(Macama). En el resto de Falcón añade **chaima, caribe, ayamán, chibcha,
+cuica-timote y africano**.
+
+> **Adícora es un topónimo híbrido**: raíz caquetía + sufijo colectivo
+> cumanagoto. Es la tesis de [[esfera-de-interaccion]] en una sola palabra.
+
+## 7. Arqueología: diez sitios
+
+**Jurijurebo** (grandes cementerios, **urnas funerarias**, cerámica de
+viviendas) · **Todariquiba** (grandes cementerios) · **Cayeruba** (cementerio +
+cerámica) · **Chamuriana** (cerámica indígena **y europea**, junto a la
+fundación española de 1538) · **Machuruca/Misaray** (cementerio + **petroglifo
+fotografiado**) · **El Supí** (petroglifos, *"piedras escritas"*) · **Cerro de
+Siraba** (petroglifos, *"Las Piedras del Almanaque"*) · **Aribanache** (cueva) ·
+**Mapiare/Churuguara** · **Taima-Taima**.
+
+> Ninguno alcanza para `precontacto: si` — son reportes sin excavación
+> publicada. Pero **Jurijurebo y Todariquiba con "grandes cementerios"
+> contradice o actualiza a Oliver 1989**, que da la ubicación de Todariquiba por
+> no hallada.
+
+## 8. Cómo se debe usar esta fuente
+
+**Fiable en la glosa, escéptico en lo transoceánico.** Sus corroboraciones van
+**8 de 8** contra lo que ya sabíamos, y descarta bien las etimologías populares
+(rechaza *Caoba* por ecología, *"what you name?"* por cronología, y la leyenda
+de Judibana por falta de documento). Pero **tiende dos puentes a Mesoamérica**
+—la serpiente emplumada de Capuhana y el supuesto maya `Tecuna`— que no se
+sostienen.
+
+Y su cadena de autoridad es **Caulín (1799, sobre la Nueva Andalucía) →
+Alvarado → Esteves**: una fuente sobre el **oriente** de Venezuela. Eso puede
+sobre-representar sus atribuciones al cumanagoto.
+
+**Regla práctica**: sus glosas entran como `hipotetico`; **suben a
+`reconstruido` cuando corroboran algo que ya teníamos**; solo llegan a
+`atestiguado` si se persigue el documento que cita.
+
+---
 
 ## Ficha
 
@@ -949,6 +1063,192 @@ la flora autóctona de Paraguaná". Es exactamente el tipo de control ecológico
 que el proyecto aplica en [[mapa-ecologia]]. No es un cronista que acepte
 cualquier cosa.
 
+## La estructura real del libro — corrección
+
+Al empezar el barrido asumí que los seis PDF eran un diccionario corrido. **No
+lo es**, y el título ya lo decía: son **dos partes**. Reconstruido leyendo los
+finales de cada lote y el Índice General (pp. 147-149):
+
+| Páginas | Qué es | Archivo |
+|---|---|---|
+| 7-10 | preliminares (introducción de Lagoven) | 1 |
+| **11-67** | **PARTE I — topónimos indígenas de PARAGUANÁ**, alfabético | 1-3 |
+| 68-70 | índice de los topónimos compilados | 3 |
+| **71** | **informantes orales** — nombre, pueblo, año de nacimiento | 3 |
+| **70-72** | **FUENTES BIBLIOGRÁFICAS** | 3 |
+| **73-80** | **APÉNDICE** — artículos ensayísticos | 4 |
+| **81-144** | **PARTE II — "otros topónimos indígenas del ESTADO FALCÓN"** | 4-6 |
+| 145-146 | biografía del autor | 6 |
+| ~147-154 | Resumen numerado (**413 topónimos**) e Índice General | 6 |
+
+> ⚠️ **La Parte II NO es Paraguaná.** Cubre el resto del estado Falcón, que
+> incluye territorio de otras polities y otros pueblos (jirajara, ayamán,
+> caribe). Por la **regla 4 de CLAUDE.md**, todo lo que salga de las pp. 81-144
+> hay que marcarlo con su procedencia geográfica antes de usarlo: no vale
+> importar un topónimo de la sierra falconiana al canon costero sin decirlo.
+
+Las remisiones internas que fui encontrando (*"Ver en el Apéndice el artículo:
+Sobre el Nombre de Adícora"*, p. 14; *"la leyenda de la Piedra del Toro"*,
+p. 51) apuntan a las pp. 73-80.
+
+**El autor**: Juan de la Cruz Esteves, nacido en **El Hato, Paraguaná, 1922**.
+Escribe sobre su propia tierra. (La biografía data la edición en **1988**; la
+portada dice **Caracas, 1989** — se cita por la portada.)
+
+## ⭐⭐ Los informantes — y un apellido que no esperaba
+
+La p. 71 nombra a los informantes orales, con pueblo y año de nacimiento. Dos
+de ellos se apellidan **Manaure**:
+
+> **Don Jesús Manaure Pulgar** — *"Nativo de Misaray, municipio Santa Ana
+> (1935). Pintor-poeta… Nos dio datos sobre los pueblos de Santa Ana."*
+>
+> **Don Miguel Manaure** — *"Nativo de El Vínculo, municipio Pueblo Nuevo
+> (1942). Analfabeta, hombre de campo, completo; domador de bestias cerreras,
+> peón de fundos pecuarios, **silbador de iguanas, aguaitador de venados** y en
+> todo momento fabulador maravilloso… nos suministró **un detallado inventario
+> de la fauna y la flora en la Península**."*
+
+**Manaure es un apellido vivo en Paraguaná.** Encaja con la serie de apellidos
+caquetíos de la p. 13 (Adaure, Timaure, Yaraure, Chunaure, **Manaure**).
+
+> ⚠️ **Esto no dice nada sobre descendencia del diao histórico** ni sobre
+> continuidad de linaje — los apellidos indígenas se difundieron por bautismo y
+> encomienda. Lo que sí dice es que **el nombre sobrevive en el terreno**, y
+> que buena parte del inventario de fauna y flora de este libro viene de un
+> hombre llamado Manaure. Para un proyecto cuyo personaje central se llama así,
+> merece quedar escrito.
+
+Los otros informantes: **Don Napoleón Riera Rodríguez** (El Hato, mun. Adícora,
+1898) y **Dr. Luis A. Barreno** (El Vínculo, 1939).
+
+## 📚 La bibliografía de Esteves (pp. 71-72) — transcrita
+
+| Autor | Obra |
+|---|---|
+| **Acosta Saignes, Miguel** | *Estudios de Etnología Antigua de Venezuela* |
+| **Alvarado, Lisandro** | *Datos Etnográficos de Venezuela* · ***Glosario de Voces Indígenas*** |
+| **Arcaya, Pedro Manuel** | *La Independencia de Paraguaná* · *Población de Origen Europeo de Coro* |
+| **Coddazzi, Agustín** | *Resumen de Geografía de Venezuela* |
+| **Armas Chitty, J. A.** | *Historia de Paraguaná y Punto Fijo* |
+| **Cisneros, José Luis** | *Descripción de la Probincia de Benezuela* |
+| **Hill Peña, Aníbal** | *Noticias Históricas de Paraguaná* |
+| **Martí Estadella, Mariano** | ***Relación de la Visita Pastoral (4 tomos)*** |
+
+De estos, el repo ya tiene a **Alvarado** ([[alvarado-1921]]) y a **Arcaya**
+([[arcaya-1920]]) — aunque **no las mismas obras**: las de Esteves son otras.
+
+> **Martí en 4 tomos** es la pieza a conseguir. Es colonial (1773), primaria, y
+> Oliver ya la cita como "Martí 1969" (la edición moderna del Concejo Municipal
+> de Caracas). Existe y es rastreable.
+
+## ⭐⭐ El apéndice, p. 73 — "Sobre el nombre de Adícora"
+
+Tres cosas de peso en una sola página.
+
+#### `tuba` = 'aglomeración, abundancia' **en caquetío**
+
+> *"examinamos el primitivo `jadícuar` y lo descomponemos en **`jade`, de
+> jajato**, y la desinencia **`cuar`, que identifica a los sustantivos
+> colectivos en lengua cumanagota**. `Cuar`, en cumanagota, significa:
+> **aglomeración, abundancia**, según el misionero **Caulín**.
+>
+> Este `cuar`, cumanagota, **tiene el mismo significado del `tuba` de los
+> caquetíos**."*
+
+Morfema caquetío nuevo con glosa explícita — y **el barrido paralelo del
+archivo 3 lo encontró por su cuenta dos veces más**, con la misma glosa
+('aglomeración, montón'). Confirmación cruzada entre dos lecturas
+independientes del libro.
+
+Nótese además: **Adícora resulta ser un topónimo híbrido** — raíz caquetía
+(`jade` 'jajato') + sufijo colectivo **cumanagoto** (`cuar`). Sexto apunte
+multilingüe.
+
+#### 🆕 Coro = 'viento', según Castellanos
+
+> *"si nos atenemos al verbo retozón del **Cronista de Indias, Don Juan de
+> Castellanos**, en aquello de que **Coro quiere decir viento en lengua
+> generosa**"*
+
+Segunda aparición de Castellanos (la primera, Hurraque, p. 43). Y una glosa
+para el topónimo mayor de toda la región. ⚠️ Esteves la reporta con distancia
+irónica (*"verbo retozón"*, *"podríamos caer en el desplante"*), así que no la
+suscribe del todo.
+
+#### 🆕 Fray Antonio Caulín (1799) — y una cadena de fuentes
+
+> *"fray Antonio Caulín, profundo estudioso de las lenguas indígenas de
+> Venezuela, es el autor de **"Historia Corográfica, Natural y Evangélica de la
+> Nueva Andalucía"**, valiosa obra etnográfica publicada en **1799** y la cual
+> utilizó el sabio **Lisandro Alvarado** para desentrañar el significado de las
+> Voces Geográficas que sirven de Apéndice a su monumental **Glosario de Voces
+> Indígenas**."*
+
+Queda dibujada la cadena: **Caulín (1799) → Alvarado → Esteves (1989)**. Es la
+genealogía de buena parte de las glosas de este libro, y explica por qué tantas
+atribuciones son a lenguas orientales (cumanagoto, caribe): **Caulín escribió
+sobre la Nueva Andalucía**, o sea el oriente de Venezuela, no sobre Falcón.
+
+> ⚠️ **Sesgo de fuente que hay que tener presente**: si la autoridad léxica de
+> Esteves para lo "indígena" es una obra sobre el oriente, sus atribuciones al
+> cumanagoto pueden estar sobre-representadas por el material que tenía a mano,
+> no por la realidad de Paraguaná.
+
+## ⭐⭐⭐ p. 78 — Castellanos enumera los poblados de Paraguaná
+
+El hallazgo con más consecuencias de todo el libro. Textual:
+
+> **JURIJUREBO** — *"**Juan de Castellanos** en los monótonos endecasílabos que
+> conforman su famosa por extensa *Elegías de Varones Ilustres de Indias*, nos
+> habla del **Gran Señor de Jurijurebo**, y **por la larga enumeración que hace
+> de los poblados indígenas de Paraguaná**, induce a pensar que el fraile
+> rimador **estuvo en esta Península de Paraguaná en 1540**.
+>
+> Pero como hasta el presente no ha aparecido un documento preciso que le
+> confiera autenticidad a estos indicios, **la cuestión no pasa del terreno de
+> las conjeturas**. También, vagamente, algunos historiadores han conjeturado
+> que el Cacique Jurijurebo y su esposa Judibana fueron los "indianos" llevados
+> por **Alonso de Ojeda a las Cortes españolas en el año de 1500** y que de allá
+> regresaron con los nombres cristianos de Fernando García y Juana de García.
+>
+> Sobre el particular nos abstenemos de más comentarios, **porque la historia es
+> historia y no invención**…
+>
+> Pero lo que sí hay de cierto es que la población de **Jurijurebo junto con
+> Todariquiba eran los asientos poblacionales de más importancia en la nación
+> caquetía**, como ha quedado demostrado últimamente con el descubrimiento de
+> **grandes cementerios** en las inmediaciones."*
+
+### Por qué esto es lo más importante del libro
+
+1. **Castellanos trae una lista de poblados de Paraguaná del siglo XVI.**
+   [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92) existe
+   porque `asentamientos.yaml` tiene Paraguaná casi vacía por falta de fuente
+   temprana. **Aquí está la fuente**, y es de ~1540 — anterior a la carta de
+   Bastidas y a todo lo demás que maneja Esteves.
+2. **Todariquiba y Jurijurebo, al mismo rango.** Todariquiba es `nodo-001`, el
+   poblado de Manaure. Esteves pone a Jurijurebo a su altura: los dos *"asientos
+   poblacionales de más importancia en la nación caquetía"*.
+3. **Cementerios grandes en ambos.** Y la ubicación de Todariquiba está **en
+   debate** en Oliver 1989 — *"no se ha hallado un sitio arqueológico del tamaño
+   correspondiente"*. Si Esteves dice que se descubrieron cementerios grandes,
+   **eso contradice o actualiza a Oliver** y hay que perseguirlo.
+
+### ⚠️ Y una corrección al barrido automático
+
+Un extracto paralelo resumió esto como *"Jurijurebo/Judibana: cacique y esposa
+mencionados por Juan de Castellanos"*. **No es lo que dice el texto.**
+Castellanos nombra al *Gran Señor de Jurijurebo*; la historia de la pareja
+llevada por Ojeda en 1500 la atribuye Esteves, *"vagamente"*, a *"algunos
+historiadores"* — y se abstiene de suscribirla. La diferencia importa: una cosa
+es una mención en una crónica del XVI y otra una conjetura historiográfica sin
+documento.
+
+Es coherente con lo que Esteves ya había dicho en la p. 47 sobre la misma
+pareja (*"Es pura leyenda, nada consta en documentos"*). **No se contradice: se
+mantiene escéptico las dos veces.**
+
 ## Cómo se lee esta fuente
 
 Los PDF **no tienen capa de texto**: son fotos de CamScanner y `pdftotext` solo
@@ -961,6 +1261,26 @@ python <scratchpad>/extraer_paginas.py <pdf> <desde> <hasta> <destino>
 
 Los seis archivos son **contiguos y sin solapamiento**, por tramos de página del
 libro: 1-25 · 25-55 · 55-72 · 72-100 · 100-129 · 129-final.
+
+## La transcripción cruda
+
+El barrido página por página está en `4-fuentes/sesiones/`:
+
+| Archivo | Páginas del libro |
+|---|---|
+| `06_esteves_1989_barrido_lote3.md` | 56-72 (cola del diccionario + aparato) |
+| `06_esteves_1989_barrido_lote4.md` | 73-100 (apéndice + Parte II, letra A-C) |
+| `06_esteves_1989_barrido_lote5.md` | 101-129 (Parte II, C-Q) |
+| `06_esteves_1989_barrido_lote6.md` | 130-154 (Parte II, Q-Z + índices) |
+
+Las pp. 11-55 están transcritas en esta misma nota, arriba. **Nadie debería
+tener que releer las 154 imágenes**: si falta un dato, está en esos cuatro
+archivos con cita textual y número de página.
+
+> ⚠️ Los lotes 3-6 salen de un barrido automático. **Todo lo que se ascienda
+> desde ahí al lexicón o al corpus hay que verificarlo contra la imagen** — ya
+> se detectó un caso donde el resumen automático convertía una conjetura
+> historiográfica en una mención de crónica (ver p. 78 arriba).
 
 ## Lo que falta
 

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -272,6 +272,32 @@ que es *lo contrario* de llano.
 Es una glosa nueva y de una fuente que conoce el terreno: Capuhana **es** un
 cerro. D9 lleva abierta desde el principio y **bloquea el gate**.
 
+##### 🔴 Y en la p. 28, segunda atestación — que además explica de dónde vino nuestro error
+
+> **CARIRUBANA** — *"significa: orilla del peñón, la orilla del cerro. **`Cari`:
+> orilla. `Bana`: sitio alto.**"*
+>
+> **CARIGUARIANA** — *"quiere decir: la playa de los tabacones… **`Cari`:
+> orilla de mar.** `Guariana`: tabaco pescador o tabacón."*
+
+Con esto quedan **dos morfemas separados y dos atestaciones cada uno**:
+
+| Morfema | Glosa de Esteves | Dónde |
+|---|---|---|
+| **`cari`** | **'orilla, orilla de mar'** | Carirubana, Cariguariana |
+| **`bana`** | **'sitio alto, cerro'** | Carirubana, Capuhana |
+
+> ⭐ **La hipótesis que esto sugiere**: el proyecto glosa `-bana` como
+> **'orilla, borde'** — que es exactamente lo que Esteves asigna a **`cari`**.
+> Si `Carirubana` = `cari`+`ru`+`bana` = 'orilla del cerro', entonces alguien
+> leyó el compuesto entero, se quedó con 'orilla' y se lo colgó al elemento
+> equivocado. **`-bana` habría absorbido el significado de `cari`.**
+>
+> Es una hipótesis, no un veredicto: hace falta ver de dónde salió nuestra
+> glosa original. Pero explica el conflicto entero de D9 de una manera
+> económica, y encaja con que `-bana` conviva con `-ana` sin que nadie sepa
+> distinguirlos.
+
 #### `capu` = 'duende, ente sobrenatural' — el cronista tenía razón
 
 `curiana_cronista.py` sustituye *demonio* → **`capu`** como parte de
@@ -301,6 +327,63 @@ contrario: de los caquetíos hacia los mejicanos.
 > con jadeíta de Motagua en las Antillas Menores, ~1000 años antes de la
 > ventana simulada. Esto es de otro tipo: folclore moderno, no material
 > arqueológico. Se anota, no se usa.
+
+##### Tercera atestación de `bana`, pp. 30-31
+
+> **COABANA** — *"El topónimo es una voz compuesta que dice: **el cerro de las
+> coas**. `Coa` es un tosco instrumento de labranza, un palo aguzado para abrir
+> el surco. **`Bana`: cerro.**"*
+
+Tres topónimos, tres veces 'cerro / sitio alto', y en los tres el referente es
+un accidente elevado: **Capuhana · Carirubana · Coabana**. Para una glosa que
+el proyecto tiene como 'orilla' o 'llano', es evidencia dura.
+
+### pp. 30-31 — dos afijos corroborados y un sitio precolombino
+
+#### ✅ `-uco` / `-uto` = 'quebrada, cauce' — corroboración limpia
+
+> **CODUTO** — *"El sufijo **`uto`** y **`uco`**, indistintamente, lo hemos
+> hallado formando voces compuestas con la significación de **quebrada,
+> cauce**."*
+
+`morfologia.md:35` ya tenía `-uco` = 'cauce, quebrada (variante `-uto`)',
+**sostenido por una sola fuente**: Zavala #268. Esteves da la **misma glosa y
+la misma variante** de forma independiente. Es de los afijos de
+`REGLAS_ZAVALA`, así que toca al motor.
+
+#### 🆕 `-dito` = colectivo
+
+> **COCODITE** — *"Del topónimo sabemos que el sufijo **"dito"** es distintivo
+> de los **sustantivos colectivos** en lengua indígena."*
+
+Afijo nuevo, no está en `morfemas.yaml`. Una sola fuente y sin más ejemplos:
+`hipotetico`.
+
+#### ⭐ CAYERUBA — el primer sitio de Paraguaná con evidencia precolombina
+
+> *"no hay dudas de que en **tiempos precolombinos** fue asiento de un populoso
+> vecindario indígena, lo atestigua, aparte de la abundancia de **restos de
+> cerámica aborigen** que se encuentra en el lugar, **el hallazgo reciente de
+> un cementerio**."*
+
+Esto **sí** es del tipo de evidencia que `3-mundo/asentamientos.yaml` exige para
+`precontacto`: material, no documental. Hoy ningún nodo continental lo tiene.
+
+> ⚠️ Pero es **Esteves reportando**, no un informe arqueológico. Sin excavación
+> publicada ni fecha, no alcanza para `precontacto: si` —que exige
+> `precontacto_razon` verificable— pero sí marca **dónde habría que buscar**.
+> Curiosamente, Cayeruba **no aparece en el censo de 1881** y Esteves llama la
+> omisión "inexplicable".
+
+#### Documentos de archivo con fecha, que es lo que rinde
+
+| Año | Qué | Dónde |
+|---|---|---|
+| **1590** | *"antiguos papeles escriturados… como tierras compuestas a favor de Alonso Arias Vaca"* — donde el topónimo es **Cocodito**, no Cocodite | p. 31 |
+| **1698** | papeles escriturados de los linderos de la posesión de **Urupaguaduca** (topónimo *Carajaima*, antes *Caramajaima*) | p. 27 |
+
+**1590 es el documento más antiguo que Esteves cita**, y está a 52 años del
+pacto de Manaure. Merece perseguirse.
 
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -385,6 +385,123 @@ Esto **sí** es del tipo de evidencia que `3-mundo/asentamientos.yaml` exige par
 **1590 es el documento más antiguo que Esteves cita**, y está a 52 años del
 pacto de Manaure. Merece perseguirse.
 
+### pp. 32-33 — `bana` cuarta vez, `bacoa` segunda, y un vínculo con los jirajaras
+
+#### `bana` / `bano` — cuarta atestación, con variante
+
+> **CUBIANO** — *"`Cujíbano`, que es la forma primitiva, quiere decir: **el
+> cerro del cují**."*
+
+Cuatro: **Capuhana · Carirubana · Coabana · Cujíbano**. Y aparece la variante
+**`-bano`**, que el proyecto no tenía registrada. (También hay un
+**Cucurubano**, pero Esteves lo despacha como onomatopéyico.)
+
+#### ✅ `bacoa` = 'lugar' — segunda atestación dentro de Esteves
+
+> **CUMUJACOA** — *"alteración de `Curumubacoa`, quiere decir: **lugar de los
+> zamuros**. `Curumu`: zamuro. **`Bacoa`: lugar.**"*
+
+Con `Caibacoa` (p. 25) van dos dentro de esta obra, más las cinco de Zavala en
+nuestro `toponimos.yaml`. **`bacoa` es el morfema mejor sostenido del corpus
+toponímico.** Y `curumu` = 'zamuro' es entrada nueva.
+
+#### ⭐ Un vínculo lingüístico caquetío–jirajara, dicho por Esteves
+
+> **CUMARAGUAS** — *"En los valles de **Yaracuy** hay también un lugar con ese
+> nombre, esto revela que **existieron vínculos lingüísticos entre caquetíos y
+> jirajaras**."*
+
+Toca dos cosas a la vez:
+
+- **[[esfera-de-interaccion]]**: es una afirmación explícita de contacto
+  lingüístico entre dos pueblos. El elenco tiene 2 agentes jirajara y el
+  lexicón 7 formas `jirajaroide-contacto`.
+- **[[polities-caquetias]]**: Yaracuy es una polity **distinta** de la costera
+  que simulamos. Esteves cruza esa frontera con un topónimo compartido — que es
+  justo el tipo de dato que la regla 4 de CLAUDE.md obliga a marcar antes de
+  usar.
+
+> ⚠️ Un topónimo compartido no prueba parentesco lingüístico: puede ser
+> préstamo, coincidencia o difusión posterior. La inferencia es de Esteves.
+
+##### 🔴 Y de paso, un conflicto de glosa
+
+Esteves: **`cumaragua`** = *"un pequeño **cangrejo** de caparazón rosada… voz
+indígena con significación de **espuma rosada**"*.
+
+El lexicón tiene `cumaragua` = **'caracol de las costas de Paraguaná'**.
+Cangrejo ≠ caracol. Menor, pero es del mismo tipo que `bara` y `tara`.
+
+#### 🆕 El mapa de Fidalgo — fuente cartográfica
+
+> **CUCUY** — *"La Punta de Cocuy está señalada en el **mapa de Paraguaná que
+> elaboró el Brigadier Joaquín Fidalgo**."*
+
+Fidalgo levantó la carta de la costa de Venezuela a finales del s. XVIII. Es
+**fuente primaria cartográfica** y fija topónimos con posición. Va a la lista
+de adquisición.
+
+#### Dos entes sobrenaturales más
+
+- **El Cude** (paraje boscoso con rocas cavernosas, Pedregalito, mun. Adícora):
+  *"un ente sobrenatural, un espíritu perturbador que trastorna a las personas
+  con su invitación al viaje del Más Allá"*. Voces, quejidos, luces nocturnas.
+- Junto al **Capó** de Capuhana y el **Región** del Guárico, van tres.
+  ⚠️ Todos son creencia viva recogida en el s. XX: `retro-abstraido`.
+
+#### Y una nota ecológica que sí sirve
+
+> **CUNACHO** — de `Cuna`/`Cunaro`, *"pez lábrido que abunda en el golfete de
+> Coro y del cual extraían **manteca para untar los 'jachos'**, teas de madera,
+> comúnmente de curarí, para encandilar en labores de **pesca nocturna**"*.
+
+Técnica de pesca con antorcha alimentada con grasa de mero, en el Golfete.
+Material para [[mapa-ecologia]] y para el canon.
+
+### p. 35 — `ebo` corroborado, un sitio de 1538 y una pista guayquerí
+
+#### ✅ `ebo` = 'camino, paso, senda' — tercera atestación, segunda fuente
+
+> **CURAIDEBO** — *"su forma primitiva `Curarirebo`, significa: **el paso del
+> Curarí**. `Curarí`: árbol maderable, tecoma. **`Ebo`: camino, paso, senda.**"*
+
+`toponimos.yaml` lo tenía por `jurijurebo` y `cumarebo`, ambos vía Zavala.
+Esteves lo da **con la glosa idéntica** y en un tercer topónimo. Junto con
+`bacoa`, es de lo más firme que hay.
+
+(Y `curarí` 'árbol maderable, tecoma' ya había salido en la p. 33 como la
+madera de los `jachos` para pesca nocturna: coherencia interna.)
+
+#### ⭐ CHAMURIANA — una aldea indígena anterior a 1538
+
+> *"**Antigua aldea indígena** en cuyas cercanías los españoles fundaron en
+> **1538** el pueblo de Santa Ana de Paraguaná. En el lugar se hallan **restos
+> de cerámica indígena y europea**. Nada sabemos del significado de la voz."*
+
+Segundo sitio de Paraguaná con evidencia material (tras Cayeruba), y este
+además **fechado por el contacto**: la aldea ya estaba cuando llegaron los
+españoles en 1538.
+
+> ⚠️ Anterior a 1538 **no es precontacto**: el contacto en esta costa empieza
+> hacia 1499-1527. Sigue sin dar `precontacto: si`, pero es el nodo peninsular
+> con la evidencia más temprana de todo el libro hasta aquí — y la cerámica
+> mixta indígena/europea documenta el momento del choque.
+
+#### 🆕 Charaima y los guayquerí — una pista para un hueco declarado
+
+> **CHARAIMA** — 1881: 79 casas, 527 habitantes. Nombre primitivo **`Charaide`**
+> según su *Título de Composición*. Y: *"No sabemos qué relación guarda el
+> nombre de esta Charaima de Paraguaná con el del **cacique Charaima de la Isla
+> de Margarita, el abuelo del guayquerí Francisco Fajardo**."*
+
+[[esfera-de-interaccion]] §6 declara como hueco: *"Si los guaycaríes eran un
+grupo distinto o una denominación de otra cosa. Son 4 agentes del elenco y no
+hay nota de fuente que los sostenga."*
+
+Esto **no lo cierra** —Esteves mismo dice que no sabe si hay relación— pero es
+el primer rastro documental de los guayquerí que toca el proyecto, y viene con
+nombres perseguibles: cacique Charaima de Margarita, Francisco Fajardo.
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -848,6 +848,78 @@ colectivo **de abundancia**, no colectivo a secas. Ya es un afijo sólido.
 
 Con Amuay, Elegüey y Maragüey van cuatro.
 
+### pp. 48-51 — el contrato de los Welser, el venado extinto y dos afijos más
+
+#### ⭐ La capitulación de los Welser, citada textualmente
+
+> **MARACAPANA** — *"en el **contrato de arrendamiento, otorgado por Carlos
+> Primero a los Belzares**, decía: **"Desde el Cabo de La Vela hasta la costa
+> de Maracapana"**"*.
+
+Es la **capitulación de 1528** que entregó Venezuela a los Welser — documento
+fundacional del período que Federmann y Alfínger protagonizaron. Esteves lo
+cita para **corregir un error**: ese Cabo de la Vela es el de La Guajira y esa
+Maracapana la de Cumaná, no las homónimas de Paraguaná. Buen criterio otra vez.
+
+#### 🦌 `matacán` — un venado de Paraguaná, extinguido
+
+> **MATACÁN** — *"cérvido de poca alzada. **En tiempos pasados había rebaños de
+> este tipo de venado en los bosques de Paraguaná. Se han extinguido por la
+> cacería incontrolada.**"*
+
+Toca dos cosas del proyecto:
+
+- **[#45](https://github.com/miguelgilurbina/curiana-radio/issues/45)** (`tara`:
+  ¿venado o mariposa?) — confirma que **había venados en Paraguaná**, lo que
+  hace ecológicamente viable la glosa 'venado'. No decide el issue (no habla de
+  `tara`), pero quita el argumento de que no habría referente.
+- **[[mapa-ecologia]]** — es un caso literal de la tesis "fauna moderna ≠ fauna
+  del s. XV": había rebaños de cérvidos y ya no hay.
+
+#### Afijos: tercera y segunda atestación
+
+> **MATUTO** — *"la desinencia **"uto"**, o **"uco"**, expresa: **quebrajón,
+> cauce**."* → tercera vez (con Coduto p. 31 y la mención de la p. 31).
+>
+> **MICHACO** — *"la desidencia **`Aco`** significa: **dos**."* → segunda vez
+> (con Guachaco p. 39, 'los dos zorros').
+
+`aco` = 'dos' ya no es una aparición suelta. Sigue chocando con el `gudamuen` =
+'dos' del lexicón.
+
+#### 🔴 Quinto estrato: papiamento
+
+> **MACAMA** — *"`Macamba` y `Macambo` hemos leído en antiguos mapas, lo cual
+> nos induce a considerar la voz como **originaria del papiamento de las
+> Antillas holandesas**. Sabemos que en Aruba y Curazao —suponemos que también
+> en Bonaire— **`macambo` es gentilicio despectivo que aplican a los nativos de
+> Holanda**."*
+
+Es la dirección **inversa** a la de [[van-buurt-2014]], que documenta palabras
+caquetías **en** el papiamento. Aquí una voz papiamenta llega a un topónimo de
+Paraguaná — o sea, **tráfico en los dos sentidos** entre las islas y la
+península. Material directo para [[esfera-de-interaccion]].
+
+Y **MAITIRUMA** suma al estrato antillano: *"En el **caribe insular**, `mái`
+significa: manantial, ojo de agua; `Iruma`: azul celeste, o sea que Maitiruma
+expresa: **manantial azul**."*
+
+#### Segundo cumanagoto, y una coherencia interna
+
+> **MANARE** — *"es **voz cumanagota** que significa: **cesto de fibra**."*
+
+Y **`quigua`** = 'concha de almeja y otros moluscos' (Maquigua < *Moriquigua*),
+que es el mismo elemento que el **`caigua`** 'almeja' que dio como cumanagoto en
+Caradacagua (p. 27). Las glosas de Esteves cierran entre sí.
+
+#### ✅ Cita a Jahn, fuente que ya tenemos
+
+> *"En la Guajira hay un lugar con ese nombre (**Alfredo Jhan, "Los Aborígenes
+> del Occidente de Venezuela"**)"* (p. 49)
+
+Es [[jahn-1927]] — con el apellido mal escrito (*Jhan* por **Jahn**). Tercera
+obra del repo que Esteves cita, tras Alvarado y (indirectamente) Arcaya.
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -693,6 +693,88 @@ tenía `guasare` glosado *'Árbol cactáceo'*. Coincidencia literal.
   alcaloide"*. ⚠️ `hayo` es también el nombre de la coca en zonas de Colombia —
   no lo doy por relacionado, pero merece comprobarse.
 
+### ⭐⭐ pp. 44-45 — Federmann vació la península, y un patrón en Esteves que hay que nombrar
+
+#### Federmann y Alfínger, según el cronista
+
+> **JAGÜE** — *"en esa cueva perecieron asfixiados cantidad de indios de los
+> **reclutados por Nicolás Federmann**, el conquistador alemán que varias veces
+> hizo levas de indios en Paraguaná. Es bien sabido que **Federmann y Alfínger
+> fueron los grandes genocidas de Paraguaná**: sus descabelladas excursiones
+> las organizaban utilizando como bestias de carga a nuestros primitivos
+> pobladores y los seguidos reclutamientos que practicaron con ese fin,
+> **dejaron sin habitantes a nuestra península**."*
+>
+> **JACUQUE** — *"fue por Punta de Jacuque por donde **Nicolás Federmann
+> desembarcó los caballos que trajo de Santo Domingo en 1530**"* (Esteves avisa
+> que esto *"no se puede confirmar históricamente"*).
+
+**Federmann era el nombre que encabezaba la lista de adquisición** de fuentes
+directas del turno anterior — el teniente de los Welser que salió de Coro en
+1530 y escribió la *Indianische Historia*. Esteves confirma que **operó en
+Paraguaná**, y con esto la fuente pasa de "interesante" a "necesaria".
+
+Y añade una tesis demográfica con consecuencias:
+
+> ⚠️ Si las levas de Federmann y Alfínger **dejaron sin habitantes la
+> península** en los años 1530, eso explica por qué los poblados de Paraguaná
+> no se dejan rastrear hacia atrás: **la continuidad se rompió**. Los censos de
+> 1881 y las visitas de 1773 estarían contando repoblación posterior, no
+> descendencia directa.
+>
+> Es una afirmación fuerte de un cronista local, sin cita. **Perseguirla en
+> Federmann mismo es exactamente el trabajo que hay que hacer.**
+
+#### ✅ `quiba` = 'pedruzco' — corroborado, y resuelve un conflicto viejo
+
+> **JADACAQUIVA** — *"**`Quiba` en caquetío es pedruzco**"*.
+
+`toponimos.yaml` (toponimo-003, `quibacoas`) ya había resuelto a favor de
+'piedra' un conflicto entre `quiba` = 'ayuda' (Zavala #203) y `quiva`/`cuiva` =
+'piedra', apoyándose en van Buurt. **Esteves lo confirma de forma
+independiente y en caquetío.** Tercera fuente para la misma glosa.
+
+> (La etimología que Esteves reporta para el topónimo —*"¡Jaca… quiba!"* =
+> 'piedra contra esas jacas'— es etimología popular, y él mismo llama
+> "pintorescas" a las dos versiones que recoge. La glosa de `quiba` sí la
+> afirma en seco.)
+
+**Jadacaquiva** es además el poblado más grande del censo: **243 casas y 1.840
+vecinos** en 1881, iglesia de 1740, *"uno de los más antiguos de Paraguaná"*.
+
+#### 🔴 El patrón mesoamericano de Esteves — segunda vez, y hay que decirlo
+
+> **ITICUNA** — *"`Cuna` es el nombre de un pez que hay en el Golfete de Coro.
+> **`Tecuna` es una voz maya que quiere decir: mujer infiel.** Ahondando con
+> seriedad en el asunto, se podría establecer la afinidad de esta voz maya con
+> este topónimo caquetío."*
+
+Es la **segunda vez** que Esteves tiende un puente a Mesoamérica: antes fue la
+serpiente emplumada de Capuhana (p. 26), donde propuso transculturación
+caquetío → mexicano.
+
+> ⚠️ **Esto no se sostiene, y conviene nombrarlo como sesgo del autor.**
+> - Un parecido de una palabra a 2.000 km sin nada más es el caso de manual de
+>   falso cognado.
+> - **La forma es inestable**: el censo de 1881 escribe **`Arituna`**, no
+>   `Iticuna`. Se está comparando con el maya una forma que ni siquiera es
+>   firme.
+> - El propio Esteves hedge: *"se podría establecer"*.
+>
+> **Consecuencia práctica**: Esteves tiene una atracción declarada por las
+> conexiones mesoamericanas. Eso no invalida el resto del libro —sus glosas
+> corroboradas van cinco de cinco— pero **obliga a mirar con lupa cualquier
+> afirmación suya que cruce el Caribe**. [[horizonte-de-contacto]] cerró la
+> pregunta maya con jadeíta de Motagua, evidencia material y ~1000 años
+> anterior a la ventana. Ni la serpiente ni `Tecuna` la reabren.
+
+#### 🆕 Fuentes nuevas
+
+| Fuente | Para qué |
+|---|---|
+| **Tulio Febres Cordero** | glosa de `jagüe` como árbol de los Andes |
+| **Juan de Castellanos**, *Elegías* | ver Hurraque, p. 43 |
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -76,9 +76,71 @@ precontacto que la carta de Bastidas (1538), no más cerca.
 de topónimos** y su ubicación — que es justo lo que [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92)
 necesita para dejar de tener a Paraguaná vacía.
 
-## Lo minado hasta ahora — 6 de 146 páginas
+## Lo minado hasta ahora — 10 de 146 páginas
 
-> 🔴 **Barrido apenas empezado.** Lo de abajo sale de las páginas 11-12 y 25.
+> 🔴 **Barrido en curso.** Lo de abajo sale de las páginas 11-16 y 25 del libro.
+
+### ⭐ Los cuatro hallazgos que ya cambian algo
+
+**1. `jadicuar` resuelto — y contra la hipótesis que teníamos.**
+
+`toponimos.yaml` tiene `jadicuar` sin glosa, y yo lo había marcado como posible
+variante de **Jadacaquiva**. Es falso. Esteves (p. 14):
+
+> ADÍCORA — *"El nombre primitivo era **Jadícuar**, que quiere decir: jajatal,
+> sitio donde abunda el jajato, hierba halófila de terrenos salobres. Este
+> Jadícuar, por uno de esos curiosos procesos de selección eufónica, ha venido
+> cambiando de Jadícuar a Jadícora, de Jadícora a Jatícora, hasta llegar al
+> sugestivo y poético Adícora de hoy."*
+
+Es **el nombre indígena de Adícora**, con la cadena de cambio completa. Sirve
+para subir `nodo-012` en `3-mundo/asentamientos.yaml`, que hoy está como
+`reconstruido` porque solo teníamos el nombre.
+
+**2. Una serie morfológica de apellidos caquetíos — con Manaure dentro.**
+
+Esteves (p. 13) lista *"algunos de los apellidos de la gran familia caquetía"*:
+
+> **Adaure · Timaure · Yaraure · Chunaure · Manaure**
+
+Cinco formas en `-aure`. `toponimos.yaml` ya tenía `timaure` ('Apellido') y
+`tumarure` ('Apellido de un cacique') sueltos y sin explicar; ahora hay serie.
+Toca directamente al personaje central del elenco.
+
+> ⚠️ Esteves **no** analiza `-aure` como morfema ni da su significado. La serie
+> es suya; el análisis sería nuestro y sería `hipotetico`.
+
+**3. 🔴 Amuay no sería caquetío: Esteves lo atribuye al caribe insular.**
+
+> AMUAY (p. 16) — *"La voz da la idea de cavidad subterránea, haitón, cueva
+> grande… **Por su fonética la voz pertenece al caribe insular**, como batey,
+> mamey, caney, carey"*.
+
+Es un topónimo **de Paraguaná** atribuido a otro estrato lingüístico. Va
+directo a [[esfera-de-interaccion]]: la sociedad no era monoétnica y la lengua
+no era homogénea. El lexicón ya tiene las categorías `kalinago` (19) y
+`kalinago-caribe-overlay` (4) donde esto encajaría.
+
+**4. Un documento de 1556 con voz indígena, citado textual.**
+
+Petición de los **indios amuayes** al obispo Gerónimo de Ballesteros pidiendo
+cambiar de santo patrono:
+
+> *"A vos, Gerónimo, que sos nuestro Obispo y Amo, te pedimos dos cosas. La
+> primera: es un buen santo para nuestro Patrón, pues nosotros no queremos a
+> San Juan, pues como está desnudo, no va a querer que llueva para no tener
+> frío. La segunda: Danos otro cura, que no sea cobarde como el que tenemos,
+> que en cuanto vio venir el verano se largó…"*
+
+**Ballesteros es el mismo obispo cuya carta de 1550 ya citamos** vía Oliver
+(`geografia_politica-004/005`, el canal del `buco` y los 14-15 mil indios).
+Esteves añade que fue el **segundo obispo de Coro** y que murió allí en 1558.
+
+> ⚠️ Esteves **no da la referencia de esta petición**. Menciona la compilación
+> del Coronel José Félix Blanco, *Documentos para la Historia del Libertador*
+> (1875), pero en la frase siguiente y aplicada al dato de la lápida. **Hay que
+> perseguir la fuente antes de usarla**: una cita sin procedencia de un texto
+> tan bueno es exactamente donde conviene desconfiar.
 
 ### Morfemas que corroboran el lexicón
 
@@ -99,13 +161,28 @@ necesita para dejar de tener a Paraguaná vacía.
 | **Abudure** | aldea al SO de Moruy | censo 1881: 6 casas, 50 vecinos. `dabuda`+`ure` = 'sitio de donde se extrae barro de las raíces' |
 | **Acaboa** | lugar pecuario, municipio Jadacaquiva | censo 1881: 2 casas, 11 vecinos. **Oratorio en 1773 (Martí)** |
 | **Adaro** | Punta de Adaro, costa occidental, Los Taques | de `dara`, con prótesis vocálica y disimilación a>o |
+| **Adaure** | aldea al oeste de Buenavista | censo 1881: **87 casas, 522 vecinos** — mayor que muchas cabeceras de municipio. **Martí 1773 citado textual**. Aníbal Hill Peña los da como "tribu belicosa" |
+| **Adícora** | capital de municipio, costa oriental | ⭐ antes **Jadícuar** = 'jajatal' (ver arriba) |
+| **Aguaque** | fundo a dos leguas al norte de Pueblo Nuevo | de *guaco*, portulácea. Casa natal de Josefa Camejo; Monumento Histórico desde 1982 |
+| **Amaraya** | aldea al sur de Jadacaquiva | censo 1881 (como *Amaralla*): 16 casas, 108 vecinos. ¿de *maracaya*, el "güirito", gato silvestre? |
+| **Amuay** | bahía y población, municipio Los Taques | censo 1881: 8 casas, 60 vecinos → ~400 casas y 3.000 hab. al escribir. 🔴 **atribuido al caribe insular** |
+| **Antuni** | lugar pecuario al norte de Jadacaquiva | Esteves **duda que sea indígena** |
 | **Buenibativa** | caserío San Pedro, municipio Adícora | de *Guanibativa*; `bativa` sin explicar |
 | **Caibacoa** | sabana al oeste del fundo de Aguaque | `cái` (< *guay*, árbol tipo ceiba) + `bacoa` |
 | **Camare** | municipio Pueblo Nuevo | censo 1881: 8 casas, 48 vecinos |
 | **Camoruco** | cerca de Caradacagua, oeste de Pueblo Nuevo | antes *Semeruco* |
 
 Y aparecen como referencia geográfica: **Moruy · Jadacaquiva · Los Taques ·
-Adícora · Pueblo Nuevo · San Pedro · Aguaque · Caradacagua · Urupaguaduco**.
+Adícora · Pueblo Nuevo · San Pedro · Aguaque · Caradacagua · Urupaguaduco ·
+Buenavista**.
+
+### Más fuentes que cita, según avanza el barrido
+
+| Fuente | Dónde | Qué aporta |
+|---|---|---|
+| **Aníbal Hill Peña**, historiador | p. 13 | los adaures como "tribu belicosa"; Esteves dice tener papeles de sus peleas contra los españoles |
+| **José Félix Blanco (Cor.)**, *Documentos para la Historia del Libertador* (1875) | p. 16 | compilación por decreto de Guzmán Blanco |
+| **Obispo Gerónimo de Ballesteros** | p. 16 | 2.º obispo de Coro, † Coro 1558. **El mismo de la carta de 1550** que ya citamos vía Oliver |
 
 ### 👍 Un punto a favor del método de Esteves
 
@@ -129,10 +206,13 @@ libro: 1-25 · 25-55 · 55-72 · 72-100 · 100-129 · 129-final.
 
 ## Lo que falta
 
-- **140 de 146 páginas.** El barrido completo es el trabajo de #92.
-- Comprobar si **`jadicuar`** de `toponimos.yaml` tiene algo que ver con
-  **Jadacaquiva**. Parecerse no es evidencia.
-- Perseguir a **Martí 1773**.
+- **136 de 146 páginas.** El barrido completo es el trabajo de #92.
+- ✅ ~~Comprobar `jadicuar` ↔ Jadacaquiva~~ — **resuelto y descartado**: es el
+  nombre primitivo de **Adícora**.
+- Perseguir a **Martí 1773** y a la petición de 1556, que Esteves cita sin dar
+  procedencia.
+- Hay un **Apéndice** con un artículo "Sobre el Nombre de Adícora" (remitido
+  desde la p. 14). Localizarlo — probablemente en el archivo 6.
 
 ## Enlaces
 

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -176,6 +176,84 @@ Y aparecen como referencia geográfica: **Moruy · Jadacaquiva · Los Taques ·
 Adícora · Pueblo Nuevo · San Pedro · Aguaque · Caradacagua · Urupaguaduco ·
 Buenavista**.
 
+### 🔴 Lo que el cruce con nuestros datos destapó (pp. 17-19)
+
+**El proyecto ya citaba a Esteves sin tener la obra.** `morfemas.yaml` §46-47
+dice: *"van Buurt §5 recoge `-ure` (papiamentu -huri/-uri) glosado 'raíz' por
+**Cruz Esteves 1989**, y lo declara equivalente al `-ure` continental. La
+evidencia toponímica dice 'sitio de'."* Era un conflicto abierto contra una
+fuente que no teníamos. Ahora la tenemos.
+
+#### 1. `-ure` = 'raíz' — Esteves lo sostiene con tres topónimos
+
+| Topónimo | Descomposición de Esteves |
+|---|---|
+| **Abudure** | `dabuda` 'barro de loza' + `ure` 'raíz' = 'sitio de donde se extrae barro de las raíces' |
+| **Babahuro** | `baba` 'caño' + `ure` 'raíz' = 'el caño de las raíces' — *"por las abundantes raíces adventicias de los tupidos manglares"* |
+| **Asubure** | nombre indígena del *sesuvio* (*Sesuvium portulacastrum*), el "vidrio". ⚠️ Esteves NO lo descompone |
+
+Los dos primeros son referencias **literales** a raíces (raíces de manglar,
+barro extraído de raíces), no a 'sitio de'. Eso **refuerza la lectura de
+Esteves** frente a la nuestra, pero no la cierra: `-ure` podría ser 'sitio de'
+y el sentido de raíz venir del otro elemento. Sigue en conflicto declarado.
+
+#### 2. 🔴 `bara`: el lexicón dice 'río', dos fuentes dicen 'árbol'
+
+Esteves (p. 19), citando el *Glosario de Voces Indígenas* de **Lisandro
+Alvarado** — que es [[alvarado-1921]], obra que **ya tenemos y ya minamos**:
+
+> *"Sabemos que **Bara**, en lengua caquetía, es voz general para designar toda
+> clase de **árbol**. Nos informamos en Lisandro Alvarado que **Barabara**,
+> plural por duplicación, es el nombre de un árbol caparidáceo que aquí
+> conocemos con el nombre de olivo."*
+
+Y `morfemas.yaml` §59 ya decía que **van Buurt §5** documenta `bara`/`bari`
+'árbol' (cf. lokono *balli*).
+
+**Pero `curiana_lexicon.py:113` tiene `bara` = 'río, corriente fluvial'**,
+`caquetío-reconstruido`, *"forma justificada por cognado en
+proto-arawakan/topónimo"*.
+
+> Dos fuentes independientes dicen 'árbol'; el motor dice 'río'. Es el mismo
+> patrón que `tara` ([#45](https://github.com/miguelgilurbina/curiana-radio/issues/45)),
+> `saruro` ([#47](https://github.com/miguelgilurbina/curiana-radio/issues/47))
+> y `corie` ([#46](https://github.com/miguelgilurbina/curiana-radio/issues/46)).
+> Levantado aparte.
+
+Complica el cuadro que `bara` aparece **además** como cognado lokono de `para`
+'mar' (`cognados.yaml`). Tres sentidos en danza: 'río', 'árbol', 'mar'.
+
+#### 3. `saruro` (#47) — pista, no solución
+
+Esteves da **Asaro** (aldea de Pueblo Nuevo) y lo compara con **Sarosaro** de
+La Guajira, *"plural por duplicación… un árbol cuya madera blanda utilizaban
+los guajiros para obtener el fuego por frotación"*.
+
+⚠️ **No resuelve #47.** La forma es `sarosaro`/`asaro`, no `saruro`; y es
+**guajiro**, no caquetío. El issue dice que Alvarado no trae `saruro` ni como
+lema — y esto no lo cambia. Es una pista para seguir, nada más.
+
+#### 4. Dos rasgos morfológicos que se repiten
+
+- **Reduplicación = plural.** Esteves lo dice dos veces con esas palabras:
+  `Sarosaro` y `Barabara` son *"plural por duplicación"*. Nuestro
+  `jurijurebo` ya usaba reduplicación. ⚠️ Pero `morfologia.md:176` la lee como
+  **intensidad** (`barabara` = 'árbol de madera dura'), no como plural.
+  **Otro conflicto**, y esta vez Esteves es explícito.
+- **`baba` = `baja` = 'caño'.** Esteves los da como equivalentes (Bajabaroa,
+  Babahuro).
+
+#### 5. Una regla prosódica, y es nueva
+
+> ARAJÓ (p. 17) — *"Sobre esta voz Arajó, inusitada por **aguda**, mantenemos
+> reservas: **las voces agudas escasean en los topónimos indígenas de
+> Paraguaná**; a nuestro modo de ver, la pronunciación primitiva debió ser:
+> Arajo."*
+
+Es una afirmación **fonotáctica comprobable** contra nuestros 74 topónimos, y
+el proyecto no tenía nada sobre acento. Encaja en
+[[fonotactica]] — que hoy solo mira inventario, clusters y codas.
+
 ### Más fuentes que cita, según avanza el barrido
 
 | Fuente | Dónde | Qué aporta |
@@ -183,6 +261,8 @@ Buenavista**.
 | **Aníbal Hill Peña**, historiador | p. 13 | los adaures como "tribu belicosa"; Esteves dice tener papeles de sus peleas contra los españoles |
 | **José Félix Blanco (Cor.)**, *Documentos para la Historia del Libertador* (1875) | p. 16 | compilación por decreto de Guzmán Blanco |
 | **Obispo Gerónimo de Ballesteros** | p. 16 | 2.º obispo de Coro, † Coro 1558. **El mismo de la carta de 1550** que ya citamos vía Oliver |
+| ⭐ **Lisandro Alvarado**, *Glosario de Voces Indígenas* | p. 19 | **Ya lo tenemos**: [[alvarado-1921]]. Fuente de su `bara` = 'árbol' — comprobable directamente |
+| **José Luis Cisneros**, *Descripción de la Probincia de Benezuela* | p. 18 | libro colonial (1764). Da *Avotuca* como "lugar de vigilancia de las costas de Paraguaná" |
 
 ### 👍 Un punto a favor del método de Esteves
 

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -775,6 +775,79 @@ caquetío → mexicano.
 | **Tulio Febres Cordero** | glosa de `jagüe` como árbol de los Andes |
 | **Juan de Castellanos**, *Elegías* | ver Hurraque, p. 43 |
 
+### ⭐⭐⭐ pp. 46-47 — JURIJUREBO: nuestro `toponimo-001`, corroborado entero
+
+> **JURIJUREBO** — *"Antaño hubo allí una importante comunidad indígena; **la
+> gran ciudad de Jurijurebo, decían los cronistas**; todavía hay vestigios de
+> su cementerio; **al excavar se encuentran restos humanos dentro de tinajas de
+> barro**, también se hallan fragmentos de cerámica alrededor de los sitios
+> donde estuvieron las viviendas.
+>
+> `Jurijurebo` quiere decir: **el paso de los vientos**. `Juri`: viento; `Ebo`:
+> **paso, ruta, valle estrecho, cañón. En efecto, hay allí una abertura
+> orográfica.**"*
+
+`2-lengua/toponimos.yaml`, **`toponimo-001`**, nivel A, con esta observación:
+*"Estaba archivado en TOPONIMOS_ZAVALA como 'glosa incierta' y fuera del habla.
+**Es el caso que originó toda la tarea F11.**"*
+
+Nuestra glosa: *'Paso de los vientos'*, `juri` 'viento' + `ebo` 'camino, paso'.
+**Esteves da exactamente lo mismo**, desde otra fuente y con tres cosas más:
+
+1. **Verifica contra el terreno**: *"En efecto, hay allí una abertura
+   orográfica"*. La glosa no es solo etimológica, la sostiene la geografía.
+2. **Enriquece `ebo`**: 'paso, ruta, **valle estrecho, cañón**'. Nuestra glosa
+   ('camino, paso, senda') se queda corta en el sentido orográfico.
+3. **Era un asentamiento mayor**: *"la gran ciudad de Jurijurebo, **decían los
+   cronistas**"*. O sea que hay cronistas que lo nombran — otra pista
+   documental que perseguir.
+
+> El topónimo que abrió la línea de trabajo entera queda **confirmado por
+> fuente independiente, con verificación de terreno**. Es la mejor
+> corroboración del libro.
+
+#### 🏺 Quinto sitio arqueológico — y con enterramiento en urnas
+
+*"restos humanos dentro de **tinajas de barro**"* es **enterramiento en urna**,
+un rasgo diagnóstico en la arqueología venezolana, no un detalle de color. Más
+cerámica alrededor de las viviendas.
+
+Los cinco sitios que Esteves reporta hasta aquí:
+
+| Sitio | Evidencia |
+|---|---|
+| **Jurijurebo** | cementerio con **urnas funerarias** + cerámica de viviendas |
+| Cayeruba | cementerio + cerámica aborigen abundante |
+| Chamuriana | cerámica indígena **y europea** (contacto, 1538) |
+| Machuruca / Misaray | cementerio indígena |
+| El Supí (playa de Adícora) | **petroglifos** — *"placer de piedras escritas"* |
+
+#### `bana` = 'sitio alto' — sexta atestación
+
+> **JUDIBANA** — *"**`Judi`, `juri`: viento. `Bana`: sitio alto.**"*
+
+Seis: Capuhana · Carirubana · Coabana · Cujíbano · Chichibana · **Judibana**.
+Y aparece la variante **`judi`** de `juri` 'viento'.
+
+(La leyenda que recoge —Judibana como *"hermosa mujer, esposa del Gran Cacique
+de Jurijurebo"*— la despacha él mismo: *"Es pura leyenda, **nada consta en
+documentos**"*. Buen criterio otra vez.)
+
+#### `-dito` — tercera atestación, y ahora "abundancial"
+
+> **JARAYADITO** — *"El sufijo **"dito"** es distintivo de los nombres
+> colectivos **abundanciales**."* (censo de 1881: *Sarayadite*)
+
+Tres apariciones (Cocodite, Guanadito, Jarayadito), con la glosa afinada:
+colectivo **de abundancia**, no colectivo a secas. Ya es un afijo sólido.
+
+#### Cuarto topónimo de estrato caribe insular
+
+> **JAMAICA** — *"en el **caribe insular**, quiere decir: **tierra de los
+> manantiales**."* (lugar del municipio Buenavista)
+
+Con Amuay, Elegüey y Maragüey van cuatro.
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -622,6 +622,77 @@ Tercera aparición de Martí 1773 en el barrido, y aquí conserva una **forma m�
 larga** del topónimo. Es justo lo que hace valiosa la fuente primaria: la
 grafía de 1773 está menos erosionada que la de 1881.
 
+### ⭐⭐ pp. 41-43 — HURRAQUE: un pueblo caquetío del siglo XVI, y tres sitios arqueológicos
+
+#### Hurraque / Jurraque — nombrado por Juan de Castellanos
+
+> *"Nombre de un **pueblo caquetío** mencionado por **Juan de Castellanos**, el
+> fraile rimador de las famosas por extensas *Elegías de Varones Ilustres de
+> Indias*. Debió ser **`Jurraque`** la pronunciación primitiva de este
+> desaparecido pueblo. **Hasta el presente se desconoce el sitio** donde estuvo
+> ubicada esta importante comunidad indígena. Podría ser cerca del caserío
+> **Misaray, en Machuruca**, sitio en el cual fue descubierto **un cementerio
+> indígena**. O tal vez en las cercanías de **El Supí, playa de Adícora, donde
+> hay un placer de "piedras escritas"**."*
+
+Esto es lo mejor que ha dado el libro para [#92](https://github.com/miguelgilurbina/curiana-radio/issues/92):
+
+1. **Un poblado caquetío nombrado en el siglo XVI.** Castellanos escribió las
+   *Elegías* hacia 1589 sobre hechos desde los 1540. Es **la fuente más
+   temprana que Esteves cita**, y estaba en mi lista de adquisición del turno
+   anterior — ahora hay una razón concreta para perseguirla.
+2. **Un poblado perdido**: nadie sabe dónde estuvo. Entra en
+   `asentamientos.yaml` como `atestiguado` de existencia y **sin ubicación**,
+   igual que Todariquiba.
+3. **Tres pistas arqueológicas nuevas**:
+   - **cementerio indígena en Machuruca / Misaray**
+   - **"piedras escritas" (petroglifos) en El Supí, playa de Adícora**
+   - más el cementerio y la cerámica de **Cayeruba** (p. 30) y la cerámica
+     mixta de **Chamuriana** (p. 35)
+
+> Cuatro sitios con material arqueológico en Paraguaná, todos reportados por
+> Esteves sin excavación publicada. Ninguno alcanza para `precontacto: si`,
+> pero juntos dicen **dónde habría que mirar** — y los petroglifos de El Supí
+> son el único rastro no funerario del conjunto.
+
+#### ✅ `-dito` sube de nivel: segunda atestación, y atribuida al caquetío
+
+> **GUANADITO** (p. 41) — *"**`Dito` es característica desinencial de nombres
+> colectivos en caquetío**."*
+
+Con `Cocodite` (p. 31) van dos, y aquí Esteves **nombra la lengua**. Deja de ser
+un `hipotetico` de una sola aparición.
+
+(Y en `Guayacanal`, p. 42, observa que *"la partícula 'al' colectiviza y
+españoliza la voz **Guayacán, de origen taíno**"* — o sea que distingue el
+colectivo indígena del castellano.)
+
+#### ✅ `guasare` — corroborado exacto
+
+Esteves: *"`Guasare` es un **árbol cactáceo**"*. Nuestro `toponimos.yaml` ya
+tenía `guasare` glosado *'Árbol cactáceo'*. Coincidencia literal.
+
+#### Más léxico dado como caquetío
+
+| Forma | Glosa de Esteves |
+|---|---|
+| **`guara`** | *"en caquetío"*, el ave que llaman cunareja — mayor que el zamuro, plumones blancos en las alas, occipucio rojo sin plumas |
+| `guaraguaja` / `guaraguara` | 'cunarejal' — **plural por duplicación** (cuarto caso) |
+| `guarataro` | barro de loza gomoso para budares y ollas |
+| `güica` | otro nombre indígena del árbol *yabo* |
+| `imujo` | aféresis de `huaymujo`, cangrejo pequeño |
+| `guatacare` | árbol perennifolio sapindáceo |
+
+#### Y dos apuntes de mundo
+
+- **Güima** (p. 43) era *"un cacique que, según la leyenda, él y su familia
+  padecían de **albinismo**"*. Mencionado en el Título de Composición de
+  Urupaguaduco.
+- **Hayo** (p. 43): *"leyenda de que los indios masticaban las hojas de este
+  árbol para **aliviar el hambre**; quizás la savia contenga alguna sustancia
+  alcaloide"*. ⚠️ `hayo` es también el nombre de la coca en zonas de Colombia —
+  no lo doy por relacionado, pero merece comprobarse.
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/esteves-1989.md
@@ -502,6 +502,126 @@ Esto **no lo cierra** —Esteves mismo dice que no sabe si hay relación— pero
 el primer rastro documental de los guayquerí que toca el proyecto, y viene con
 nombres perseguibles: cacique Charaima de Margarita, Francisco Fajardo.
 
+### pp. 36-37 — `bana` quinta vez, `naure` glosado y el estrato taíno
+
+#### `bana` = 'cerro' — quinta atestación
+
+> **CHICHIBANA** — *"`Chichabana` es una aféresis de `Achichibana`, que quiere
+> decir: **el cerro de los achechives**."*
+
+Cinco compuestos, cinco veces 'cerro': **Capuhana · Carirubana · Coabana ·
+Cujíbano · Chichibana**. Para una fuente única es todo lo consistente que puede
+llegar a ser.
+
+#### ⭐ `naure` / `ñaure` — glosados "en lengua caquetía", y tocan a Manaure
+
+> **CHUNAURE** — *"`Chunaure` es un apellido indígena; sabemos, además, que **en
+> lengua caquetía "ñaure" es planta bejucosa, y "naure", es jojoto, mazorca de
+> maíz tierno**."*
+
+Dos entradas léxicas nuevas, atribuidas explícitamente al caquetío. Y **cierran
+sobre la serie de apellidos de la p. 13** (Adaure, Timaure, Yaraure, Chunaure,
+**Manaure**): el elemento `-naure` ya no es opaco.
+
+> ⚠️ **No lo apliques a Manaure todavía.** El corpus ya tiene una explicación
+> del nombre (`geografia_politica-008`: término laudatorio, con las variantes
+> *managuanare* y *managuarire*, vía Zavala citando a González). Segmentar
+> `Ma-naure` = '?-maíz tierno' sería nuestro, no de Esteves, y entraría como
+> `hipotetico`. Lo que sí es de Esteves: `naure` = 'jojoto' en caquetío.
+
+#### 🔴 Dos topónimos más de estrato taíno / caribe insular
+
+> **ELEGÜEY** — *"Nombre antiguo de **Punta Cardón**… **Es voz taína, del caribe
+> insular**. En Casicure, en la otra costa del golfete de Coro, hay una pequeña
+> península llamada **Maragüey, que también es voz taína**."*
+
+El elemento compartido **`-güey`** apoya la atribución: es un formante bien
+conocido de la toponimia taína antillana. Con esto el mapa lingüístico de
+Paraguaná que dibuja Esteves va así:
+
+| Estrato | Topónimos |
+|---|---|
+| caquetío | el grueso del libro |
+| **taíno / caribe insular** | **Amuay · Elegüey (Punta Cardón) · Maragüey** |
+| **cumanagoto** | **Caradacagua** |
+| **ayamán** (dudoso) | Cuara — *"parece voz ayamán"* |
+
+> Es exactamente la tesis de [[esfera-de-interaccion]] vista desde el terreno:
+> **una península con topónimos de al menos tres lenguas distintas.** Y no es
+> una inferencia nuestra — la hace un cronista local, topónimo por topónimo.
+
+#### Corroboraciones menores
+
+- **`dabuda`** 'barro de loza' — segunda vez (Dabadubare, mun. Santa Ana), tras
+  Abudure. Esteves mismo remite de una entrada a la otra.
+- **`chiguaral`** — *"colectivo de `chigua`re"*: segundo caso de sufijo
+  colectivo, tras `-dito`. Esteves no lo nombra como afijo aquí.
+
+### pp. 38-39 — un contraejemplo nuestro que se cae, y un numeral
+
+#### ✅ `ebo` — cuarta y quinta atestación, **y resuelve un contraejemplo declarado**
+
+> **GISEBO** — *"`Ebo`: significa camino."*
+>
+> **GUACUREBO** — *"proviene de 'Guacoa', pero más explícito por el **sufijo
+> "ebo"**, o sea que expresa: **el paso de la guacoa**."*
+
+⭐ `2-lengua/toponimos.yaml` lista, bajo `ebo`: *"nota: dos contraejemplos con
+glosa divergente: **guacurebo**, turijerebo"*.
+
+**Esteves analiza `guacurebo` exactamente como `ebo`** — y con la misma glosa
+que ya teníamos ('paso'). Uno de los dos contraejemplos declarados **deja de
+serlo**. Queda `turijerebo` por resolver.
+
+Y aquí Esteves lo llama **sufijo** con esa palabra, cosa que no había hecho.
+
+#### ✅ `bacoa` — tercera atestación, con análisis alternativo
+
+> **GUAIDABACOA** — *"con sílaba epentética intercalada, es una voz compuesta de
+> **`guái`, árbol parecido a la ceiba** y **`bacoa`: sitio, paraje**."*
+
+Tercera dentro de Esteves (Caibacoa, Cumujacoa, Guaidabacoa). Pero ojo:
+
+> ⚠️ **Nuestro `toponimos.yaml` analiza `guadabacoa` de otra manera**: glosa
+> 'Arboleda', con `ada` = 'árbol' y `wa-` como prefijo de pluralidad (van Buurt
+> §6, de Goeje 1928). **Esteves lo parte en `guái` + `bacoa`.**
+>
+> Los dos coinciden en `bacoa` y en que hay un árbol; discrepan en el primer
+> elemento y en si hay prefijo de plural. Es el **mismo topónimo con dos
+> segmentaciones**, y conviene anotarlo antes de que alguien las mezcle.
+> (Esteves también da `Guadabacoa` como la grafía del censo de 1881.)
+
+#### 🆕 `aco` = 'dos, par' — un numeral, y choca con el que tenemos
+
+> **GUACHACO** — *"quiere decir: **los dos zorros**. **`Guache`: zorro; `Aco`:
+> dos, par.**"*
+
+El lexicón tiene solo 3 numerales, y uno de ellos es **`gudamuen` = 'dos'**.
+Esteves da **`aco`**. Dos formas distintas para el mismo número: o es variación
+dialectal, o una de las dos está mal atribuida. Menor, pero anotado.
+
+#### ✅ `guanepe` — corroborado casi palabra por palabra
+
+> **GUACHUNEPE** — *"el nombre viene de **`guanepe`**, objeto doméstico de la
+> artesanía autóctona, **cesto de fibra primorosamente elaborado por las indias
+> para cargar dentro a sus hijos recién nacidos**."*
+
+El lexicón ya tiene `guanepe` = **'cesto para cargar niños'**. Coincidencia
+exacta, de fuente independiente. 👍
+
+(Esteves además **descarta** con buen criterio la etimología popular de
+*"what you name?"* → "guachumen", razonando que el topónimo es anterior a la
+llegada de las petroleras.)
+
+#### Martí otra vez, con grafía distinta
+
+> **GUACUIRA** (1881: 84 casas, 593 habitantes) — *"El obispo Martí escribió
+> **"Guaimaguacuira"** en la relación de su Visita Pastoral."*
+
+Tercera aparición de Martí 1773 en el barrido, y aquí conserva una **forma más
+larga** del topónimo. Es justo lo que hace valiosa la fuente primaria: la
+grafía de 1773 está menos erosionada que la de 1881.
+
 #### `caramata`/`caigua`: otro estrato, y cumanagoto
 
 > **CARADACAGUA** (p. 27) — de *Caramatacaigua*, 'guairón de cal'. **"En lengua

--- a/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote3.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote3.md
@@ -1,0 +1,336 @@
+# Hallazgos — Esteves, *Topónimos indígenas de Paraguaná* (1989) — Archivo 3 (est3, p001-p017)
+
+Nota general: las imágenes cubren las páginas impresas 56 a 72 del libro (final del diccionario alfabético de P a Y, más los apéndices). **Falta la página 65** en la secuencia de escaneos: p009.jpg = p.64, p010.jpg es una foto sin número visible (probablemente el reverso de la lámina "Cerro Siraba"/"Cerro Santa Ana", posiblemente numerada 65 pero sin texto), y p011.jpg salta directo a p.66, cuyo primer párrafo ("La voz es taína y quizás fue traída por holandeses antillanos...") es la continuación de una entrada (probablemente TUCACAS/TUPARO o similar, cerca de TUCUATO/TURA) cuyo comienzo no está en el material disponible. Esa entrada queda incompleta — falta su encabezado y el inicio del texto.
+
+---
+
+## p. 56
+
+### TOPÓNIMOS
+- **Paraguaná**: "Conuco en medio del mar es la más repetida de las significaciones que le dan al topónimo. Está suficientemente averiguado que *Para* significa agua."
+- **Perabay**: lugar limítrofe entre los municipios Jadacaquiva, Pueblo Nuevo y Buenavista, cerca de Piedra Honda, al Sureste de San José de Cocodite.
+- **Peticuare**: cerro al Este del caserío Quitaire, municipio Santa Ana. "Es voz indígena adulterada con una raíz afrancesada: peti, petit."
+- **Pipiacoa**: nombre de sabanas dentro de las tierras del Vínculo de Curaidebo. "Las sabanas de Pipiacoa leemos en un documento de 1596."
+- **Pipiribana**: cerro cercano al cerro de Tausabana, municipio Santa Ana. "¿Será voz onomatopéyica?"
+- **Pitajaya**: aldea de Buenavista. Censo 1881: 12 casas, 71 vecinos. "Pitajaya es otro nombre indígena de nuestro *susucure*, cardo seudo-parásito que da una fruta de piel y pulpa roja."
+- **Pury**: nombre en un antiguo mapa, cerca del cerro Plantacio, cerca de Caradacagua. "Los vecinos no recuerdan ese nombre."
+
+### FUENTES
+- Documento de 1596 (sabanas de Pipiacoa).
+- Mapa antiguo (Pury, sin más identificación).
+
+### CENSO 1881
+- Pitajaya: 12 casas, 71 vecinos.
+
+---
+
+## p. 57
+
+### MORFEMAS Y GLOSAS
+- **Quibarute**: "quiere decir: la quebrada de las piedras. *Quiba*: pedruzco. *Uto o uco*, quebrada."
+- **Quipital**: "colectiva de Quipito, árbol pequeño de corteza olorosa..."
+- **Quiyegua**: "es una voz híbrida de español y caquetío: Piedra y Yegua."
+- **Sabarigua**: "puede ser una alteración de *Sibidigua*, arbusto euforbiáceo."
+
+### TOPÓNIMOS
+- **Quibarute**: aldea del municipio Jadacaquiva.
+- **Quitaire**: lugar al Este del Taparo, municipio Santa Ana. "No parece voz indígena."
+- **Quipital**: nombre que llevan varios fundos en distintos sitios de la Península.
+- **Quipayú**: cuevas naturales en La Cieneguita, cerca de Punta Salinas, municipio Los Taques.
+- **Quiyegua**: lugar al Norte de Jadacaquiva.
+- **Sabarigua**: aldea del municipio Adícora, al Norte de Santa Cruz y de Pueblo Nuevo.
+
+### OTROS DATOS
+- Frase inicial (continuación de página anterior, sin encabezado en esta imagen): "En cumanagoto, *puripuri*, plural por duplicación, es el molestoso mosquito que aquí llamamos 'jején'." — **RASGO GRAMATICAL: reduplicación/plural por duplicación**, atribuido a lengua cumanagota (no caquetía).
+
+---
+
+## p. 58
+
+### TOPÓNIMOS
+- **Sacuragua**: aldea del municipio Pueblo Nuevo, al Oeste de Guacuira y al Sur de Pueblo Nuevo. "El nombre primitivo era [S]uragua, modificación de Susucure, cardo de fruto rojo..."
+- **Saguatumo**: lugar del municipio Moruy. Censo 1881: 2 casas, 8 vecinos. "El nombre es antiquísimo."
+- **Sanajaquí**: salinas en el territorio del municipio Los Taques.
+- **Sanquinche**: lugar al Oeste de la población de Moruy, antaño punto de descanso de peones y acémilas entre Coro y Los Taques.
+- **Sarabón**: punto costeño al Norte de Punta Cardón, atalaya de pescadores para avistar cardúmenes; hoy conjunto residencial de la ciudad de Maraven.
+
+### MORFEMAS Y GLOSAS
+- **Sanajaquí**: "*Sanajaquire*. *Quire*: color."
+- **Sanquinche**: "El *Quinche* nos parece un hipocorístico de Joaquín." (etimología popular/leyenda, no caquetía)
+
+### CENSO 1881
+- Saguatumo: 2 casas, 8 vecinos.
+
+### FOLKLORE / TRADICIÓN ORAL
+- Refrán citado textualmente: "'Sale más que el espanto de Sanquinche' o más corriente, 'sale más que el muerto de Sanquinche'", con la leyenda del espanto de los músicos arrieros. (No es dato lingüístico caquetío, es leyenda local.)
+
+---
+
+## p. 59
+
+(foto — "Cerro Siraba", sin texto)
+
+---
+
+## p. 60
+
+### TOPÓNIMOS
+- **Sarinao**: aldea del municipio Santa Ana. Censo 1881: 20 casas, 157 habitantes. "El nombre primitivo era *Sarinaro*."
+- **Saruro**: cerro, punto de referencia en linderos de tierras comuneras de Cerro Atravesado y Taparo.
+- **Sicaname**: aldea del municipio Jadacaquiva. Censo 1881: 10 casas, 55 vecinos.
+- **Sibidigual**: lugar cercano a la aldea de Matividiro, municipio Buenavista.
+- **Siraba**: cerro cónico unido al cerro de Santa Ana por el lado Noreste, altura ~500 m.
+- **Sisibaúco**: lugar y quebrada en el municipio Baraived.
+
+### MORFEMAS Y GLOSAS
+- **Saruro**: "nombre de una serpiente no venenosa, la boa constrictora."
+- **Sicaname**: "Se nos ha informado que *Sicaanme* viene de Sicagua, árbol resinoso."
+- **Sibidigual**: "colectivo abundancial de Sibidigua, arbusto euforbiáceo."
+- **Sisibaúco**: "Es un paraje frondoso donde abundan los 'yacures', árboles de verdor perenne." (nota: sufijo **-uco** de nuevo asociado a lugar/paraje)
+
+### EVIDENCIA ARQUEOLÓGICA
+- **Siraba**: "En el cerro de Siraba están localizadas unos petroglifos que llaman: 'Las Piedras del Almanaque'." — petroglifos ("piedras escritas"/petroglifos).
+
+### CENSO 1881
+- Sarinao: 20 casas, 157 habitantes.
+- Sicaname: 10 casas, 55 vecinos.
+
+---
+
+## p. 61
+
+### MORFEMAS Y GLOSAS
+- **Supí**: "es un árbol cactáceo que exuda una goma medicinal, es el guamacho periskia de los botánicos."
+- **Suriquiba**: "Es voz híbrida que dice: la Piedra del Sur." (quiba = piedra)
+- **Tacal**: "colectivo de taque, árbol nucífero."
+- **Tacaduto**: "expresa la quebrada del taque. *Uto*: cauce. *Taque*: árbol." (nuevamente **-uto** = quebrada/cauce, morfema ya rastreado)
+- **Taque**: "árbol que produce una nuez comestible."
+
+### TOPÓNIMOS
+- **Supí**: dos lugares en Paraguaná — uno cerca de Adícora (balneario El Supí) y otro en municipio Baraived.
+- **Supideo**: lugar del municipio Moruy. "No tenemos más noticias."
+- **Suriquiba**: punto costeño de Punta Cardón, atalaya de pescadores.
+- **Tacal**: aldea del municipio Los Taques.
+- **Tacaduto**: aldea del municipio Moruy. Censo 1881: 4 casas, 17 vecinos.
+- **Taque**: I - Los Taques, población capital del municipio. II - Santa Cruz de Los Taques (antes Punta de Los Taques, hoy Villa Marina). III - El Taque, hato pecuario al Norte de Tacuato, municipio Baraived.
+
+### CENSO 1881
+- Tacaduto: 4 casas, 17 vecinos.
+
+---
+
+## p. 62
+
+### TOPÓNIMOS
+- **Tacuato**: población del municipio Santa Ana. Censo 1881: 37 casas, 237 vecinos. "Es un pueblo muy antiguo; en 1773 ya tenía iglesia, según el Obispo Martí; en ese entonces San Antonio de Padua era el santo patrono, hoy es San José el obrero. *Tocato* escribe Martí."
+- **Tausabana**: cerro al Este del Cerro de Santa Ana, ~8 km; hay vecindario homónimo.
+- **Tequeguacare**: aldea del municipio Moruy. "*Tequeguacure* es como está escrito en la Ley de División Territorial, tal vez por equivocación de la persona que copió el texto. Nada tenemos que informar sobre el significado de esta voz compuesta."
+
+### MORFEMAS Y GLOSAS
+- **Tausabana**: "*Tausabana* era primitivamente *Tautabana*, que quiere decir: el cerro de las palomas 'tautas', pero la voz evolucionó hacia Tausabana, por razones de eufonía, para suprimir la aliteración." — **RASGO GRAMATICAL: cambio fonético por eufonía / disimilación de aliteración**
+- **Tauta**: "pequeña paloma de hábitos ictiófagos..."
+
+### FUENTES CITADAS
+- **Obispo Mariano Martí**: "en 1773 ya tenía iglesia, según el Obispo Martí" — cita indirecta (no textual) referida a la visita pastoral de 1773; grafía "Tocato" atribuida a Martí.
+
+### CENSO 1881
+- Tacuato: 37 casas, 237 vecinos.
+
+### FOLKLORE / ETIMOLOGÍA POPULAR
+- Anécdota del diálogo "—¿A cómo está la sal? —Ta a cuatro" como origen popular alternativo del nombre Tacuato (Esteves dice estar "en desacuerdo con la información recibida sobre el origen del nombre").
+
+---
+
+## p. 63
+
+### TOPÓNIMOS
+- **Ticuí**: lugar pecuario en el caserío Maquigua, municipio Baraived.
+- **Tiguadare**: punto costeño en la ribera norteña del Golfete de Coro, al Este de Punta Cardón.
+- **Tijuro**: sabanas en el municipio Adícora. Se menciona que ahí existió un fundo pecuario de John Hill, legionario británico, héroe de Carabobo, avecindado en Urupaguaduco en 1826, introductor del arado.
+- **Tiraya**: ensenada pesquera al Norte de Adícora y al Este de Santa Rita.
+- **Tiquiba**: sabanas al Norte de Pueblo Nuevo; escenario de combates en la guerra de los Azules (general Pedro María Rodríguez, revolución contra Juan Crisóstomo Falcón en 1868).
+
+### MORFEMAS Y GLOSAS
+- **Ticuí**: "*Tigüí* y no *Ticuí* es el nombre de una palomita que se alimenta de peces."
+- **Tiguadare**: "*Tigua* es un árbol rutáceo."
+- **Tijuro**: "Se nos ha informado que *Tijuro* viene de Tijúa, paloma de canto onomatopéyico."
+- **Tiraya**: "*Taria* y *Taría* es la grafía que aparece en los papeles de las tierras de Urupaguaduco."
+- **Tiquiba**: "*Quiba*: es piedra." (morfema `quiba` ya rastreado, reiterado)
+
+### FUENTES CITADAS
+- "Papeles de las tierras de Urupaguaduco" (documento colonial, grafías Taria/Taría).
+- Copla folclórica citada textualmente: "En el camino de Caracas / mataron una tijúa / y del buche le sacaron / una vieja paperúa." (folclore, no dato lingüístico caquetío directo, pero relacionado a Tijúa/Tijuro)
+
+---
+
+## p. 64
+
+### TOPÓNIMOS
+- **Tobagía**: lugar de Jadacaquiva, junto con Guaidabacoa y Chibuche, puntos de referencia en linderos occidentales del municipio Pueblo Nuevo.
+- **Todariquiba**: "Legendaria ciudad caquetía que se supone fuera asiento del gobierno del Cacique Manaure." Juan de Castellanos la menciona junto con Miraca y Hurraque como pueblos de "grandísimo momento"; de esos tres solo existe hoy Miraca. Ubicación incierta: "Algunos opinan que pudo estar asentada cerca de Tacuato y otros piensan que en los Médanos de Coro."
+- **Tubarao**: lugar cerca de Santa Ana, lado occidental.
+- **Tumarusa**: aldea del municipio Moruy. Censo 1881: 6 casas, 39 vecinos.
+- **Tumatey**: ensenada pesquera en la costa oriental, cerca del Cabo de San Román.
+
+### MORFEMAS Y GLOSAS
+- **Todariquiba**: "El topónimo da muy poca luz sobre la incertidumbre, ya que *Tubariquiba* y no *Todariquiba*, quiere decir: pedregal, y en los sitios prenombrados no hay terrenos pedregosos, sino arenosos. *Tuba*: aglomeración. *Quiba*: pedruzco." (morfema **quiba** de nuevo)
+- **Tubarao**: "significa arenales. *Tuba*: montón. *Rao*: arena (r sencilla)."
+- **Tumarusa**: "Se nos ha informado que *Tumarure* era el apellido de un cacique."
+
+### FUENTES CITADAS
+- **Juan de Castellanos**: cita indirecta — "Juan de Castellanos menciona como pueblos de 'grandísimo momento' a Miraca, Hurraque y Todariquiba" (frase entrecomillada "grandísimo momento" es cita textual de Castellanos).
+- **P. M. Arcaya** (historiador): "quien manejó documentos de primera mano, siempre escribió Tumarure, pero el pueblo ya se ha acostumbrado con Tumarusa."
+
+### CENSO 1881
+- Tumarusa: 6 casas, 39 vecinos.
+
+### FIGURAS/LUGARES HISTÓRICOS CAQUETÍOS
+- Cacique Manaure vinculado a la legendaria ciudad de Todariquiba como asiento de su gobierno.
+
+---
+
+## p. 65
+
+**PÁGINA FALTANTE en los escaneos.** El texto de p.66 comienza a mitad de una entrada ("La voz es taína y quizás fue traída por holandeses antillanos...") cuyo encabezado y comienzo no están disponibles en este lote. Se atribuye a lengua **taína** (no caquetía) — dato de "ATRIBUCIONES DE LENGUA" cuya entrada completa no pudo extraerse.
+
+---
+
+## p. 66
+
+### ATRIBUCIONES DE LENGUA
+- (Continuación de entrada sin encabezado, ver nota p.65): "La voz es taína y quizás fue traída por holandeses antillanos. Desde tiempos inmemoriales, pescadores arubianos se avecindaron en el lugar, atraídos por los quelónidos que abundan en esas aguas." — **atribución explícita a lengua taína, no caquetía.**
+
+### TOPÓNIMOS
+- **Tura**: extensas salinas al Sur de la población de Baraived. "Hato de Jura es como está escrito el fundo que fue censado en 1881."
+- **Tutubacoa**: lugar pecuario en el territorio del municipio Adícora; otro lugar homónimo en Jadacaquiva.
+- **Urupagua**: fundo pecuario cercano a la población de El Vínculo.
+- **Urupaguaduco**: antiguo fundo pecuario, principal de la posesión, donde hoy está la población de El Hato, municipio Adícora. En 1881 era capital del municipio González, con 157 casas y 1.123 vecinos.
+
+### MORFEMAS Y GLOSAS
+- **Tura**: "*Jura, juri*: ventarrón."
+- **Tutubacoa**: dos versiones — (1) "significa: el lugar de los tuturutos. *Tuturutos*: hierba cuya savia tiene propiedades eméticas y se usa para cuajar queso." (2) "que el nombre fue modificado, antiguamente era *Datobacoa*: lugar de los datos."
+- **Urupagua**: "es un arbusto espinoso, hojas y fruto de sabor amargo, pero es buen pasto de cabras." Advertencia: "la urupagua de Paraguaná es una planta de la familia de la retama (castella depresa); y la urupagua de la Sierra de Coro es un árbol gigante, nucífero, cuya nuez se come cocida."
+- **Urupaguaduco**: "significa la quebrada de las urupaguas." (**-uco** de nuevo como "quebrada")
+
+### CENSO 1881
+- Urupaguaduco (capital del municipio González): 157 casas, 1.123 vecinos.
+- Hato de Jura: censado en 1881 (sin cifras dadas).
+
+---
+
+## p. 67
+
+### TOPÓNIMOS
+- **Yacure**: nombre de un conuco en las sabanas de Güima, municipio Adícora. II - Yacural: vecindario de la aldea de Cocodite.
+- **Yaguarima**: punto costeño en el golfete de Coro, al Este de Punta Cardón.
+- **Yaima**: sitio pesquero al Norte de Adícora, cerca de Santa Rita; bahía de aguas profundas que en tiempos coloniales sirvió de puerto para la sal de Las Cumaraguas.
+- **Yarí**: sitio en la sabana de Barabara, municipio Adícora; también hay un lugar homónimo en Santa Ana. "*Yaride* era el nombre primitivo."
+- **Yauquiba**: población del municipio Moruy. Censo 1881: 26 casas, 199 vecinos.
+
+### MORFEMAS Y GLOSAS
+- **Yacure**: "árbol leguminoso de hojas perennes, es una acacia."
+- **Yauquiba**: "*Yabu-quiba*: la piedra del yabo, árbol resinoso." (morfema **quiba** de nuevo)
+
+### CENSO 1881
+- Yauquiba: 26 casas, 199 vecinos.
+
+---
+
+## p. 68
+
+Página del apéndice "TOPÓNIMOS COMPILADOS" — lista numerada (1-93) de todos los topónimos tratados en el libro, de Abudure a Güica. No contiene glosas ni etimologías nuevas, es un índice. Se transcribe para referencia de nombres del libro: Abudure, Acaboa, Adaro, Adaure, Adícora, Aguaque, Amaraya, Amuay, Antuní, Arajó, Asaro, Asubure, Avotuca, Babahuro, Bajabaroa, Bajarigua, Barabara, Baracara, Baraived, Barbasco, Bariquí, Barisigua, Barunú, Bibidure, Bibuche, Biniche, Bucuruy, Buchaquiba, Buchuaco, Buenevara, Buenibativa, Caibacoa, Camare, Camoruco, Camunare, Capacheruda, Capuhana, Caradacagua, Carajaima, Cararapa, Cariguariana, Carirubana, Caruca, Caseto, Caujarito, Cayeruba, Cayude, Cimiro, Coabana, Cocodite, Coduto, Cuara, Cubiano, Cucurubano, Cucuy, Cude, Cujicana, Cumaraguas, Cumujacoa, Cunacho, Curaidebo, Cuzubitos, Chamuriana, Charaima, Chaure, Chichibana, Chiguaral, Chirache, Chuchube, Chujaro, Chunaure, Dabadubare, Dibaragua, Duraguaco, Elegüey, Garrapata, Gisebo, Guacuira, Guacujúa, Guacurebo, Guachaco, Guachunepe, Guaidabacoa, Guanadito, Guarama, Guaranao, Guarataro, Guaricure, Guaruguaja, Guasare, Guatacare, Guayacanal, Güica.
+
+---
+
+## p. 69
+
+Continuación del índice "TOPÓNIMOS COMPILADOS" (94-187): Güima, Hayo, Hurraque, Imujo, Isiro, Isito, Iticuna, Jabe, Jacuque, Jagüe, Jadacaquiva, Jamaica, Jarayadito, Jariaca, Jayana, Juderecal, Judibana, Jurijurebo, Juroguagua, Laguarí, Macama, Machuruca, Maicara, Maitiruma, Manadí, Manare, Manichare, Maquigua, Maracapana, Matacán, Matividiro, Matuto, Michaco, Miraca, Misaray, Moruy, Muaco, Niraba, Nonocoti, Oboque, Oripopo, Paguara, Paraguaná, Perabay, Peticuare, Pipiacoa, Pipiribana, Pitajaya, Pury, Quibarute, Quitaire, Quipital, Quipayú, Quiyegua, Sabarigua, Sacuragua, Saguatumo, Sanajaquí, Sanquinche, Sarabón, Sarinao, Saruro, Sicaname, Sibidigual, [ilegible: ...Sisibaúco], Siraba, Supí, Supideo, Suriquiva, Tacal, Tacaduto, Taque, Tacuato, Tausabana, Tequeguacare, Ticuí, Tiguadare, Tijuro, Tiraya, Tiquiba, Tobagía, Todariquiba, Tubarao, Tumarusa, Tumatey, Tura, Tutubacoa, Urupagua, Urupaguaduco, Yacure, Yaguarima, Yaima, Yarí, Yauquiba.
+
+(Nota: esta lista confirma que "Tucuato" no aparece como entrada separada de "Tacuato"; y que el nombre faltante de la entrada de p.65/66 no se puede identificar con certeza solo por posición alfabética — cae entre Tumatey/Tura y Tutubacoa según el orden del libro, es decir el topónimo perdido empieza probablemente con "Tu-".)
+
+---
+
+## p. 70
+
+Sección **FUENTES PRINCIPALES** — informantes orales del autor. No son datos lingüísticos caquetíos en sí, pero documentan de dónde proceden las glosas y topónimos:
+
+- **Don Pedro Tinoco**, nativo de El Hato, municipio Adícora (1854-19?0), bachillerato en San Felipe, Yaracuy. "Nos dio información sobre Curaidebo, Jurijurebo, Imujo, Tutubacoa, Guaruguaja y otros lugares del Norte de la Península."
+- **Don Benito Ruiz**, nativo de Yauquiba, municipio Moruy (1900-1953), campesino analfabeto. "Nos dio noticias de los nombres de Yauquiba, Nonocoti, Quibarute; también nos habló de la elaboración del 'jabón de la tierra', la resina de caricarito, de los guarises de torcer algodón: datos éstos que procesamos en nuestra obra: 'Apuntes Lexicológicos'." — **NOTA: menciona otra obra del autor, "Apuntes Lexicológicos"**, posible fuente adicional a rastrear.
+- **Don Amoroso Weffer**, nativo de Pueblo Nuevo (1862-1948), bachiller en Filosofía y Letras. Datos sobre próceres del prócerato paraguanero (Josefa Camejo, Juan Garcés, León Colina, Heriberto García de Quevedo) — no lingüístico.
+- **Don Hispéridas Ocando**, nativo de Guanadito, municipio Los Taques (1860-1942). "Nos informó sobre Cumujacoa, Jayana, Amuay, Guanadito y otros lugares del occidente peninsular."
+- **Don Alberto Reyes**, nativo de El Hato, municipio Adícora (1895), analfabeto, "excelente conversador, dotado de una prodigiosa memoria" — relatos históricos, no lingüístico específico.
+
+---
+
+## p. 71
+
+Continuación de **FUENTES PRINCIPALES**:
+- **Don Napoleón Riera Rodríguez**, nativo de El Hato, municipio Adícora (1898). Alumno de la escuela de Don Pancho Martínez Bagú. "Nos ha suministrado datos... de los pueblos circunvecinos de El Hato."
+- **Don Jesús Manaure Pulgar**, nativo de Misaray, municipio Santa Ana (1935), pintor-poeta. "Nos dio datos sobre los pueblos de Santa Ana."
+- **Dr. Luis A. Barreno**, nativo de El Vínculo, municipio Pueblo Nuevo (1939), abogado y poeta. "En cuatro cuartillas mecanografiadas, nos suministró información sobre la mayoría de los pueblos de Jadacaquiva."
+- **Don Miguel Manaure**, nativo de El Vínculo, municipio Pueblo Nuevo (1942), analfabeto, hombre de campo. "Suministró un detallado inventario de la fauna y la flora en la Península."
+
+Inicio de **FUENTES BIBLIOGRAFICAS**:
+- **Acosta Saignes, Miguel**: *Estudios de Etnología Antigua de Venezuela.*
+- **Alvarado, Lisandro**: *Datos Etnográficos de Venezuela.* / *Glosario de Voces Indígenas.*
+
+---
+
+## p. 72
+
+Continuación y final de **FUENTES BIBLIOGRAFICAS**:
+- **Arcaya, Pedro Manuel**: *La Independencia de Paraguaná.* / *Población de Origen Europeo de Coro.*
+- **Coddazzi, Agustín**: *Resumen de Geografía de Venezuela.*
+- **Armas Chitty, J. A.**: *Historia de Paraguaná y Punto Fijo.*
+- **Cisneros, José Luis**: *Descripción de la Provincia de Benezuela [Venezuela].*
+- **Hill Peña, Aníbal**: *Noticias Históricas de Paraguaná.*
+- **Martí Estadella, Mariano**: *Relación de la Visita Pastoral* (4 tomos).
+
+(Última página del libro; no hay más contenido.)
+
+---
+
+## Resumen del archivo 3
+
+### Morfemas nuevos o reforzados (de los ya rastreados por el proyecto)
+- **quiba / -quiba**: reaparece reiteradamente = "piedra" / "pedruzco" — Quibarute ("quebrada de las piedras"), Tiquiba ("Quiba: es piedra"), Todariquiba ("Quiba: pedruzco"), Yauquiba ("Yabu-quiba: la piedra del yabo").
+- **-uco / -uto**: reaparece — Quibarute ("Uto o uco, quebrada"), Tacaduto ("Uto: cauce"), Urupaguaduco ("la quebrada de las urupaguas"), Sisibaúco (paraje/quebrada).
+- **cari / bacoa / bana / ebo / ure / naure / aco / juri / dabuda / guara**: no aparecen como morfemas glosados explícitamente en este lote de páginas (56-72), salvo posibles coincidencias superficiales de grafía (p.ej. "Jura, juri: ventarrón" en Tura — nótese: esto es "juri" pero glosado como "ventarrón", no como el morfema "juri/judi" que el proyecto rastrea con otro sentido; señalar la homografía pero no asumir identidad semántica).
+
+### Morfemas/glosas nuevos identificados en este tramo (no estaban en la lista de rastreo pero podrían ser relevantes)
+- **tuba**: "aglomeración" (Todariquiba) / "montón" (Tubarao) — aparece dos veces con sentido consistente de "montón/aglomeración".
+- **rao**: "arena (r sencilla)" (Tubarao).
+- **quire**: "color" (Sanajaquí).
+- **tigua**: árbol rutáceo (Tiguadare).
+- **taria/taría**: grafía de Tiraya en papeles coloniales.
+- **para**: "agua" (Paraguaná) — reafirmación de una etimología muy citada.
+
+### Fuentes citadas en este tramo
+- Documento de 1596 (sabanas de Pipiacoa)
+- Obispo Mariano Martí, *Relación de la Visita Pastoral* (1773; 4 tomos) — grafía "Tocato" para Tacuato
+- Juan de Castellanos — cita textual "grandísimo momento" (Miraca, Hurraque, Todariquiba)
+- P. M. Arcaya (historiador) — grafía "Tumarure" con documentos de primera mano
+- Ley de División Territorial — grafía "Tequeguacure"
+- Papeles de las tierras de Urupaguaduco — grafías "Taria"/"Taría"
+- Censo de 1881 (repetido en varias entradas)
+- Fuentes bibliográficas listadas al final del libro: Acosta Saignes (Estudios de Etnología Antigua de Venezuela), Lisandro Alvarado (Datos Etnográficos de Venezuela; Glosario de Voces Indígenas), Pedro Manuel Arcaya (La Independencia de Paraguaná; Población de Origen Europeo de Coro), Agustín Coddazzi (Resumen de Geografía de Venezuela), J. A. Armas Chitty (Historia de Paraguaná y Punto Fijo), José Luis Cisneros (Descripción de la Provincia de Benezuela), Aníbal Hill Peña (Noticias Históricas de Paraguaná), Mariano Martí Estadella (Relación de la Visita Pastoral, 4 tomos).
+- Informantes orales (pp. 70-71): Pedro Tinoco, Benito Ruiz, Amoroso Weffer, Hispéridas Ocando, Alberto Reyes, Napoleón Riera Rodríguez, Jesús Manaure Pulgar, Luis A. Barreno, Miguel Manaure. **Dato notable: Benito Ruiz menciona otra obra del propio Esteves, "Apuntes Lexicológicos", como destino de datos sobre jabón de la tierra, resina de caricarito y guarises de torcer algodón — posible fuente adicional a ubicar/minar.**
+
+### Sitios arqueológicos / evidencia material
+- **Cerro de Siraba**: petroglifos llamados "Las Piedras del Almanaque" (p.60).
+
+### Atribuciones de lengua (no caquetía)
+- Entrada incompleta (falta encabezado, página 65 ausente) atribuida a lengua **taína**: "La voz es taína y quizás fue traída por holandeses antillanos..." vinculada a pescadores arubianos y quelónidos (p.66). El topónimo exacto no se pudo determinar; por posición alfabética en el índice de "Topónimos compilados" (p.69) cae entre Tumatey/Tura y Tutubacoa, sugiriendo un nombre que empieza con "Tu-" no listado (posiblemente TUCACAS o similar, ausente del índice compilado, lo cual es en sí mismo llamativo).
+- Referencia lateral: "puripuri" en **lengua cumanagota** (no caquetía), plural por reduplicación, glosado como "jején" (p.57, continuación de página anterior).
+
+### Rasgos gramaticales notados
+- **Plural por duplicación/reduplicación**: "puripuri" en cumanagoto (p.57).
+- **Cambio eufónico / disimilación de aliteración**: Tautabana > Tausabana, "por razones de eufonía, para suprimir la aliteración" (p.62).
+- **Voces híbridas español-caquetío**: Quiyegua ("Piedra y Yegua", p.57); Suriquiba ("la Piedra del Sur", p.61).
+
+### Páginas sin contenido textual (fotos)
+- p.59: foto "Cerro Siraba" (sin leyenda adicional).
+- p.65 (probable, no confirmado con número visible): foto "Cerro Santa Ana".
+
+### Gap identificado
+- **Falta la página 65** del libro en este lote de escaneos — hay una entrada truncada al inicio de p.66 cuyo encabezado y comienzo no se pudieron recuperar.

--- a/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote4.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote4.md
@@ -1,0 +1,498 @@
+# Hallazgos — Esteves (1989), archivo 4 (p001-p027.jpg = pp. 73-100 del libro)
+
+Nota de estructura: este tramo del libro cubre el final del **Apéndice** ("Sobre el nombre de Adícora" y "Jurijurebo", pp. 73-80) y el arranque de la sección **"Otros topónimos indígenas del Estado Falcón"** (diccionario alfabético, pp. 81-100, letra A completa y letra B-C hasta "Cayude"). El escaneo intercala fotos de página completa sin número impreso (aprox. pp. 75, 81, 89, 97); se anotan como "(foto)" con su ubicación relativa.
+
+---
+
+## p. 73 (p001.jpg)
+
+**Sección: Apéndice — "Sobre el nombre de Adícora"**
+
+### Morfemas y glosas
+- *"Adícora quiere decir: jajatal, sitio donde hay abundancia de jajato, hierba halófila de terrenos salobres."*
+- *"Es una voz indígena cuya forma primitiva era 'jadícuar' y que por uno de esos curiosos procesos de selección eufónica, ha venido pasando por 'jatícora', por 'jadícora', por 'aríkula', hasta llegar al sugestivo por poético Adícora de hoy"*
+
+### Fuentes que cita
+- Juan de Castellanos (Cronista de Indias), citado por "el verbo retozón" sobre Coro = "viento en lengua generosa" (no es cita textual de Castellanos, es referencia).
+
+---
+
+## p. 74 (p002.jpg)
+
+### Morfemas y glosas
+- *"si examinamos el primitivo 'jadícuar' y lo descomponemos en 'jade', de jajato, y la desinencia 'cuar', que identifica a los sustantivos colectivos en lengua cumanagota. 'Cuar', en cumanagota, significa: aglomeración, abundancia, según el misionero Caulín."*
+- *"Este 'cuar', cumanagota, tiene el mismo significado del 'tuba' de los caquetíos."* — **morfema caquetío "tuba" = aglomeración/abundancia** (comparado con "cuar" cumanagota).
+
+### Fuentes que cita
+- Fray Antonio Caulín, autor de *"Historia Corográfica, Natural y Evangélica de la Nueva Andalucía"* (1799), fuente que también usó Lisandro Alvarado para su *"Glosario de Voces Indígenas"*.
+- Título de Composición de Tierras otorgado por el Juez sub-delegado Juan Damián Pérez de Medina, año 1719: aparece "Jadícora" como punto de referencia en los linderos de la posesión de Urupaguaduco.
+- Carta náutica del siglo XVII y mapa de Paraguaná en un trabajo del Dr. Pedro Manuel Arcaya (publicado 1947, referido al año 1718 — compra de terrenos de El Cardón por un tal Oyarvide).
+- Agustín Codazzi, *Geografía*: incluye a Adícora entre los Resguardos Marítimos Habilitados en 1832.
+- José Gil Fortoul, menciona Adícora al analizar la economía colonial tardía (con reserva: pudo haber actualizado el nombre).
+
+### Atribuciones de lengua
+- *"'Aríkula', que a nuestro juicio es una grafía anglicada"* (no indígena, sino deformación por influencia inglesa de la escritura).
+
+---
+
+## (foto, sin número impreso, ~p.75) (p003.jpg)
+
+Fotografía de un ave (tipo perdiz/codorniz moteada), sin leyenda visible ni texto.
+
+---
+
+## p. 76 (p004.jpg)
+
+### Fuentes que cita
+- Dr. Aníbal Hill Peña, consigna noticias de Adícora en pasajes de la Guerra de Independencia.
+- Referencia a la Compañía Guipuzcoana (operó 1740-1780), levantó edificios en Adícora.
+- *"Apuntes sobre la Geografía Médica del Estado Falcón"*, obra documental del Dr. Víctor Raúl Soto: registra epidemia de viruela negra hemorrágica que invadió por el puerto de Adícora el 14 de julio de 1848, traída por marinos de Sant Thomas (antilla inglesa).
+- Tradición oral: cólera morbus llegó a Paraguaná en 1854 por una balandra desde La Guaira.
+
+---
+
+## p. 77 (p005.jpg)
+
+### Fuentes que cita
+- *"Recuerdos"*, libro de memorias de Leontine Perignon de Roncajolo (esposos franceses Roncajolo-Perignon), editado por la Universidad del Zulia en 1962; describe su estadía en Adícora 1875-1880 y "La Tormenta" (ciclón del 23 de septiembre de 1877).
+- José Rafael Pocaterra, escala del buque de guerra en Adícora en 1919 (prisionero rumbo al Castillo de San Carlos).
+
+---
+
+## p. 78 (p006.jpg)
+
+### Fuentes que cita
+- Enrique Bernardo Núñez, novelas con "marineros adicoreños".
+- Ángel S. Domínguez, maestro de primeras letras en Adícora en 1917, autor del poema "Nébulas".
+
+**Sección: "JURIJUREBO"**
+
+### Morfemas y glosas
+(ninguna glosa etimológica de "Jurijurebo" en esta página; es nombre propio de cacique/población)
+
+### Fuentes que cita
+- Juan de Castellanos, *"Elegías de Varones Ilustres de Indias"*: habla del "Gran Señor de Jurijurebo"; Esteves infiere que Castellanos estuvo en Paraguaná hacia 1540, sin documento que lo confirme.
+- Menciona conjetura de "algunos historiadores": el Cacique Jurijurebo y su esposa **Judibana** habrían sido los "indianos" llevados por Alonso de Ojeda a las Cortes españolas en 1500, regresando con los nombres cristianos de Fernando García y Juana de García. (Esteves se abstiene de comentar: *"la historia es historia y no invención..."*)
+
+### Evidencia arqueológica
+- *"la población de Jurijurebo junto con Todariquiba eran los asientos poblacionales de más importancia en la nación caquetía, como ha quedado demostrado últimamente con el descubrimiento de grandes cementerios en las inmediaciones de los sitios donde estuvieron ubicadas sus poblaciones."*
+- Todariquiba: *"asiento del gobierno de... Manaure"*, junto a la desembocadura del río Coro / golfete.
+
+---
+
+## p. 79 (p007.jpg)
+
+### Evidencia arqueológica / rasgos culturales
+- Industria indígena de procesamiento de pescado en Jurijurebo: *"Estos primitivos habitantes empleaban un método para acondicionar la pulpa de pescado y la envasaban en vasijas fabricadas con los frutos del camuro, el totumo y de otras cucubirtáceas... proceso de someter a desmenuzamiento el pescado salado, tostado al sol."*
+- Intercambio: *"traían los cuicas y timotes por la sal y el pescado de nuestros caquetíos."*
+- *"Los montículos de conchas y otros residuos óseos que se ven diseminados en este lugar, dan una idea de la magnitud de esta actividad."*
+
+---
+
+## p. 80 (p008.jpg)
+
+### Evidencia arqueológica
+- *"De su cementerio [de Jurijurebo] sí hay muchos vestigios que es indispensable cuidar para que no desaparezcan."*
+- *"Esos fósiles y fragmentos de cerámica que la erosión de la lluvia hace aflorar en estos terrenos aluvionales... tienen hoy un gran valor arqueológico, porque con la aplicación de pruebas con carbono radioactivo se pueden establecer exactas valoraciones cronológicas."*
+
+Fin del Apéndice.
+
+---
+
+## (título de sección, sin número, ~p.81) (p009.jpg)
+
+"OTROS TOPÓNIMOS INDÍGENAS DEL ESTADO FALCÓN" — página de título, sin texto adicional.
+
+---
+
+## p. 83 (p010.jpg)
+
+**Inicio del diccionario alfabético (letra A)**
+
+### Topónimos y glosas
+- **ABATO** — cerro, municipio Capatárida. (sin glosa)
+- **ACACA** — quebrada, municipio Agualarga, Distrito Federación. *"Acaca es una forma adjetival de Aca, nombre de una planta bejucosa; es como si dijéramos: abejucada."*
+- **ACANES** — lugar, Distrito Petit; mencionado en el "Camino de Perera", obra vial de 1854 (Carora-Cumarebo).
+- **ACARITE** — aldea, municipio Curimagua, Distrito Petit. *"Aca: bejuco."*
+- **ACATUTO** — zona selvática, municipio Píritu, Distrito Zamora. *"Literalmente expresa: el bejuco de la quebrada, pero, conforme a la sintaxis de la lengua caquetía, la construcción es a la inversa: la quebrada de los bejucos. Aca: bejuco; uto: quebrada."*
+
+### Rasgos gramaticales
+- Nota sobre sintaxis: en ACATUTO, Esteves señala explícitamente que el orden compuesto caquetío es inverso al literal español (objeto+"quebrada" en vez de "quebrada de...").
+
+### Morfemas del proyecto detectados
+- **-uto**: *"uto: quebrada"* (en ACATUTO).
+
+---
+
+## p. 84 (p011.jpg)
+
+### Topónimos y glosas
+- **ACURIGUA** — población capital y río, Distrito Colina. *"Según Lisandro Alvarado, 'Glosario de Voces Indígenas', la voz viene de Acure, vocablo caribe que designa un pequeño roedor, llamado también Picure."*
+- **AGÜIDE** — puerto y pueblo, municipio La Pastora, Distrito Acosta. *"Es voz taína, caribe insular."*
+- **AGÜIMA** — punto costeño, municipio Píritu, Distrito Zamora. *"Voz taína."*
+- **AGÜIRARO** — lugar, municipio San Luis, Distrito Bolívar. (Primitivamente: Agüirare)
+- **AMONES** — aldea, municipio Borojó, Distrito Buchivacoa. *"Puede ser una aféresis de Mamones; mamón: árbol frutal."*
+- **APARITO** — lugar, municipio Casigua, Distrito Mauroa. *"Puede ser una aféresis de 'taparito' diminutivo de 'taparo', árbol de fruto voluminoso."*
+- **APURITE** — caserío, municipio La Pastora, Distrito Acosta. *"Aféresis de mapurite: mofeta almizclosa."*
+
+### Fuentes que cita
+- Lisandro Alvarado, *"Glosario de Voces Indígenas"* (para ACURIGUA).
+
+### Atribuciones de lengua
+- AGÜIDE: voz taína, caribe insular.
+- AGÜIMA: voz taína.
+- ACURIGUA: vocablo caribe (según Alvarado).
+
+### Rasgos gramaticales
+- Aféresis identificadas en AMONES, APARITO, APURITE.
+
+---
+
+## p. 85 (p012.jpg)
+
+### Topónimos y glosas
+- **ARABEBURE** — aldea, municipio Casigua, Distrito Mauroa. (nombre antiguo, en papeles de la Colonia)
+- **ARACAGUARE** — aldea, municipio Borojó, Distrito Buchivacoa. (sin glosa)
+- **ARACUA** — población capital, Distrito Bolívar. (antes "Marzal", en homenaje al Dr. Antonio Marzal, hasta 1930 — topónimo no indígena en ese uso)
+- **ARAGUATA** — quebrada, municipio Libertador, Distrito Acosta. *"Araguata es una abeja peluda del color del mono araguato, pelo rojo oscuro. De ahí la homonimia."*
+- **ARAGÜÍ** — aldea, municipio San Francisco (Mirimire), Distrito Acosta. (sin glosa)
+- **ARAGÜITO** — caserío, municipio Unión, Distrito Federación. (grafía dudosa: "Aregüito" en la Ley de División Territorial vs. "Aragüito" como lo pronuncia el pueblo)
+- **ARAICA** — caserío, municipio Agualarga, Distrito Federación. (sin glosa)
+- **ARAJÓ** — Las Cañadas de Arajó, caserío, municipio Sabaneta, Distrito Miranda. (sin glosa)
+
+---
+
+## p. 86 (p013.jpg)
+
+### Topónimos y glosas
+- **ARAJÚ** — aldea, municipio Agualarga, Distrito Federación.
+- **ARANDIMA** — río, municipio Agualinda, Distrito Acosta, afluente del Tocuyo.
+- **ARAURIMA** — aldea/colonia agrícola-ganadera/río, municipio Jacura, Distrito Acosta.
+- **ARIAGUA** — caserío, municipio Capatárida, Distrito Buchivacoa.
+- **ARIBANACHE** — cueva, en un cerro homónimo, 8 km al sureste de Urumaco, Distrito Democracia.
+- **ARIPINO** — cerro, linderos Distritos Petit y Miranda. *"Aripino: árbol maderable."*
+- **AROA** — río (nace en Yaracuy), población capital Distrito Silva, y aldea Cruz de Aroa (municipio Jacura, Acosta).
+- **AUTAQUIRE** — extinta comunidad indígena, 30 km al sur de Pedregal. *"Quire, en ayamán, es color."*
+
+### Evidencia arqueológica
+- ARIBANACHE: cueva en un cerro (mencionada como sitio, sin más detalle arqueológico en esta página).
+
+### Atribuciones de lengua
+- AUTAQUIRE: *"Quire, en ayamán, es color"* — atribuido explícitamente a la lengua **ayamán**, no caquetío.
+
+---
+
+## p. 87 (p014.jpg)
+
+### Topónimos y glosas
+- **AVARIA** — municipio, capital Tupure, Distrito Democracia. *"Avaria, del tamanaco awaree, rabipelado, animal didelfo."*
+- **BACHACAL** — aldea, municipio Jacura, Distrito Acosta. *"Bachacal: colectivo de bachaco; voz tamanaca: chiauco, hormiga grande, rojiza."*
+- **BAITOITA** — caserío, municipio Pedregal, Distrito Democracia. *"Baitoita, diminutivo de baitoa, árbol ulmáceo, sinónimo de membrillo."*
+- **BARABARA** — zona selvática, municipio Píritu, Distrito Zamora. Población desaparecida por paludismo. *"El obispo Mariano Martí visitó ese pueblo en 1773 y describió su iglesia, de la que aún hay vestigios."* *"Barabara, que es plural por duplicación, es voz con que se designa a un árbol caparidáceo, más conocido con el nombre de Olivo. Datos de Lisandro Alvarado: 'Glosario de Voces Indígenas'."*
+- **BARAGUA** — río y serranía, municipio Capatárida. *"Baragua: árbol de madera de construcción, cuaguaro."*
+- **BARICUA** — aldea, municipio Pedregal, Distrito Democracia. (Puede ser alteración de Barigua)
+
+### Fuentes que cita
+- Obispo Mariano Martí, visita pastoral de 1773 (Barabara).
+- Lisandro Alvarado, *"Glosario de Voces Indígenas"* (Barabara).
+
+### Evidencia arqueológica
+- BARABARA: *"describió su iglesia, de la que aún hay vestigios"* (ruinas coloniales, no precolombinas, pero registradas).
+
+### Rasgos gramaticales
+- **BARABARA**: *"que es plural por duplicación"* — **reduplicación** (morfema tracked por el proyecto: patrón gramatical relevante).
+
+### Morfemas del proyecto detectados
+- **bara**: aparece como raíz en BARABARA, BARAGUA, BARICUA (sin glosa aislada aquí; ver p.88 donde sí se glosa "bara: árbol").
+
+---
+
+## p. 88 (p015.jpg)
+
+### Topónimos y glosas
+- **BARIGUA** — I: aldea, municipio Guaibacoa, Distrito Colina / II: aldea, municipio La Vela, Distrito Colina. *"Barigua, con 'b' protética, es Arigua, insecto melífero."*
+- **BARIMISAL** — aldea/quebrada, municipio Píritu/La Soledad, Distrito Zamora. *"Barimisal, colectivo de Barimiso: árbol ramoso, de fruto comestible, guacharagüero."*
+- **BARIQUÍ** — aldea, municipio Puerto Cumarebo / El Bariquisal, quebrada, municipio Guaibacoa, Distrito Colina. *"Bariquí: árbol tintóreo; bara, árbol; quire: color."*
+- **BARIRO** — población capital del municipio Bariro, Distrito Buchivacoa. *"La desinencia 'iro' es diminutivo de voces indígenas."*
+- **BARISIGUA** — aldea, municipio Dabajuro, Distrito Buchivacoa. *"Barisigua es un árbol corpulento de madera liviana, significa palo blando."*
+- **BARUCHE** — aldea, municipio Capatárida, Distrito Buchivacoa. (sin glosa)
+- **BEREBORO** — aldea, municipio Independencia, Distrito Federación. *"Puede ser una alteración de Boroboro, arbusto apocináceo de flores muy pequeñas."*
+
+### Rasgos gramaticales
+- BARIGUA: *"con 'b' protética"* — **prótesis**.
+- BARIRO: *"la desinencia 'iro' es diminutivo de voces indígenas"* — sufijo diminutivo.
+
+### Morfemas del proyecto detectados
+- **bara**: *"bara, árbol"* (glosado explícitamente en BARIQUÍ) — **confirma morfema "bara" = árbol**.
+- Nuevo morfema notable: **"quire" = color** (glosado en BARIQUÍ, y antes atribuido al ayamán en AUTAQUIRE p.86) — no está en la lista de morfemas rastreados por el proyecto, pero aparece repetido y vale la pena señalarlo.
+
+---
+
+## (foto, sin número impreso, ~p.89) (p016.jpg)
+
+Fotografía: **"Petroglifo de Misaray."** — piedra grabada con motivos geométricos (rejilla de puntos/círculos). Evidencia arqueológica directa (petroglifo).
+
+---
+
+## p. 90 (p017.jpg)
+
+### Topónimos y glosas
+- **BIDARE** — aldea, municipio Borojó, Distrito Buchivacoa. *"¿Será budare?"* (conjetura del propio Esteves)
+- **BISURE** — La Cuesta de los Bisures, cerros, linderos municipios Bruzual/Zazárida. *"Bisure: lagarto común."*
+- **BOBARE** — barrio de Coro / cauce que desemboca en el golfete de Coro, Distrito Miranda. (sin glosa)
+- **BOBOY** — caserío, municipio Churuguara, Distrito Federación. *"Parece voz onomatopéyica. Sin embargo, puede ser apócope de Boboyo, que en Cuba es voz general para toda clase de lagartos."*
+- **BORABLE** — Borable Arriba y Abajo, caseríos, municipio Casigua, Distrito Mauroa. (sin glosa)
+- **BORAURE** — antigua posesión comunera, antiguo Cantón Casicure. (sin glosa; nótese sufijo -ure)
+- **BOROBUNO** — caserío, municipio Zazárida, Distrito Buchivacoa. (sin glosa)
+- **BOROJÓ** — población capital del municipio Borojó, Distrito Buchivacoa, y río homónimo. *"Borojó es chibcha: un árbol frutal."*
+
+### Atribuciones de lengua
+- BOROJÓ: *"es chibcha"* — atribuido explícitamente a lengua **chibcha**, no caquetío.
+
+### Rasgos gramaticales / dudas del autor
+- BIDARE, BOBOY: Esteves formula hipótesis alternativas explícitas con signos de interrogación ("¿Será...?").
+
+---
+
+## p. 91 (p018.jpg)
+
+### Topónimos y glosas
+- **BOSUGO** — El Bosugo (dos lugares distintos), municipios Borojó y Unión. *"Busuga, bosúa, bosuga: árbol rutáceo, tintóreo."*
+- **BOTOMANÓN** — caserío, municipio Independencia, Distrito Federación. (sin glosa)
+- **BOTOROA** — aldea, municipio Santa Ana, Distrito Miranda / quebrada que desagua en el Golfete de Coro. (sin glosa)
+- **BUCARAL** — Santa Cruz de Bucaral (población capital municipio Unión) / aldea municipio Cabure, Distrito Petit. *"Bucaral, colectivo de bucare, árbol frondoso, una eritrina."*
+- **BUCHAL** — El Buchal, aldea, municipio Dabajuro, Distrito Buchivacoa. *"Buchal, colectivo de buche: cardo globoso, melocacto."*
+- **BUCHIVACOA** — Distrito del Estado Falcón / aldea, municipio Capatárida; sitio histórico de la batalla que decidió la Guerra Federal el 2 de diciembre de 1862. *"El topónimo expresa: paraje poblado de buches."*
+- **BURGUERA** — Mesa de Burguera, caserío, municipio Mene de Mauroa, Distrito Mauroa. *"Burguera no es voz indígena, sino un apellido español, lo registramos para despejar el equívoco."*
+
+### Fuentes que cita
+- Referencia histórica: batalla de Buchivacoa, 2 de diciembre de 1862 (Guerra Federal).
+
+### Atribuciones de lengua
+- BURGUERA: explícitamente **no indígena** (apellido español).
+
+---
+
+## p. 92 (p019.jpg)
+
+### Topónimos y glosas
+- **BUTARE** — aldea, municipio La Vela / quebrada de Guaibacoa. *"Butare, ¿será budare?"*
+- **CABARAO** — caserío, municipio Sabaneta, Distrito Miranda. *"De la parte desinencial 'rao', sabemos que significa: aglomeración."*
+- **CABURE** — población capital del municipio Cabure y del Distrito Petit. *"Si Cabure es alteración de Cambure (síncopa), entonces es voz africana."*
+- **CABURITO** — aldea, municipio Bruzual, Distrito Democracia. (Diminutivo de Cabure)
+- **CACETAL** — aldea, municipio Mene de Mauroa, Distrito Mauroa. *"Cacetal, colectivo de Caceto, planta herbácea, una malvácea."*
+- **CACIMBA** — manantial, municipio Pueblo Cumarebo, Distrito Zamora. *"Cacimba: jagüey."*
+- **CACURO** — caserío, municipio Churuguara, Distrito Federación. *"Cacuro: pequeña avispa negra cuyo aguijonazo es muy doloroso y produce hinchazón."*
+- **CACHIMBO** — La Quebrada del Cachimbo, municipio Casigua, Distrito Mauroa. *"Cachimbo es un pequeño árbol de tallos cilíndricos y huecos que usan para fabricar 'cachimbos', objetos para fumar."*
+
+### Rasgos gramaticales
+- CABARAO: desinencia **"rao" = aglomeración**, morfema sufijal nuevo, no listado entre los rastreados por el proyecto pero potencialmente relevante (comparar con "-uco/-uto" y "cuar"/"tuba" de p.74).
+
+### Atribuciones de lengua
+- CABURE: posible voz **africana** (si es síncopa de Cambure).
+
+---
+
+## p. 93 (p020.jpg)
+
+### Topónimos y glosas
+- **CADILLARES** — aldea, municipio San Juan de los Cayos, Distrito Acosta. *"Cadillares, colectivo de Cadillo, hierba con espigas ganchosas."*
+- **CADUCE** — cerro al sur de Urumaco, Distrito Democracia. *"La última sílaba, silbante, como 'che'."*
+- **CAIDÍ** — río (lindero Zamora/Acosta) / aldeas en San Francisco (Mirimire) y Jacura. *"Creemos que la grafía 'Caidy' es inadecuada."*
+- **CAIMITO** — El Caimito, cerro cerca de Mapararí, Distrito Federación. *"Caimito: árbol sapotáceo, frutal."*
+- **CALEMBE** — aldea, municipio Urumaco, Distrito Democracia. *"Calembe es voz africana o africanizada; significa ropa raída."*
+- **CAMACHIMA** — pueblo, municipio Capadare, Distrito Acosta. *"Hemos notado que la desinencia 'ima', que significa humedad en caquetío, está presente en muchos topónimos de los distritos orientales del Estado."*
+- **CAMARE** — El Camare (varios lugares) / Camarito, aldea municipio Macoruca, Colina. *"Camare: árbol frutal, cocoloba."*
+
+### Morfemas y glosas — DESTACADO
+- *"la desinencia 'ima', que significa humedad **en caquetío**"* — glosa explícita en lengua caquetía, morfema nuevo no listado entre los rastreados por el proyecto (**"-ima" = humedad**).
+
+### Atribuciones de lengua
+- CALEMBE: voz africana o africanizada.
+- CAMACHIMA: "-ima" explícitamente marcado **"en caquetío"**.
+
+### Rasgos gramaticales
+- CADUCE: nota fonética sobre la sibilante final.
+
+---
+
+## p. 94 (p021.jpg)
+
+### Topónimos y glosas
+- **CAMAYATA** — paso en el río Tocuyo, municipio Agualinda, Distrito Acosta. *"Camayata, proviene de Camata, gallina silvestre; Camaya: también significa cesto, nasa. Ambas son voces cumanagotas."*
+- **CAMBUYÓN** — caserío, municipio Mapararí, Distrito Federación. *"Cambuyón es un americanismo de amplia difusión en Centro América y Colombia, con la significación de lío, enredo, etc. Aquí, en Venezuela, es cambalache, permuta, etc."*
+- **CAMPECHE** — dos aldeas (Tocuyo de la Costa / Libertador). *"Parece que Campeche es una alteración de campestre. Sin embargo, algunos me han informado que es el nombre de un árbol."*
+- **CAMURUJURE** — aldea, municipio Dabajuro, Distrito Buchivacoa. *"El topónimo, interpretado como una voz compuesta, significaría: raíz de camuro; 'ure': raíz, y camuro, planta cucubirtácea."*
+- **CAMURURÍA** — aldea, municipio Jacura, Distrito Acosta. *"En el sustantivo compuesto está presente la voz 'camuro' y de la partícula final desconocemos su significado."*
+- **CANAPO** — dos caseríos, municipio Borojó, Distrito Buchivacoa. (sin glosa)
+
+### Morfemas del proyecto detectados
+- **ure**: *"'ure': raíz"* — glosa explícita del morfema **-ure = raíz** (en CAMURUJURE).
+
+### Atribuciones de lengua
+- CAMAYATA: *"Ambas son voces cumanagotas"* (Camata, Camaya) — no caquetío.
+- CAMBUYÓN: "americanismo de amplia difusión" (no específicamente caquetío ni indígena venezolano).
+
+---
+
+## p. 95 (p022.jpg)
+
+### Topónimos y glosas
+- **CANIDE** — caserío, municipio Curimagua, Distrito Petit. (sin glosa, "no sabemos más nada")
+- **CANOA** — quebrada/lugar. *"Canoa, que es una tosca barca, es voz cumanagota ya incorporada a los diccionarios."*
+- **CAÑAFISTOLA** — lugar de referencia, municipio Avaria, Distrito Democracia. *"Un árbol cuya legumbre contiene una pulpa negra, dulce, comestible. Se dice que esta pulpa es medicinal, pero con la superstición de que hay que recogerla en Viernes Santo."* *"Cañaflota la nombran en Maracaibo. No parece voz indígena."*
+- **CAOBAL** — aldea, municipio Agualinda, Distrito Acosta. *"Caobal, colectivo de caoba, árbol meliáceo de madera preciosa."*
+- **CAPADARE** — población capital del municipio Capadare, Distrito Acosta; río que toma el nombre de Tucurere en su desembocadura. *"Capadare: diente de tigre, según Lisandro Alvarado. Es zona agrícola de renombre desde los tiempos coloniales; Capadare llegó a ser sinónimo de buen tabaco."*
+- **CAPANA** — Punta Capana, sitio costeño, Distrito Buchivacoa, en la desembocadura del Río Borojó. (sin glosa)
+
+### Fuentes que cita
+- Lisandro Alvarado (para CAPADARE: "diente de tigre").
+
+### Atribuciones de lengua
+- CANOA: voz cumanagota.
+- CAÑAFISTOLA: "No parece voz indígena."
+
+---
+
+## p. 96 (p023.jpg)
+
+### Topónimos y glosas
+- **CAPATÁRIDA** — población capital y río homónimo, Distrito Buchivacoa. *"Voz grave que el uso la ha hecho esdrújula. Capatarida escribió Juan de Castellanos."* Fue capital del Gran Estado Falcón-Zulia (1881-1890).
+- **CAQUETILLO** — caserío, municipio Guzmán Guillermo, Distrito Miranda. *"Caquetillo: árbol que da buena madera de construcción, resistente a la humedad."* *"Caquetillo, voz afín de caquetío, según Lisandro Alvarado."*
+- **CARABOBO** — caserío, municipio Agualarga, Distrito Federación. *"Carabobo: una palma que se conoce con distintos nombres: jipijapa, iraca, etc."*
+- **CARACARA** — aldea, municipio Boca de Aroa / lugar en Avaria. *"La voz es plural por duplicación: caracara: árbol maderable."*
+- **CARACOLÍ** — dos aldeas (Mene de Mauroa / Bruzual). *"Caracolí: árbol frutal, merey, caujil."*
+- **CARACUBANA** — caserío, municipio Borojó, Distrito Democracia. *"Caracubana: cerro poblado de caracara."*
+
+### Fuentes que cita
+- Juan de Castellanos (grafía "Capatarida").
+- Lisandro Alvarado, para CAQUETILLO: *"voz afín de caquetío"*.
+
+### Rasgos gramaticales
+- CARACARA: *"La voz es plural por duplicación"* — segunda instancia de **reduplicación** (cf. Barabara, p.87).
+
+---
+
+## (foto, sin número impreso, ~p.97) (p024.jpg)
+
+Fotografía: **"Artesanía miraquense."** — vasijas de cerámica alineadas contra una pared (cerámica tradicional, no necesariamente prehispánica, pero de tradición local de Mirimire).
+
+---
+
+## p. 98 (p025.jpg)
+
+### Topónimos y glosas
+- **CARAGUAO** — manantial u ojo de agua, municipio Pueblo Cumarebo, Distrito Zamora. (sin glosa)
+- **CARAMABURE** — aldea, municipio Capatárida, Distrito Buchivacoa. *"Caramabure: raíz de las caramas o raíz de la ramazón: carama es igual que ramazón."*
+- **CARAMÓN** — caserío, municipio Sucre, Distrito Bolívar. *"Parece un hipocorístico de Carlos Ramón."* (no indígena)
+- **CARAPA** — lugar / Cararapa, quebrada, municipio Unión. *"Cararapa, epéntesis de Carapa, y Carapa: árbol resinoso."*
+- **CARATIBANO** — aldea, municipio Píritu, Distrito Zamora. *"Caritibano, mejor que Caratibano, es un árbol de madera recia. Dicen también: Carativá."*
+- **CARAZAO** — población, municipio Sabaneta, Distrito Miranda. (sin glosa)
+- **CARÉPANO** — río, municipio Agualinda, Distrito Acosta. (sin glosa)
+- **CARIAGUA** — río, San Luis, Distrito Bolívar. (sin glosa)
+
+### Rasgos gramaticales
+- CARARAPA: *"epéntesis de Carapa"* — **epéntesis**.
+
+### Morfemas del proyecto detectados
+- **cari**: raíz presente en CARAMABURE, CARAPA, CARATIBANO, CARÉPANO, CARIAGUA — sin glosa aislada del morfema "cari" en esta página (aparece solo como parte de nombres).
+
+---
+
+## p. 99 (p026.jpg)
+
+### Topónimos y glosas
+- **CARICUCHE** — aldea, municipio Píritu, Distrito Zamora. (sin glosa)
+- **CARITUPE** — caserío/aldea, municipios Cabure y Casigua. (sin glosa)
+- **CARRAOS** — Los Carraos, aldea, municipio Dabajuro, Distrito Buchivacoa. *"Carrao: ave zancuda de pico desmesurado, más largo que la cabeza."*
+- **CARRIZAL** — tres lugares (Carrizalito, El Carrizal x2). *"Carrizal, colectivo de carrizo, planta gramínea, gamelote."*
+- **CASANARE** — lugar de referencia, linderos de Democracia y Buchivacoa con Lara. (sin glosa)
+- **CASICURE** — nombre del litoral falconiano, desde el golfete de Coro hasta el Caño Oribor (límite con Zulia). A finales de la Colonia, "Partido de Casicure" (capital Casigua); en la República, "Cantón Casicure" (capital Capatárida). *"Casicure: raíz de cacito; cacito: cacto de tallo aplanado que se extiende por el suelo."*
+
+### Morfemas del proyecto detectados
+- **ure**: segunda glosa explícita, *"Casicure: raíz de cacito"* — refuerza **-ure = raíz** (cf. Camurujure, p.94).
+- **cari**: en CARICUCHE, CARITUPE (sin glosa aislada).
+
+---
+
+## p. 100 (p027.jpg)
+
+### Topónimos y glosas
+- **CASIGUA** — población capital del municipio homónimo, Distrito Mauroa. *"Cacigua, con 'c' para diferenciarla de la voz geográfica, es una planta herbácea, enredadera, marantácea: maranta casupo."*
+- **CASIMONURE** — manantial u ojo de agua, municipio Pueblo Cumarebo, Distrito Zamora. (sin glosa aislada; nótese sufijo -ure)
+- **CAUCA** — aldea/río/riachuelo (varios lugares). (sin glosa)
+- **CAUDERAL** — El Caudheral [sic: Caudneral], caserío, municipio Borojó, Distrito Buchivacoa. *"Cauderal, colectivo de Caudero, árbol leguminoso de mediano porte, cují cabrero."*
+- **CAUJARO** — caserío, municipio Mitare, Distrito Miranda. *"Caujaro, árbol de madera blanda, ramos inermes, fruta muciliginosa. Del género Cordia."*
+- **CAUJARAO** — caserío, San Antonio, Distrito Miranda. *"Caujarao, significa: aglomeración de caujaros, caujaral."*
+- **CAYUDE** — tres lugares (La Pastora, Pueblo Cumarebo, Píritu). *"Cayude: árbol anonáceo, turagua."*
+
+### Morfemas del proyecto detectados
+- **ure**: tercera aparición en este archivo, en CASIMONURE (sin glosa aislada esta vez, pero refuerza el patrón del sufijo).
+
+---
+
+## Resumen del archivo 4
+
+### Morfemas nuevos o reforzados con glosa textual
+- **tuba** (caquetío) = aglomeración, abundancia — comparado explícitamente con "cuar" cumanagota. *"Este 'cuar', cumanagota, tiene el mismo significado del 'tuba' de los caquetíos."* (p.74)
+- **-uto** = quebrada — *"uto: quebrada"* (p.83, en ACATUTO)
+- **bara** = árbol — *"bara, árbol"* (p.88, en BARIQUÍ); raíz también en BARABARA, BARAGUA, BARICUA, BARIGUA, BARIMISAL, BARIRO, BARISIGUA, BARUCHE (p.87-88)
+- **-ure** = raíz — *"'ure': raíz"* (p.94, CAMURUJURE); *"Casicure: raíz de cacito"* (p.99); también en BORAURE (p.90) y CASIMONURE (p.100), sin glosa aislada en estos dos últimos casos.
+- **-ima** = humedad, marcado explícitamente "en caquetío" — *"la desinencia 'ima', que significa humedad en caquetío, está presente en muchos topónimos de los distritos orientales del Estado."* (p.93, CAMACHIMA)
+- **-rao** = aglomeración — *"de la parte desinencial 'rao', sabemos que significa: aglomeración"* (p.92, CABARAO)
+- **-iro** = diminutivo — *"la desinencia 'iro' es diminutivo de voces indígenas"* (p.88, BARIRO)
+- **quire** = color — glosado dos veces: atribuido a **ayamán** en AUTAQUIRE (p.86) y sin atribución de lengua explícita en BARIQUÍ (p.88, "quire: color"). Posible relación con "quiba" tracked por el proyecto, pero grafía y contexto distintos — señalar para verificación.
+- **cari**: raíz presente en múltiples topónimos (CARAMABURE, CARAPA, CARATIBANO, CARÉPANO, CARIAGUA, CARICUCHE, CARITUPE), pero **sin glosa aislada explícita** en este tramo del libro.
+- **Jurijurebo / Judibana**: nombre del cacique y su esposa (posible relación con el morfema "juri/judi" que rastrea el proyecto) — no se ofrece glosa etimológica, solo referencia histórica/legendaria (p.78).
+- **-uco/-uto**: confirmado "-uto" (ver arriba); no aparece "-uco" en este tramo.
+
+### Reduplicación (plural por duplicación) — confirmada dos veces
+- BARABARA (p.87): *"que es plural por duplicación"*
+- CARACARA (p.96): *"La voz es plural por duplicación"*
+
+### Otros rasgos gramaticales señalados por Esteves
+- Prótesis: BARIGUA, *"con 'b' protética"* (p.88)
+- Epéntesis: CARARAPA, *"epéntesis de Carapa"* (p.98)
+- Aféresis: AMONES, APARITO, APURITE (p.84)
+- Sintaxis inversa (objeto-núcleo) en compuestos: ACATUTO (p.83) — *"conforme a la sintaxis de la lengua caquetía, la construcción es a la inversa"*
+
+### Atribuciones de lengua NO caquetío
+- Aríkula: grafía anglicada (p.74)
+- AGÜIDE, AGÜIMA: voz taína, caribe insular (p.84)
+- ACURIGUA (de Acure): vocablo caribe, según Alvarado (p.84)
+- AUTAQUIRE (quire = color): lengua **ayamán** (p.86)
+- BOROJÓ: lengua **chibcha** (p.90)
+- BURGUERA: apellido español, no indígena (p.91)
+- CABURE (si es de Cambure): voz **africana** (p.92)
+- CALEMBE: voz **africana** o africanizada (p.93)
+- CANOA, CAMAYATA (Camata/Camaya): voces **cumanagotas** (p.94-95)
+- CAÑAFISTOLA: "No parece voz indígena" (p.95)
+- CARAMÓN: hipocorístico de nombre español "Carlos Ramón" (p.98)
+- Cumanagota "cuar" vs. caquetío "tuba" (p.74): comparación explícita entre dos lenguas indígenas distintas.
+
+### Fuentes citadas en este archivo
+- Juan de Castellanos, *"Elegías de Varones Ilustres de Indias"* (Jurijurebo, p.78; grafía "Capatarida", p.96)
+- Fray Antonio Caulín, *"Historia Corográfica, Natural y Evangélica de la Nueva Andalucía"* (1799) (p.74)
+- Lisandro Alvarado, *"Glosario de Voces Indígenas"* (p.74, p.84, p.87, p.95, p.96)
+- Obispo Mariano Martí, visita pastoral de 1773 (Barabara, p.87)
+- Título de Composición de Tierras, Juan Damián Pérez de Medina, 1719 (p.74)
+- Carta náutica del siglo XVII (p.74)
+- Dr. Pedro Manuel Arcaya, trabajo publicado en 1947, referido a 1718 (p.74)
+- Agustín Codazzi, *Geografía* (Resguardos Marítimos, 1832) (p.74)
+- José Gil Fortoul (p.74-76)
+- Dr. Aníbal Hill Peña (p.76)
+- Dr. Víctor Raúl Soto, *"Apuntes sobre la Geografía Médica del Estado Falcón"* (p.76)
+- Leontine Perignon de Roncajolo, *"Recuerdos"*, Universidad del Zulia, 1962 (p.77)
+- José Rafael Pocaterra (1919) (p.77)
+- Enrique Bernardo Núñez (novelas) (p.78)
+- Ángel S. Domínguez, poema "Nébulas" (1917) (p.78)
+- "Camino de Perera" (obra vial, 1854) (p.83)
+- Ley de División Territorial (p.85)
+
+### Sitios / evidencia arqueológica
+- **Jurijurebo** (junto con Todariquiba): grandes cementerios descubiertos en sus inmediaciones; industria de procesamiento de pescado (envases de camuro/totumo); montículos de conchas y residuos óseos; fósiles y fragmentos de cerámica aptos para datación por carbono radioactivo (p.78-80).
+- **Todariquiba**: asiento del gobierno del cacique Manaure, en la desembocadura del río Coro (p.79).
+- **Aribanache**: cueva en un cerro homónimo, 8 km al sureste de Urumaco, Distrito Democracia (p.86).
+- **Iglesia de Barabara**: vestigios de la iglesia descrita por el obispo Mariano Martí en 1773 (p.87).
+- **Petroglifo de Misaray**: fotografía de piedra grabada (foto entre p.88-90, sin número impreso) (evidencia arqueológica directa).
+- **Artesanía miraquense**: fotografía de vasijas de cerámica tradicional de Mirimire (foto entre p.96-98, sin número impreso) — tradición alfarera local, no necesariamente prehispánica.

--- a/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote5.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote5.md
@@ -1,0 +1,656 @@
+# Hallazgos — Esteves 1989, archivo 5 (p001-p029.jpg)
+
+Fuente: Juan de la Cruz Esteves, *Topónimos indígenas de Paraguaná y otros topónimos indígenas del estado Falcón* (1989). Diccionario alfabético de topónimos, letras C (final) a Q (parcial). Páginas impresas 101-129 (dos o tres son fotografías sin numeración visible, interpoladas entre 102-104, 114-116 y 128-129).
+
+---
+
+## p. 101 (p001.jpg)
+
+### TOPÓNIMOS
+- **La Ceiba**: I aldea de Purureche, Distrito Democracia; II caserío de Mene de Mauroa, Distrito Mauroa; III aldea del municipio Unión, Distrito Federación; IV manantial en Pueblo Cumarebo, Distrito Zamora. **La Ceibita**: aldea del municipio Cabure, Distrito Petit.
+- **El Cerey**: caserío del municipio San Francisco (Mirimire), Distrito Acosta.
+- **Cibira**: aldea del municipio San Félix, Distrito Mauroa.
+- **Cocorote**: I caserío y quebrada en el municipio Mitare, Distrito Miranda; II manantial en el municipio Pueblo Cumarebo, Distrito Zamora.
+- **Cocuiza**: I caserío del municipio Mitare; II aldea del municipio Colina; III aldea del municipio Casigua; IV aldea del municipio Macoruca; V río límite entre Falcón y Zulia.
+- **Cocuyal**: lugar al Norte de Churuguara, Federación.
+
+### MORFEMAS Y GLOSAS
+- "(*Ceiba* y *Ceibo*: árbol maderable; hay varias clases)."
+- "(*Cerey*, apócope de Cereipo, árbol leguminoso, madera fuerte y de fácil pulimento. La corteza y su fruto son resinosos; su resina es antirreumático)."
+- "(Sibira, con 's', es un apellido, posiblemente indígena)" — sobre Cibira.
+- "(Paloma de plumaje verdoso)" — sobre Cocorote.
+- "(*Cocuiza*: planta de la que extrae fibra)."
+- "(*Cocuyal*: colectivo de cocuy, agave, planta fibrosa)." — nótese el sufijo colectivo "-al".
+
+---
+
+## p. 102 (p002.jpg)
+
+### TOPÓNIMOS
+- **Cocuyito**: aldea del municipio Jacura, Distrito Acosta.
+- **Codore**: salinas y aldea del municipio Urumaco, Distrito Democracia.
+- **Cogollal / Cogollales**: aldeas en Jacura (Acosta) y Unión (Federación).
+- **Cojina**: río que desagua en el Golfete de Coro, Distrito Miranda.
+- **Colacho**: caserío del municipio Urumaco, Distrito Democracia.
+- **Las Conchonchas**: poza en el Municipio Pedregal.
+- **Copey**: cuatro aldeas (Seque/Buchivacoa, Guzmán Guillermo/Miranda, Avaria/Democracia, Aguaclara/Democracia).
+- **Coropal**: aldea del Municipio Guzmán Guillermo, Distrito Miranda.
+
+### MORFEMAS Y GLOSAS
+- "(*Cocuyito*... diminutivo de cocouyo, luciérnaga, o planta tierna de cocuy, agave)."
+- "(Colacho, hipocorístico de Nicolás)."
+- "(*Copey*, palmera del género clusia)."
+- "(Puede ser una disimilación de Corozal. (Ver más adelante))." — sobre Coropal.
+
+### RASGOS GRAMATICALES
+- Diminutivo "-ito" en Cocuyito.
+- Hipocorístico en Colacho.
+- Posible disimilación fonética Coropal < Corozal.
+
+---
+
+## p. 103 (p003.jpg) — foto
+
+(foto) "Extracción de sal." Fotografía de dos personas trabajando salinas con carretillas. Sin número de página visible ni texto etimológico.
+
+---
+
+## p. 104 (p004.jpg)
+
+### TOPÓNIMOS
+- **Coroquidiro**: aldea del Municipio Capatárida, Distrito Buchivacoa.
+- **El Corozo / El Corozal**: aldea en Colina (Distrito Falcón) y caserío en Unión, Federación.
+- **El Corubo**: dos aldeas (San Antonio/Miranda, Urumaco/Democracia).
+- **Cuarajacume**: aldea repartida entre Urumaco (Democracia) y Zazárida (Buchivacoa).
+- **Cuare (Altamira)**: caserío del municipio Borojó, Distrito Buchivacoa.
+- **Cube**: San José del Cube y Cubecito, caseríos de San Francisco (Mirimire); Maicillar del Cube, aldea de Jacura.
+- **Cueparo**: aldea del municipio Jacura, Distrito Acosta.
+
+### MORFEMAS Y GLOSAS
+- "Aldea del Municipio Capatárida... conocemos la desinencia 'iro', que es diminutivo." — sobre Coroquidiro.
+- "(*Corozal*, colectivo de Corozo, una palmera)."
+- "(*Corubo*: caracol, habitáculo calcáreo de ciertos moluscos. *Coruba*: ave gallinácea muy ruidosa)."
+- "(*Cube* o *Cude*: ente sobrenatural, fantasma)."
+
+### RASGOS GRAMATICALES
+- Sufijo diminutivo "-iro" identificado explícitamente en Coroquidiro.
+- Sufijo colectivo "-al" (Corozal < Corozo).
+
+---
+
+## p. 105 (p005.jpg)
+
+### TOPÓNIMOS
+- **Las Cuibas / La Cuibita**: caseríos en Pedregal y Aguaclara, Democracia; ambas con fuentes termales.
+- **El Cují / El Cujizal**: caseríos en Urumaco, Capatárida y caserío urbano San Gabriel (Miranda).
+- **Cumarebo**: nombre del antiguo cantón, hoy Distrito Zamora; Puerto Cumarebo (capital), Pueblo Cumarebo (municipio), Cumarebito (aldea).
+- **Cume**: aldea del municipio Borojó, Distrito Buchivacoa.
+- **Cuquía**: aldea del municipio Capatárida, Buchivacoa.
+- **Curairima**: aldea del municipio Cabure, Distrito Petit.
+- **Curamaco**: aldea del municipio Pedregal, Distrito Democracia.
+
+### MORFEMAS Y GLOSAS — DESTACADO: "ebo"
+- **"(Cumarebo significa: el camino del cacique Cumare: 'ebo' paso, senda y Cumare, el cacique)."** — glosa explícita del morfema rastreado **ebo**.
+- "(*Cují*: árbol leguminoso, madera recia)."
+- "(*Cume*, cube, ser sobrenatural, fantasma)." [nótese variante de "cube" ya visto en p.104]
+- "(Irima: humedad)." — sobre Curairima.
+- "Aca: par, casal, pareja." — sobre Curamaco.
+
+---
+
+## p. 106 (p006.jpg)
+
+### TOPÓNIMOS
+- **Curamichate**: puerto y pueblo en el municipio La Pastora; minas de carbón, arena y sal.
+- **Curarí**: ocho entradas (I-VIII), incluyendo "Nombre que dan al Río Hueque en su desembocadura" (VII) y "En los tiempos coloniales, El Curaridal era el nombre que le daban a la población de San Félix de Mauroa" (VIII).
+- **Curazao**: pueblo del municipio Casigua, Distrito Mauroa.
+- **Curiaja**: sitio en los linderos del municipio Casigua.
+- **Curimagua**: población capital del municipio Curimagua, Distrito Petit.
+- **Curuquebo**: aldea del municipio Zazárida, Distrito Buchivacoa. "El paso de la paloma."
+- **Curuquides**: aldea del municipio Zazárida, Distrito Buchivacoa.
+
+### MORFEMAS Y GLOSAS
+- "(Curiaja, planta bromeliácea, teco, maya)."
+- "(Puede que provenga de *Curi*, pequeño roedor, acure, picure)." — sobre Curimagua.
+- "Aldea del municipio Zazárida... El paso de la paloma." — sobre Curuquebo (glosa toponímica compuesta, sin desglosar morfemas).
+
+### EVIDENCIA ARQUEOLÓGICA / HISTÓRICA
+- Nota histórico-colonial: "En los tiempos coloniales, El Curaridal era el nombre que le daban a la población de San Félix de Mauroa" — dato de continuidad toponímica colonial.
+
+---
+
+## p. 107 (p007.jpg)
+
+### TOPÓNIMOS
+- **Cururupare**: caserío del municipio Piedra Grande (texto parcialmente ilegible por mancha/reflejo).
+- **Chacha**: posesión comunera del Distrito Zamora; aldea del municipio Guzmán Guillermo (texto parcialmente ilegible).
+- **La Chara / Las Charas / El Charal**: cuatro entradas en Maparari, Avaria, Unión (Federación) y sabanas de San Juan de los Cayos (Acosta).
+- **Chibare**: montaña al Oeste de Chichiriviche, Distrito Silva.
+- **Chicagua**: pequeña península en el golfete de Coro, Distrito Miranda.
+- **Chidare**: aldea del municipio Capatárida, Distrito Buchivacoa.
+- **Chichiriviche**: puerto y población, capital del municipio Chichiriviche, Distrito Silva.
+- **Chiguarigua**: caserío del municipio Agualinda, Distrito Acosta.
+
+### MORFEMAS Y GLOSAS
+- "(Chara, fruto del charo, árbol frutal, de las Moráceas)."
+- "(Chibare, aféresis de Achivare, variedad de matapalo cuya madera es de poca utilidad)."
+- "(Voz compuesta de 'chigua', nasa, cesto, y 'arigua', un insecto melífero)." — sobre Chiguarigua.
+
+### RASGOS GRAMATICALES
+- Aféresis explícita: Chibare < Achivare.
+- Composición morfológica explícita: Chiguarigua = "chigua" (nasa, cesto) + "arigua" (insecto melífero).
+
+---
+
+## p. 108 (p008.jpg)
+
+### TOPÓNIMOS
+- **Chimpire**: tres entradas (Pedregal/Democracia, Píritu/Zamora, Maparari/Federación).
+- **El Chinchorro**: caserío del municipio Agualinda, Distrito Acosta.
+- **Chipare**: caserío en Guaibacoa (Colina) y quebrada al Oeste de La Soledad (Zamora).
+- **Los Chipes**: caserío del municipio Mitare, Distrito Miranda.
+- **Chiquichique**: río del Distrito Silva.
+- **Chiriguare**: dos caseríos (Borojó/Buchivacoa, San Félix/Mauroa).
+- **Chorote**: aldea del municipio Capatárida, Distrito Buchivacoa.
+- **Chubiscal**: caserío del municipio Unión, Distrito Federación.
+
+### MORFEMAS Y GLOSAS
+- "(Chinchorro: hamaca de fique)."
+- "(Chipe: almeja)."
+- "(Chiquichique: planta abustiva, leguminosa, medicinal, 'cassia obtusifolia'. En Guayana, palmera gigante, la 'Leopoldina Piasaba')."
+- "(Chiriguare: milvago chimachima, ave rapaz de plumaje amarillo sucio)."
+- "(Chubiscal: colectivo de chubisco, insecto, escarabajo, congorroncho)."
+
+### ATRIBUCIONES DE LENGUA
+- **"(Chorote: voz cumanagota, tiesto de barro, útil de cocina)."** — Esteves atribuye explícitamente Chorote a lengua cumanagota, NO caquetía.
+
+### RASGOS GRAMATICALES
+- Sufijo colectivo "-al": Chubiscal < chubisco.
+
+---
+
+## p. 109 (p009.jpg)
+
+### TOPÓNIMOS
+- **Chuco**: cuatro entradas (Buchivacoa x2, Federación, Zamora).
+- **Chuchure**: aldea del municipio Sabaneta, Distrito Miranda.
+- **Chunaure**: "Lugar desaparecido; en antiguos papeles se menciona el fundo, ubicado en el Cantón Casicure."
+- **Churuguara**: población capital del municipio Churuguara y del Distrito Federación.
+- **Dabajuro**: población capital del municipio Dabajuro, Distrito Buchivacoa.
+- **La Danta**: aldea del municipio Unión, Distrito Federación.
+- **Las Daras**: caserío del municipio Pecaya, Distrito Bolívar.
+
+### MORFEMAS Y GLOSAS — DESTACADO
+- **"(Chunaure: voz caquetía, jojota mazorca tierna de maíz)."** — atribución EXPLÍCITA "voz caquetía" (no solo "caquetío" genérico), con morfema "-aure" cercano al rastreado naure/ñaure.
+- "(Chuco: mono pequeño de gran movi[lidad, in]secto volador)." [texto parcialmente ilegible por mancha]
+- "(Puede ser una alteración de Chuchube, pájaro canoro)." — sobre Chuchure.
+- "(Sin explicar el significado, Alfredo Jahn registra la voz: *Axadawara*. 'Aborígenes del Occidente de Venezuela')." — sobre Churuguara.
+- "(Dabajuro: nombre de un cacique. Era pichicate: ¡daba a juro!)." — juego de palabras de Esteves (dato de cacique + comentario jocoso propio del autor, no dato lingüístico serio).
+- "(Dara, ave corredora, muy ruidosa, el alcaraván)."
+
+### FUENTES QUE CITA
+- **Alfredo Jahn**, "Aborígenes del Occidente de Venezuela" — citado por el topónimo/voz "Axadawara" en relación con Churuguara.
+
+### RASGOS GRAMATICALES / DATOS HISTÓRICOS
+- Chunaure: "lugar desaparecido... en antiguos papeles" (documento histórico no identificado con fecha, dato de fundo colonial).
+- Cacique Dabajuro como epónimo del topónimo.
+
+---
+
+## p. 110 (p010.jpg)
+
+### TOPÓNIMOS
+- **Datuara**: quebrada en el municipio Borojó, Distrito Buchivacoa.
+- **Decore**: aldea del municipio Maparari, Distrito Federación.
+- **Dibana**: caserío del municipio Tocuyo de la Costa, Distrito Silva.
+- **Dividive / Dividives / Dividivito**: cinco entradas (Macoruca, La Soledad, Pedregal, Mene de Mauroa, Borojó).
+- **Doche**: cerro en los linderos del municipio San Juan de los Cayos, Distrito Acosta.
+- **Dubisí**: población del municipio Maparari, Distrito Federación.
+- **Duiza**: aldea del municipio Pecaya, Distrito Bolívar.
+- **La Enea**: caserío del municipio Jacura, Distrito Acosta.
+
+### MORFEMAS Y GLOSAS — DESTACADO: "bana"
+- **"(Es una alteración de Gibana, que significa cerro amarillo)."** — sobre Dibana. Relevante para el morfema rastreado **bana/bano**: aquí aparece como "-bana" en "Gibana" = cerro amarillo (un elemento "gi-" + "bana" = cerro, si se interpreta paralelo a otros topónimos "bana" = cerro).
+- "(Dividive: árbol cuyo fruto es una baya que da tinta)."
+- "(Es un apellido de las tribus ayamanes)." — sobre Dubisí. Atribución étnica/lingüística.
+- "(Enea: planta ciperácea)."
+
+### ATRIBUCIONES DE LENGUA
+- **Dubisí**: "Es un apellido de las tribus ayamanes" — atribución a los ayamanes, no caquetíos.
+
+### RASGOS GRAMATICALES
+- Alteración fonética explícita: Dibana < Gibana.
+
+---
+
+## p. 111 (p011.jpg)
+
+### TOPÓNIMOS
+- **Eroa**: aldea del municipio Zazárida (texto parcialmente ilegible).
+- **Escuque**: manantial en el municipio Pueblo Cumarebo, Dto. Zamora.
+- **Los Gayones**: aldea del municipio Churuguara, Dto. Federación.
+- **Garrapata**: lugar cerca de La Vela de Coro (Colina) y cerro de Zazárida (Buchivacoa).
+- **Guaca**: río afluente del río Tocuyo, Dto. Silva.
+- **Guacabana**: aldea del municipio Chichiriviche, Dto. Silva.
+- **Guacoa / Las Guacoas**: aldea en Mene de Mauroa y cerro en Avaria.
+- **Guachara**: cerro cercano a Cabure, Distrito Petit.
+
+### MORFEMAS Y GLOSAS — DESTACADO: "bana"
+- **"(Guacabana: el cerro de las cotas)."** — glosa toponímica compuesta que contiene el morfema rastreado **bana**, interpretado aquí como "cerro" (guaca = cota/animal + bana = cerro, en paralelo con "Gibana: cerro amarillo" de p.110).
+- "(Gayón: árbol de construcción. Gayones: una tribu ayamán)." — sobre Los Gayones.
+- "(Insecto hematófago)." — sobre Garrapata.
+- "(Guaca: ave, cotorra)."
+- "(Guacoa, ave de cacería; columba corensi[s])."
+
+### ATRIBUCIONES DE LENGUA
+- **Escuque**: "(Voz cuica-timote adoptada)." — Esteves marca explícitamente que Escuque NO es caquetío sino una voz cuica-timote adoptada en la toponimia falconiana.
+- **Gayones**: identificados como "una tribu ayamán" (no caquetía).
+
+---
+
+## p. 112 (p012.jpg)
+
+### TOPÓNIMOS
+- **Guacharaca**: tres caseríos (San Francisco/Mirimire, Jacura, Agualinda).
+- **Guagua**: caserío del municipio Guzmán Guillermo, Distrito Miranda.
+- **Guaguana**: aldea del municipio Casigua, Distrito Mauroa.
+- **Guaibacoa**: pueblo capital del municipio Guaibacoa, Distrito Colina.
+- **Guaimure**: aldea del municipio Capatárida, Distrito Buchivacoa.
+- **El Guaical**: cerro cerca de Mirimire, Distrito Acosta.
+- **Guaicara**: aldea del municipio Sabaneta, Distrito Miranda.
+- **Guaidima**: aldea del municipio Capadare, Dto. Acosta.
+- **Guajiro**: aldea del municipio Bariro, Distrito Buchivacoa.
+
+### MORFEMAS Y GLOSAS — DESTACADO: "ure"
+- **"(Guaimure: raíz de guay; 'ure', raíz)."** — glosa EXPLÍCITA del morfema rastreado **ure** = "raíz".
+- "(Guacharaca: gallina silvestre, muy ruidosa)."
+- "(Guagua: caña arborescente de tallo cilíndrico y hueco, guasdua)."
+- "(Guaibacoa: lugar de los guays)." — toponimo con sufijo -bacoa (relacionado con el morfema rastreado **bacoa**), glosado como "lugar de".
+- "(Guaica, planta sarmentosa, armada de grandes espinas; su savia es medicinal para la vista)." — sobre Guaical.
+
+### RASGOS GRAMATICALES
+- "Guaibacoa: lugar de los guays" sugiere que el sufijo "-bacoa" funciona como locativo ("lugar de").
+
+---
+
+## p. 113 (p013.jpg)
+
+### TOPÓNIMOS
+- **Guamacho**: población perteneciente al municipio [ilegible].
+- **Guamal**: lugar del municipio Macoruca, Distrito Colina.
+- **Guamay**: lugar del municipio Aracua, Distrito Bolívar.
+- **El Guamo**: aldea del municipio Maparari, Distrito Federación.
+- **Guamare**: aldea del municipio Jacura, Distrito Acosta.
+- **El Guanábano**: caserío del municipio Puerto Cumarebo.
+- **Guanachana**: quebrada y ciénaga en Jacura, Dto. Acosta, lindero meridional del Distrito Zamora.
+- **Guara**: caserío del municipio Chichiriviche, Distrito Silva.
+- **La Guaraba / El Guarabal**: tres aldeas (San Luis/Bolívar, Agualinda/Acosta, Independencia/Federación).
+
+### MORFEMAS Y GLOSAS
+- "(Guamacho: árbol cactáceo)."
+- "(Guama: fruta del guamo)." — sobre Guamal.
+- "(Guanábano: árbol frutal)."
+
+### NOTA
+- **Guara**: entrada simple, solo ubicación, sin etimología ofrecida por Esteves en esta página. Es uno de los morfemas rastreados por el proyecto pero aquí Esteves no lo glosa.
+
+---
+
+## p. 114 (p014.jpg)
+
+### TOPÓNIMOS
+- **Guarabita / Guarabito**: aldeas en Aracua (Bolívar) y Bariro (Buchivacoa).
+- **Guaracaro**: lugar de Casicure.
+- **Guaratal**: río afluente del Güeque, Dto. Colina.
+- **Guarebobo**: aldea del municipio Borojó, Distrito Buchivacoa.
+- **Guarecal**: aldea del municipio Píritu, Distrito Zamora.
+- **Guariro**: cerro cerca de Capatárida, Dto. Buchivacoa.
+- **Guasare**: aldea en Colina (Petit) y lugar cerca de La Vela de Coro (Colina).
+- **La Guásima**: aldea del municipio Cabure, Distrito Petit.
+- **Guasiquí**: caserío del municipio Pecaya, Distrito Bolívar.
+- **Guatacara**: lugar nombrado en los linderos del municipio Capatárida, Distrito Buchivacoa.
+
+### MORFEMAS Y GLOSAS
+- "(Guaracaro: planta herbácea, anual, que produce un grano alimenticio, una tapirama silvestre)."
+
+### ATRIBUCIONES DE LENGUA
+- **"(Guareque, voz chaima, sapo)."** — sobre Guarecal; Esteves atribuye "Guareque" explícitamente a lengua chaima, NO caquetía.
+
+---
+
+## p. 115 (p015.jpg) — foto
+
+(foto) "Casa de Josefa Camejo, en Paraguaná." Fotografía de una vivienda tradicional (techo de tejas). Sin número de página visible ni texto etimológico.
+
+---
+
+## p. 116 (p016.jpg)
+
+### TOPÓNIMOS
+- **Guatarima**: aldea del municipio Curimagua, Distrito Petit.
+- **Guate (Puente Huate)**: caserío del municipio Guzmán Guillermo, Distrito Miranda.
+- **Guay**: caserío en Sucre (Bolívar) y Mirimire (Acosta).
+- **Guayabal**: lugar selvático maderero entre Jacura y San Lorenzo, Dto. Acosta.
+- **Guaimocho**: aldea del municipio Capatárida, Distrito Buchivacoa.
+- **La Guayana**: aldea del municipio Agualinda, Distrito Acosta.
+- **Güedeque**: paso en el río Pedregal, Distrito Democracia.
+- **Güeque**: río, aldea (Colina/Petit) y montaña (Píritu).
+- **Güide (Boca de Güide)**: lugar en el municipio Guzmán Guillermo, Distrito Miranda.
+
+Sin etimologías ni glosas explícitas en esta página — solo ubicaciones.
+
+---
+
+## p. 117 (p017.jpg)
+
+### TOPÓNIMOS
+- **La Guinea**: aldea del municipio Avaria, Distrito Democracia.
+- **Guiní**: manantial u ojo de agua en Pueblo Cumarebo, Distrito Zamora.
+- **Los Icacales**: aldea del municipio La Pastora, Distrito Acosta.
+- **Icuiza**: quebrada y aldea en Jacura, Distrito Acosta.
+- **Igüy**: cerro en los linderos del municipio Acurigua, Distrito Colina.
+- **Inirgua**: aldea del municipio Guzmán Guillermo, Distrito Miranda.
+- **Iparaguaro**: "fundo pecuario" sin ubicación precisada.
+- **Ipare**: caserío del municipio Guzmán Guillermo, Distrito Miranda.
+- **Iquital**: lugar en los linderos del municipio Dabajuro, Distrito Buchivacoa.
+
+### MORFEMAS Y GLOSAS
+- "(Icaco, arbolillo frutal)." — sobre Icacales.
+- "(Igüí: árbol, matapalo, paují)." — sobre Igüy.
+- "(Ipare: aféresis de chipare, matapalo)." — nótese relación con "Chipare" de p.108.
+
+### FUENTES QUE CITA
+- **"Lugar que a lo que consideramos fue o es un fundo pecuario; no hemos precisado su ubicación. Lo documentamos de Pedro Manuel Arcaya en su obra 'Población de Origen Europeo de Coro'."** — cita textual completa de la fuente y la obra, sobre Iparaguaro.
+
+### RASGOS GRAMATICALES
+- Aféresis explícita: Ipare < chipare.
+
+---
+
+## p. 118 (p018.jpg)
+
+### TOPÓNIMOS
+- **Iraca / Iracal**: cerro cerca de Acurigua y caserío en Sabaneta, Distrito Miranda.
+- **Irima**: caserío del municipio Guzmán Guillermo, Distrito Miranda.
+- **Isiro**: lugar del municipio Guzmán Guillermo, Distrito Miranda; "hoy hay una gran represa."
+- **Itowa**: "Antiguo nombre indígena de Churuguara."
+- **Las Jabillas / El Jabillal**: aldeas en Seque (Buchivacoa) y Maparari (Federación).
+- **Jacura**: población capital del municipio del mismo nombre, Distrito Acosta.
+- **Jadagua**: aldea del municipio Casigua, Distrito Mauroa.
+- **Jajatal**: sabanas de Chichiriviche, Distrito Silva.
+- **Jatira**: ciénaga o laguna en el territorio del municipio San Juan de los Cayos, Distrito Acosta.
+
+### MORFEMAS Y GLOSAS
+- "(Iraca, palmera conocida en otros lugares con los nombres de jipijapa, palma carabobo, atadera, etc.)."
+- "(Isiro: árbol sapindáceo)."
+- "(Jabillo: árbol maderable)."
+- "(Jajato: hierba de terrenos salobres)." — sobre Jajatal.
+
+### DATOS ETNOHISTÓRICOS
+- **Itowa**: "Antiguo nombre indígena de Churuguara." — nombre indígena previo/alternativo al topónimo actual, sin más detalle etimológico. Relevante para geografía política / toponimia superpuesta.
+
+---
+
+## p. 119 (p019.jpg)
+
+### TOPÓNIMOS
+- **El Jebe / El Jebito**: tres aldeas (Pedregal/Democracia, San Antonio/Miranda, Sabaneta/Miranda).
+- **El Jobo**: aldea del municipio Pedregal, Distrito Democracia.
+- **Jubuy**: aldea del municipio Borojó, Distrito Buchivacoa.
+- **Juritiba**: aldea del municipio Borojó, Distrito Buchivacoa.
+- **Macanillas**: aldeas en Curimagua (Petit) y San Francisco/Mirimire (Acosta).
+- **Macoruca**: pueblo del Distrito Colina, antigua capital del municipio Macoruca (hoy Turaguar).
+- **Macuquita**: aldea de Guzmán Guillermo, Distrito Miranda.
+- **Macuare**: aldea en Colina (Petit) y caserío en San Luis (Bolívar).
+
+### MORFEMAS Y GLOSAS
+- "(Arbol maderable)." — sobre Jebe.
+- "(Jobo: un árbol cuya drupa es comestible)."
+- "(Macanilla: palmera de la que se extrae fibra para tejer hamacas)."
+
+---
+
+## p. 120 (p020.jpg)
+
+### TOPÓNIMOS
+- **Maguay**: caserío de Pecaya (Bolívar) y aldea de Acurigua (Colina).
+- **Maica**: caserío del municipio Piedra Grande, Distrito Democracia.
+- **Maipana**: lugar de Acurigua, Distrito Colina.
+- **Maicillar / Maicillalito**: tres/cuatro entradas en Jacura, Distrito Acosta.
+- **Majagual**: pueblo del municipio Mitare, Distrito Miranda.
+- **Majagüillo**: caserío del municipio Guaibacoa, Distrito Colina.
+- **Mamital**: caserío del municipio Unión, Distrito Federación.
+- **Mamón / Mamonal**: cuatro entradas (Píritu, San Luis, Chichiriviche, Seque).
+- **Mampostal**: cerro en los linderos meridionales del Distrito Zamora.
+
+Sin etimologías explícitas en esta página.
+
+---
+
+## p. 121 (p021.jpg)
+
+### TOPÓNIMOS
+- **Manaure**: cerro donde nace el río Ricoa (texto parcialmente ilegible el distrito). Sin etimología ofrecida por Esteves en esta entrada — solo ubicación.
+- **Mangle / El Manglar**: cuatro entradas (San Juan de los Cayos, San Francisco/Mirimire, río Capadare, Puerto Cumarebo).
+- **Maparé**: caserío del municipio Churuguara, Distrito Federación.
+- **Mapararí**: población capital del municipio Mapararí, Distrito Federación.
+- **Mapiare**: lugar de Churuguara, Distrito Federación.
+- **Maporal**: caserío del municipio Agualarga, Distrito Federación.
+- **Punta de Maragüey**: lugar costeño en el golfete de Coro, Distrito Miranda.
+- **Maripiota**: aldea del municipio Sucre (La Cruz), Distrito Bolívar.
+- **El Masagual**: aldea del municipio Mitare, Distrito Miranda.
+
+### EVIDENCIA ARQUEOLÓGICA — DESTACADO
+- **"Lugar de Churuguara en el Distrito Federación. Otrora fue una comunidad indígena que desapareció. Hoy es sitio arqueológico."** — sobre Mapiare. Cita textual explícita de un sitio arqueológico.
+
+### NOTA
+- **Manaure**: el morfema rastreado **naure/ñaure** aparece aquí como parte del topónimo (probable epónimo del cacique Manaure), pero Esteves NO ofrece glosa etimológica en esta entrada.
+
+---
+
+## p. 122 (p022.jpg)
+
+### TOPÓNIMOS
+- **Majagual**: caserío de Mitare, Dto. Miranda (repetido, entrada distinta de p.120).
+- **Masuí**: aldea del municipio Casigua, Distrito Mauroa.
+- **Matacanes**: aldea del municipio Guzmán Guillermo, Distrito Miranda.
+- **Matacara / Matacarita**: aldea de Pedregal y quebrada lindero de Bruzual, Dto. Democracia.
+- **Mataruca**: población perteneciente al municipio La Vela, Distrito Colina.
+- **Maticora**: río, aldea (Casigua/San Félix) y población del municipio San Félix, Dto. Mauroa.
+- **Mauroa**: nombre de un Distrito del Estado Falcón (municipios Mene de Mauroa, Casigua, San Félix).
+- **Mayares**: lugar y quebrada, lindero del municipio Casigua, Distrito Mauroa.
+- **Mazuca**: aldea del municipio Capatárida, Distrito Buchivacoa.
+
+### MORFEMAS Y GLOSAS
+- "(Matacán: cérvido de poco alzada)." — sobre Matacanes.
+- "(Mauroa: apellido de un cacique)."
+- "(Mayares: colectivo de maya: planta bromeliácea)." — sufijo colectivo "-res".
+
+### DATOS ETNOHISTÓRICOS
+- **Mauroa**: nombre del Distrito derivado del apellido de un cacique — dato genealógico/de autoridad indígena relevante para geografía política.
+
+---
+
+## p. 123 (p023.jpg)
+
+### TOPÓNIMOS
+- **Meachiche**: río y aldea en el municipio Guzmán Guillermo, Distrito Miranda.
+- **Mecocal**: aldea del municipio Jacura, Distrito Acosta.
+- **Memerí**: aldeas en Churuguara y Maparari, Distrito Federación.
+- **Mene (de Acosta/San Lorenzo, de Mauroa)**: capitales de municipio Libertador (Acosta) y Distrito Mauroa.
+- **Mide**: caserío del municipio Bruzual, Distrito Democracia.
+- **Mirimire / Mirimirito**: población capital del municipio San Francisco, Distrito Acosta.
+- **Mitare**: población capital del municipio Mitare, Distrito Miranda.
+- **Moruca**: cerro y caserío de Bruzual, Distrito Democracia.
+- **Moroturo**: río y pueblo de Federación en límites con Lara.
+
+### MORFEMAS Y GLOSAS
+- "(Memerí: nido de avispas, colmena)."
+- "(Mene: betún, asfalto)."
+
+---
+
+## p. 124 (p024.jpg)
+
+### TOPÓNIMOS
+- **Morrocoy**: población del municipio Tucacas, Dto. Silva.
+- **Moturo / Moturito**: lugar en Pueblo Cumarebo, Dto. Zamora.
+- **El Moyepo**: aldea del municipio Macoruca, Distrito Colina.
+- **Muaco**: puerto natural al Este de La Vela, Distrito Colina.
+- **Mucaro**: manantial en Bruzual, Distrito Democracia.
+- **Mucuría**: aldea de La Pastora, Distrito Acosta.
+- **Mucurutá**: quebrada de Zazárida, Distrito Buchivacoa.
+- **Mucurusa**: aldea del municipio Cabure, Petit.
+- **Mumuche**: cerro entre Agualinda y Jacura; aldea del municipio Jacura, Distrito Acosta.
+- **Murende**: aldea del municipio Churuguara, Distrito Federación.
+- **Nafia**: cerro lindero meridional del Distrito Bolívar.
+
+### MORFEMAS Y GLOSAS
+- "(Morrocoy: Quelónido)." — nota entre paréntesis.
+
+Sin más etimologías en esta página.
+
+---
+
+## p. 125 (p025.jpg)
+
+### TOPÓNIMOS
+- **Naguao**: quebrada en el municipio Dabajuro, Distrito Buchivacoa.
+- **Noruga**: cerro en el Distrito Democracia.
+- **Noto**: río afluente del Hueque.
+- **Numanumam**: caserío del municipio Unión, Distrito Federación.
+- **Ocorote**: aldea del municipio Mitare, Distrito Miranda.
+- **Omomo**: caserío del municipio Casigua, Distrito Mauroa.
+- **Oribor**: lugar costeño en San Félix, Distrito Mauroa; "El Caño de Oribor señala el límite del Estado Falcón con el Estado Zulia."
+- **Origuete**: quebrada, lindero del municipio Capadare, Dto. Acosta.
+- **Origuaza**: aldea y quebrada del municipio Jacura, Distrito Acosta.
+- **Orocodones**: lugar del municipio Capatárida, Distrito Buchivacoa.
+
+Sin etimologías explícitas en esta página — solo ubicaciones.
+
+---
+
+## p. 126 (p026.jpg)
+
+### TOPÓNIMOS
+- **Pagua**: caserío del municipio Colina, Distrito Petit.
+- **Paracoto**: aldea de Maparari, Federación.
+- **Paragüito**: lugar del municipio Purureche, Dto. Democracia.
+- **Paido**: aldea del municipio Capatárida, Dto. Buchivacoa.
+- **Parapara**: aldea del municipio Tocuyo de la Costa, Dto. Silva.
+- **Parapoy**: lugar del municipio Maparari, Dto. Federación.
+- **Parucia**: caserío del municipio Churuguara, Distrito Federación.
+- **Parupano**: caserío del municipio Maparari, Distrito Federación.
+- **Paují / Paujizal**: cuatro entradas (Churuguara, Pueblo Cumarebo, Borojó, Distrito Miranda).
+
+### MORFEMAS Y GLOSAS
+- "(Parapara: semilla del paraparo, árbol elevado, sapindus saponaria, la fruta de este árbol contiene una pulpa viscosa y amarga y se usa en lugar de jabón; las semillas son negras)."
+- "(Paují: ave gallinácea de carne muy apreciada. Paují: árbol sapotáceo)."
+
+---
+
+## p. 127 (p027.jpg)
+
+### TOPÓNIMOS
+- **Pecaya**: población capital del municipio del mismo nombre, Distrito Bolívar.
+- **Peregüey**: aldea del municipio San Luis, Distrito Bolívar.
+- **Píritu**: seis entradas, incl. población capital del Distrito Píritu, Zamora; Piritupano (Jacura); Alto de Píritu (serranía lindero de Capatárida).
+- **Ponjuicito**: aldea del municipio Avaria, Dtto. Democracia.
+- **Popote / Popotal**: aldea de Urumaco (Democracia) y posesión comunera en Zamora.
+- **Poropoy**: aldea del municipio Unión, Distrito Federación.
+- **Pundo**: pueblo del municipio Boca de Aroa, Distrito Silva.
+
+### MORFEMAS Y GLOSAS
+- "(*Píritu*: una palmera)."
+- "(Popote: planta ciperácea, junco)."
+- "(*Pundo* es un topónimo antillano; en Curazao la zona comercial de la ciudad la llaman Punda)." — atribución explícita a origen antillano, no caquetío.
+
+### ATRIBUCIONES DE LENGUA
+- **Pundo**: "topónimo antillano" — comparación directa con Punda (Curazao), sugiere origen no caquetío/no continental sino de las Antillas holandesas.
+
+---
+
+## p. 128 (p028.jpg)
+
+### TOPÓNIMOS
+- **Purureche**: población capital del municipio del mismo nombre, Distrito Democracia.
+- **Quebrahuto**: aldea del municipio Puerto Cumarebo, Distrito Zamora.
+- **Quererepa**: laguna o ciénaga en Píritu, Distrito Zamora.
+- **Quibucara**: quebrada de Tocópero, Dtto. Zamora.
+- **Los Quimbos**: aldea del municipio Pedregal, Dtto. Democracia.
+- **Quigua**: aldea del municipio Capatárida, Distrito Buchivacoa.
+- **Quipito**: cerro en los linderos del Distrito Bolívar.
+
+### MORFEMAS Y GLOSAS — PÁGINA CLAVE: "-uto" y "quiba"
+- **"(Generalmente se tiene aceptado que la procedencia del topónimo débese a von Felipe de Hutten, el alemán conquistador que pasaría por allí en 1540, pero de un examen de la voz, hemos llegado a la conclusión de que es un vocablo híbrido de español y caquetío, en cierto modo pleonástico, ya que la radical 'quebra' es apócope de quebrada (español) y la desinencia 'uto', en caquetío, significa quebrada)."** — sobre Quebrahuto. Análisis etimológico extenso y explícito de Esteves; corrobora el morfema rastreado **-uco/-uto** = "quebrada", y descarta la etimología popular (von Hutten, 1540).
+- "(Puede ser una epéntesis de Querepa: yuca amarga)." — sobre Quererepa.
+- **"(Puede ser alteración de Sibucara, árbol de corteza fibrosa. Sin embargo, 'quiba', en caquetío, es pedruzco)."** — sobre Quibucara. Glosa EXPLÍCITA del morfema rastreado **quiba** = "pedruzco" (piedra pequeña), marcada "en caquetío".
+- "(Quimba es voz chibcha que significa: sandalia, alpargata)." — sobre Los Quimbos.
+- "(Quigua: crustáceo)."
+- "(Quipito: árbol rutáceo de corteza olorosa. Sándalo de playa lo llamaron los españoles)."
+
+### ATRIBUCIONES DE LENGUA
+- **Quebrahuto**: "vocablo híbrido de español y caquetío" — atribución explícita mixta español + caquetío, con análisis morfológico detallado (apócope + desinencia).
+- **Quimbo/Quimba**: "voz chibcha" — explícitamente NO caquetía, de lengua chibcha.
+
+### RASGOS GRAMATICALES — DESTACADO
+- **Análisis morfológico completo de Quebrahuto**: "quebra" = apócope de "quebrada" (español) + "-uto" = desinencia caquetía que significa "quebrada" — ejemplo de hibridación léxica español-caquetío señalado explícitamente por el autor.
+- Epéntesis propuesta: Quererepa < Querepa.
+- Posible alteración fonética: Quibucara < Sibucara.
+
+---
+
+## p. 129 (p029.jpg) — foto
+
+(foto) "Trabajando la cerámica." Fotografía etnográfica de una persona elaborando cerámica junto a vasijas de barro sobre el suelo. Sin número de página visible ni texto etimológico. Relevante como evidencia de continuidad de la técnica cerámica tradicional en la región (dato cultural, no arqueológico datado).
+
+---
+
+## Resumen del archivo 5
+
+### Morfemas nuevos / corroborados (de la lista rastreada por el proyecto)
+
+- **ebo** — CORROBORADO explícitamente: "(Cumarebo significa: el camino del cacique Cumare: 'ebo' paso, senda...)" (p.105).
+- **ure** — CORROBORADO explícitamente: "(Guaimure: raíz de guay; 'ure', raíz)" (p.112).
+- **-uco/-uto** — CORROBORADO explícitamente, con análisis morfológico extenso: "'uto', en caquetío, significa quebrada" (Quebrahuto, p.128). Esteves descarta la etimología popular (von Hutten).
+- **quiba** — CORROBORADO explícitamente: "'quiba', en caquetío, es pedruzco" (Quibucara, p.128).
+- **bana/bano** — Aparece dos veces en construcciones toponímicas glosadas como "cerro": "Gibana... cerro amarillo" (Dibana, p.110) y "Guacabana: el cerro de las cotas" (p.111). Esteves no aísla el morfema explícitamente como lo hace con ebo/ure/-uto/quiba, pero el patrón es consistente con el morfema rastreado.
+- **bacoa** — Aparece en "Guaibacoa: lugar de los guays" (p.112), sugiriendo función locativa del sufijo "-bacoa" ("lugar de").
+- **naure/ñaure** — Aparece en el topónimo Manaure (p.121) y en Chunaure ("voz caquetía, jojota mazorca tierna de maíz", p.109), pero Esteves NO glosa el segmento "-naure/-aure" en sí en ninguna de las dos entradas.
+- **guara** — Topónimo simple "Guara" (p.113) y múltiples derivados (Guaraba, Guarabita, Guaracaro, etc.) pero sin glosa etimológica del morfema en esta tanda.
+- No aparecieron en este archivo: **cari, dabuda, aco, juri/judi, -dito, bara**.
+
+### Fuentes citadas
+- **Alfredo Jahn**, *Aborígenes del Occidente de Venezuela* — citado por la voz "Axadawara" en relación con Churuguara (p.109), sin explicar el significado.
+- **Pedro Manuel Arcaya**, *Población de Origen Europeo de Coro* — citado como fuente documental para el topónimo Iparaguaro (p.117).
+
+### Sitios arqueológicos / evidencia arqueológica
+- **Mapiare** (Churuguara, Distrito Federación): "Otrora fue una comunidad indígena que desapareció. Hoy es sitio arqueológico." (p.121). Único sitio arqueológico explícito en este tramo.
+- Fotografía "Trabajando la cerámica" (p.129) — evidencia etnográfica de continuidad de técnica cerámica, sin fecha ni contexto arqueológico datado.
+
+### Atribuciones de lengua (NO caquetío)
+- **Chorote**: voz cumanagota (p.108).
+- **Guareque** (→ Guarecal): voz chaima (p.114).
+- **Escuque**: voz cuica-timote adoptada (p.111).
+- **Quimba** (→ Quimbo): voz chibcha (p.128).
+- **Gayones**: tribu ayamán (p.111).
+- **Dubisí**: apellido de las tribus ayamanes (p.110).
+- **Pundo**: topónimo antillano, comparado con "Punda" de Curazao (p.127).
+- **Quebrahuto**: vocablo híbrido español + caquetío (análisis explícito, p.128).
+- **Chunaure**: marcado explícitamente "voz caquetía" (p.109) — atestación positiva, no negativa.
+
+### Rasgos gramaticales observados
+- Sufijos diminutivos: "-iro" (Coroquidiro, p.104), "-ito" (Cocuyito, p.102).
+- Sufijo colectivo "-al"/"-es": Cocuyal < cocuy (p.101); Corozal < Corozo (p.104); Chubiscal < chubisco (p.108); Mayares < maya (p.122).
+- Aféresis: Chibare < Achivare (p.107); Ipare < chipare (p.117).
+- Epéntesis propuesta: Quererepa < Querepa (p.128).
+- Alteración/disimilación fonética: Coropal < Corozal (p.102); Dibana < Gibana (p.110); Chuchure < Chuchube (p.109); Quibucara < Sibucara (p.128, alternativa).
+- Composición morfológica explícita: Chiguarigua = "chigua" (nasa, cesto) + "arigua" (insecto melífero) (p.107).
+- Análisis morfológico híbrido español-caquetío: Quebrahuto = "quebra" (apócope español) + "-uto" (desinencia caquetía = quebrada) (p.128).
+
+### Datos etnohistóricos / cacicales
+- Cacique **Cumare** → Cumarebo (p.105).
+- Cacique **Dabajuro** → Dabajuro (p.109, con comentario jocoso del autor).
+- Cacique **Mauroa** (apellido) → nombre del Distrito Mauroa (p.122).
+- **Itowa**: "antiguo nombre indígena de Churuguara" (p.118) — toponimia superpuesta/sustituida.
+- Continuidad toponímica colonial: "El Curaridal era el nombre que le daban [en tiempos coloniales] a la población de San Félix de Mauroa" (p.106).

--- a/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote6.md
+++ b/proyecto-linguistico-caquetío/4-fuentes/sesiones/06_esteves_1989_barrido_lote6.md
@@ -1,0 +1,257 @@
+# Hallazgos — Esteves, archivo 6 (pp. 001-024 del escaneo, pp. 130-154 impresas)
+
+**NOTA IMPORTANTE SOBRE EL APÉNDICE**: el prompt de esta tarea indicaba que este tramo "contiene un APÉNDICE" con un artículo tipo "Sobre el Nombre de Adícora". **Esto NO es correcto para este lote de imágenes.** El ÍNDICE GENERAL transcrito íntegro en p. 147-149 (impresas) revela la estructura real del libro:
+
+- Introducción — p. 7
+- Topónimos indígenas de Paraguaná — p. 9
+- Topónimos Compilados — p. 68
+- **FUENTES — p. 70**
+- **APÉNDICE — p. 73** (solo 7-8 páginas, hasta p. 80)
+- Otros Topónimos del Estado Falcón — p. 81 (hasta p. 139)
+- RESUMEN (lista numerada) — p. 140
+- El autor — p. 145
+- Índice General — p. 147
+
+Es decir: el APÉNDICE (pp. 73-80) y la sección FUENTES/bibliografía (p. 70-72) están **antes** de las páginas que contiene este lote de imágenes (que va de p. 130 a p. 154, es decir, la cola del diccionario "Otros Topónimos", el Resumen numerado, la biografía del autor, y el Índice General). No hay bibliografía transcribible aquí ni artículo "Sobre el Nombre de Adícora" — ese material vive en las páginas 70-80 del libro, que no están en este scratchpad. Se recomienda conseguir esas páginas (70-80) en un lote aparte si se quiere el apéndice y la bibliografía.
+
+---
+
+## p. 130
+
+### TOPÓNIMOS
+- **QUIRAGUA**: I) aldea municipio Jacura, Dtto. Acosta. II) aldea municipio Puerto Cumarebo, Dtto. Zamora. III) aldea municipio Guzmán Guillermo, Dtto. Miranda. IV) Ciénaga de Quiragua, otra aldea de Guzmán Guillermo.
+- **QUIRIBERIA**: aldea municipio Tocuyo de la Costa, Dtto. Silva.
+- **QUITARAGUA**: aldea municipio San Luis, Dtto. Bolívar.
+- **RICOA**: I) río y valle en Dtto. Zamora (nace en Dtto. Petit). II) Punta Ricoa, lugar costeño al Norte de Tocópero. III) Puente Ricoa, aldea municipio Tocópero. IV) Ricoa, aldea municipio Capatárida, Dtto. Buchivacoa.
+- **SACURAGUA**: aldea municipio Puerto Cumarebo, Dtto. Zamora. "El cerro de Sacuragua es uno de los más elevados del Distrito: tiene 488 metros sobre el nivel del mar."
+- **SAHOA**: aldea del Municipio Churuguara, Dtto. Federación.
+- **SALADILLO**: I) caserío municipio urbano San Antonio, Dtto. Miranda. II) caserío municipio Seque, Dtto. Buchivacoa.
+
+### ATRIBUCIONES DE LENGUA
+- **SALADILLO**: "(Saladillo saladilla, hierba halófila de terrenos salobres, es voz española, pero la registramos para despejar el equívoco, pues se cree que es voz indígena)." — Esteves marca explícitamente que NO es voz indígena, contra la creencia popular.
+
+---
+
+## p. 131
+
+### TOPÓNIMOS Y GLOSAS
+- **SANARE**: río y pueblo, municipio Tucacas, Dtto. Silva. "Árbol."
+- **SARURO**: El Saruro, aldea municipio Bruzual, Dtto. Democracia. "(Saruro: culebra no venenosa, boa constrictora)."
+- **SAUCA**: puerto y pueblo al Norte de Píritu, Dtto. Zamora. "Hay salinas."
+- **SEMERUCO**: aldea Municipio Acurigua, Dtto. Colina; II) El Semerucal, caserío municipio Mitare, Dtto. Miranda. "(Semeruco: cereza silvestre)." — morfema rastreado: termina en **-uco**.
+- **SEQUE**: Municipio del Dtto. Buchivacoa, capital San José de Seque. "Sécua: árbol."
+- **SIBUCARA**: lugar municipio Purureche, Dtto. Democracia. "(Sibucara: árbol corpulento de corteza fibrosa)."
+- **SIBURÚA**: pueblo y manantial, municipio Guzmán Guillermo, Dtto. Miranda.
+- **SOCOPO**: cerro, municipio Casigua, Dtto. Mauroa. "(Socopo tiene 1571 metros sobre el nivel del mar)."
+
+---
+
+## p. 132
+
+### TOPÓNIMOS Y GLOSAS
+- **SUEY**: caserío municipio Bruzual, Dtto. Democracia.
+- **SUITE**: aldea costeña, Puerto Suite, municipio Borojó, Dtto. Buchivacoa.
+- **SUPÍ**: I) lugar municipio Sabaneta, Dtto. Miranda. II) Supidito, aldea municipio Borojó, Dtto. Buchivacoa — morfema rastreado: termina en **-dito**. "(Supí: árbol cactáceo)."
+- **SURUY**: aldea municipio Independencia, Dtto. Federación. "(Susure: es un arbolillo que produce una frutilla negra de sabor agradable, codiciada de los pájaros. Una melastomácea)."
+- **TACAL**: serie de cerros al Este del Dtto. Buchivacoa, linderos con Dtto. Democracia. "Formación Tacal, se lee en textos estratigráficos." "(Tacal, colectivo de taque, árbol nucífero)."
+- **TACAMIRE**: cerro, pueblo y río al Sureste de Agualinda, Dtto. Acosta.
+- **TACARIGUA**: caserío municipio Libertador, Acosta. "(Tacariguo: árbol bombáceo)."
+- **TAGUAQUÍ**: aldea municipio Píritu, Dtto. Zamora. "(Taguaquí: acacia, árbol espinoso, juva, úbeda)."
+
+### RASGOS GRAMATICALES
+- **TACAL**: "(Tacal, colectivo de taque, árbol nucífero)" — Esteves marca explícitamente la formación de un **colectivo** con sufijo -al a partir de "taque". Comparar con TURAGUAL (p. 136).
+
+---
+
+## p. 133
+
+### TOPÓNIMOS Y GLOSAS
+- **TAICA**: aldea municipio Pueblo Cumarebo, Dtto. Zamora.
+- **TAIMATAIMA**: "Lugar cercano a La Vela de Coro, Distrito Colina. **Sitio arqueológico**."
+- **TAPACUY**: lugar de Mapararí, lindero con municipio Unión, Dtto. Federación.
+- **TAPARO**: I) Quebrada de Capadare. II) Taparito, aldea municipio La Pastora, Dtto. Acosta. III) Taparito, aldea municipio Seque, Dtto. Buchivacoa. IV) Taparitos, aldea municipio Unión, Dtto. Federación.
+- **TAPAROY**: caserío municipio Agua Larga, Dtto. Federación.
+- **TAPATAPA**: caserío municipio Unión, Dtto. Federación.
+- **TARANA**: caserío municipio Zazárida, Dtto. Buchivacoa.
+- **TARUMA**: valle al Poniente del nacimiento del río Coro, municipio Guzmán Guillermo.
+- **TARATARA**: (empieza, continúa en p. 134) I) población municipio La Vela, Dtto. Colina. II) Cerro de Taratara, otro caserío del municipio La Vela.
+
+### EVIDENCIA ARQUEOLÓGICA
+- **TAIMATAIMA**: "Sitio arqueológico" (sin más detalle en esta entrada). Es el conocido yacimiento paleoindio de Taima-Taima (restos de megafauna/mastodonte); Esteves solo lo menciona como tal, sin describir hallazgos.
+
+### ATRIBUCIONES DE LENGUA
+- **TAPATAPA**: "(Tapatapa es una voz africana que indica movimiento)." — atribución explícita a lengua **africana**, no caquetío.
+
+---
+
+## p. 134
+
+### TOPÓNIMOS Y GLOSAS
+- **TARATARA** (cont.): III) La Cruz de Taratara, población capital municipio Sucre, Dtto. Bolívar. IV) Pico Tarataráre, cerro de la cordillera de Avaria, Dtto. Democracia. V) Taratare, sabana pantanosa que riega el río Pedregal al Sur.
+- **TATARÍ**: aldea municipio Agualarga, Dtto. Federación.
+- **TIGUAJE**: caserío municipio Borojó, Buchivacoa; "aledaño al lugar hay un campo petrolero." "(Tigua: árbol rutáceo)."
+- **TOBACOA**: aldea municipio Capatárida, Dtto. Buchivacoa. — morfema rastreado: **bacoa**.
+- **TOCÓPERO**: población capital del municipio homónimo, Dtto. Zamora.
+- **TOCUYITO**: lugar en el Istmo de Médanos, municipio San Gabriel, Dtto. Miranda.
+- **TOCUYO**: I) Río que nace en Lara y desemboca en Dtto. Silva, "es el río de mayor caudal del Estado Falcón." II) Tocuyo de la Costa, municipio del Dtto. Silva. III) Boca del Tocuyo (margen derecha), aldea municipio Tocuyo de la Costa. IV) Boca del Tocuyo (margen izquierda), aldea municipio San Juan de Los Cayos, Dtto. Acosta.
+- **TOGOGO**: aldea municipio Jacura, Acosta. "(Togogo: ave ansérida)."
+
+---
+
+## p. 135
+
+### TOPÓNIMOS Y GLOSAS
+- **TOMODORE**: lugar municipio Guaibacoa, Dtto. Colina.
+- **TOROY**: caserío municipio Pecaya, Dtto. Bolívar.
+- **TUCACAS**: población capital del municipio Tucacas y del Dtto. Silva. "(Tucacas: cangrejal)."
+- **TUCÚA**: caserío municipio Zazárida, Dtto. Buchivacoa. "(Cúa: cangrejo en chaima)."
+- **TUCUDURE**: montañuela municipio Puerto Cumarebo; II) lindero de la posesión de La Candelaria, Zamora.
+- **TUCUPIDO**: puerto y aldea municipio Puerto Cumarebo. "En el puerto existió un muelle petrolero."
+- **TUCURERE**: I) río que desagua cerca de San Juan de los Cayos; "tiene el nombre de Río Mangle en la desembocadura y de Capadare en su nacimiento." II) aldea municipio San Francisco (Mirimire), Dtto. Acosta. — morfema rastreado: termina en **-ure**.
+- **TUNAPÉ**: cerro que fija linderos de los municipios Guaibacoa y Acurigua, Dtto. Colina.
+
+### ATRIBUCIONES DE LENGUA
+- **TUCÚA**: "(Cúa: cangrejo en chaima)." — atribución explícita a lengua **chaima**, no caquetío.
+
+---
+
+## p. 136
+
+### TOPÓNIMOS Y GLOSAS
+- **TUPÍ**: pueblo, capital del municipio Independencia, Federación.
+- **TUPIOPA**: fila de cerros entre municipios San Luis y Aracua, Dtto. Bolívar.
+- **TUPURE**: población capital municipio Avaria, Dtto. Democracia; Tupurito: caserío municipio Dabajuro, Dtto. Buchivacoa. — morfema rastreado: termina en **-ure**.
+- **TUQUEQUE**: cerro cerca de Puerto Cumarebo, Dtto. Zamora. "(Tuqueque: lagarto casero)."
+- **TURA**: I) Boca de Tura, caserío municipio San Antonio, Dtto. Miranda. II) El Tural, caserío municipio Mapararí, Dtto. Federación. "Tura: mazorca tierna de maíz."
+- **TURAGUAL**: El Turagual, población capital municipio Macoruca, Dtto. Colina. "(Turagual, colectivo de Turagua: árbol anonáceo)."
+- **TURUGUAPO**: cerro cerca de Puerto Cumarebo, Dtto. Zamora.
+- **TURAMACO**: caserío municipio Mitare, Dtto. Miranda.
+- **TURÉN**: posesión comunera del Dtto. Zamora.
+
+### RASGOS GRAMATICALES
+- **TURAGUAL**: "colectivo de Turagua" — segundo ejemplo (junto a TACAL, p. 132) de formación de colectivo con sufijo **-al**.
+
+---
+
+## p. 137
+
+### TOPÓNIMOS Y GLOSAS
+- **TURUPÍA**: aldea municipio Pueblo Cumarebo, Zamora. "(Turupía: árbol espinoso)."
+- **TUY**: I) El Tuy, caserío municipio Churuguara. II) El Tuy, caserío municipio Unión, Federación. "(Tui: árbol maderable, un ceibo)."
+- **UBERO**: I) Uberito, caserío municipio Mene de Mauroa, Dtto. Mauroa. II) Punta de Ubero, lugar costeño de San Juan de los Cayos, Acosta. "(Ubero: árbol coposo que da la uva de playa)."
+- **UMARE**: Las Tetas de Umare, cerros en linderos occidentales del municipio Agualinda, Dtto. Acosta.
+- **UMORÍA**: I) río afluente del Caidí, nace en Dtto. Petit. II) Sabanas de Umoría, aldea municipio Cabura, Dtto. Petit.
+- **UPIPE**: río afluente del Hueque, corre por Dtto. Colina y Zamora; "en sus comienzos le dan el nombre de Upire."
+- **URIA**: I) caserío municipio Curimagua, Petit. II) Las Urias, caserío municipio Colina, Dtto. Petit.
+- **URUCURE**: cerro al Sur del Dtto. Miranda y al Norte de Petit y Bolívar. — morfema rastreado: termina en **-ure**.
+
+---
+
+## p. 138
+
+### TOPÓNIMOS Y GLOSAS
+- **URUMACO**: población capital del Municipio Urumaco, Dtto. Democracia. — morfema rastreado: termina en **-aco**.
+- **URUY**: El Uruy, caserío municipio San Francisco (Mirimire), Dtto. Acosta.
+- **USERA**: aldea municipio Sucre, Dtto. Bolívar.
+- **UTAQUIRE**: caserío municipio Urumaco, Dtto. Democracia.
+- **YABO**: I) El Yabito, aldea de Dabajuro, Buchivacoa. II) El Yabo, caserío de Pedregal, Democracia. III) El Yabito, aldea de Piedra Grande, Democracia. IV) El Yabal, caserío municipio Bruzual, Democracia. V) El Yabalito, caserío de Pedregal, Democracia. VI) Matica de Yabo, caserío municipio Zazárida, Buchivacoa. VII) El Yabal, caserío de Guaibacoa, Dtto. Colina. "(Yabo: árbol resinoso)."
+- **YACUMARA**: caserío municipio San Francisco (Mirimire), Dtto. Acosta.
+- **YAPAMÁTICO**: caserío municipio Guzmán Guillermo, Dtto. Miranda.
+- **YARACUSITA**: punto costeño al Norte de Tocópero, Dtto. Zamora.
+- **YARACAL**: población municipio Libertador, Acosta.
+
+---
+
+## p. 139
+
+### TOPÓNIMOS Y GLOSAS
+- **YARACUY**: I) Boca de Yaracuy, caserío municipio Boca de Aroa, Dtto. Silva, "línea divisoria de los Estados Yaracuy y Falcón." II) Yaracuy, cerro cerca de Pueblo Cumarebo, Zamora.
+- **YUMARE**: aldea municipio Bolívar (Palmasola), Dtto. Silva.
+- **YUQUIQUE**: aldea municipio Capatárida, Dtto. Buchivacoa.
+- **ZÁBILA**: I) caserío municipio Pecaya, Dtto. Bolívar. II) caserío municipio Sabaneta, Dtto. Miranda. III) El Zabilar, caserío municipio Puerto Cumarebo, Dtto. Zamora.
+- **ZAMURO**: I) El Zamuro, aldea municipio Casigua, Dtto. Mauroa. II) Punta de Zamuro, sitio costeño litoral de Píritu, Zamora. III) El Zamurito, caserío municipio Capatárida, Buchivacoa. IV) El Zamuro, caserío municipio Dabajuro, Dtto. Buchivacoa.
+- **ZAZÁRIDA**: I) población capital del municipio Zazárida, Dtto. Buchivacoa. II) Boca de Zazárida, aldea municipio Zazárida. III) Cerro de Zazárida, "la mayor elevación geográfica del Distrito Zamora en el municipio La Soledad: 527 metros sobre el nivel del mar." IV) Aldea municipio Puerto Cumarebo, Zamora. V) Aldea municipio San Luis, Bolívar.
+
+Fin del diccionario alfabético de "Otros Topónimos del Estado Falcón" (última entrada: Z).
+
+---
+
+## p. 140-144 (impresas) — RESUMEN
+
+Lista numerada (1 a 413) de **todos** los topónimos catalogados en el libro (mezcla las dos secciones: Paraguaná y "Otros Topónimos del Estado Falcón"), sin etimologías ni datos adicionales — es un índice puro de nombres. Se transcribió completa la secuencia de números pero no se reproduce aquí por no aportar contenido lingüístico nuevo más allá de confirmar la lista total. Rango: 1-Abato hasta 413-Zazárida.
+
+Entradas de interés para el proyecto que aparecen en esta lista pero **sin etimología dada en este lote** (su glosa, si existe, estará en páginas anteriores del libro no incluidas aquí, aprox. pp. 9-129): Bacoa/variantes no aparecen como entrada propia; sí aparecen "Guacoa" (#183), "Caquetillo" (#85, notablemente contiene "Caquet-"), "Cambuyón", "Guajiro" (#193), "Manaure" (#264), "Naguao" (#301), "Guara" (#201), "Guaraba" (#202), etc. — relevantes para futuras sesiones de minado si se consiguen las páginas correspondientes del libro.
+
+---
+
+## p. 145-146 (impresas) — "EL AUTOR"
+
+Biografía de Juan de la Cruz Esteves (no etimológica, mantenida como contexto de fuente):
+
+- Nació en El Hato (Paraguaná, Estado Falcón), 24 de noviembre de 1922.
+- "Con meritorio esfuerzo comenzó su formación intelectual en Maracaibo sin llegar a diplomarse. Por cuenta propia y con paciente espíritu escudriñador, ha dedicado su vida a la lectura, el estudio y la investigación lingüística, histórica y cultural de Falcón."
+- Poeta, articulista, cronista de Pueblo Nuevo desde 1971.
+- Miembro fundador de la Asociación de Cronistas Oficiales de Venezuela (1972).
+- Individuo de número del Centro de Historia del Estado Falcón desde 1975.
+- "Su labor de investigación histórica es citada en la bibliografía básica del Estado Falcón."
+- Reconocido por municipalidades de Coro (1972), Puerto Cabello (1973 y 1981), Cumaná (1974), Guanare (1982), Petare (1983), Caracas (1983).
+- Obras publicadas — poemas: *Canto a Paraguaná*, *Agua en Totuma*, *Itinerario Lírico*.
+- Obras de investigación: *Nombres Propios*, *La Heroína de Paraguaná*, *Topónimos Indígenas de Paraguaná*, *Paraguaná en el Tiempo*, *Juan Garcés*, *Liceo Héctor M. Peña*, *Paraguaná Histórica y Geográfica* (editada en 1988 por la Refinería de Amuay de Lagoven — es decir, la editorial/patrocinador del libro que estamos minando).
+- "Tiene una veintena de obras inéditas entre poemas, crónicas, biografías, historia, lingüística, mitos y leyendas."
+
+---
+
+## p. 147-154 (impresas) — ÍNDICE GENERAL
+
+Tabla de contenidos completa del libro, transcrita en su estructura relevante (ver nota al inicio del documento). Confirma la organización:
+
+1. Introducción — p. 7
+2. Topónimos indígenas de Paraguaná — p. 9 (entradas Abudure p.11 → Yauquiba p.67)
+3. Topónimos Compilados — p. 68
+4. **FUENTES** — p. 70
+5. **APÉNDICE** — p. 73
+6. Otros Topónimos del Estado Falcón — p. 81 (entradas Abato p.83 → Zazárida p.139)
+7. RESUMEN — p. 140
+8. El autor — p. 145
+9. Índice General — p. 147
+
+El resto de páginas (150-153) son la continuación en columnas del índice de "Otros Topónimos", replicando (sin etimologías) los mismos 413 topónimos ya vistos en el diccionario y en el RESUMEN. La p. 154 (última imagen, p024.jpg) está muy desvaída/casi ilegible por baja tinta de fotocopia, pero se distingue que termina el índice con "RESUMEN .. 140" y "El autor .. 145", confirmando el cierre del libro.
+
+---
+
+## Resumen del archivo 6
+
+### Morfemas nuevos/reforzados (de los que el proyecto rastrea)
+- **bacoa**: TOBACOA (p. 134/impresa) — aldea, municipio Capatárida.
+- **-aco**: URUMACO (p. 138), TURAMACO (p. 136) — terminación repetida en topónimos.
+- **-uco**: SEMERUCO (p. 131) — "cereza silvestre".
+- **-dito**: SUPIDITO (p. 132) — aldea, municipio Borojó.
+- **-ure** (grafía "-ure"/"-uría"): TUCURERE, TUPURE, URUCURE (pp. 135-137) — patrón recurrente de terminación, sin glosa morfémica explícita por Esteves en estas entradas (son nombres completos, no analizados en partes).
+
+No aparecieron en este lote (páginas 130-154): bana/bano, ebo, bara, quiba, naure/ñaure, juri/judi, dabuda, guara, cari — con glosa etimológica explícita. (Varios sí figuran como nombres sueltos en la lista RESUMEN sin definición, ej. "Guara" #201, "Naguao" #301, pero su etimología —si la da el libro— estaría en páginas anteriores no cubiertas por este lote.)
+
+### Atribuciones de lengua NO caquetío (importante)
+1. **TAPATAPA** (p. 133/impresa): "es una voz africana que indica movimiento" — atribución a lengua **africana**.
+2. **TUCÚA** (p. 135/impresa): "(Cúa: cangrejo en chaima)" — atribución a lengua **chaima**.
+3. **SALADILLO** (p. 130/impresa): declarado explícitamente **voz española**, no indígena, pese a creencia popular contraria — Esteves lo registra justamente para "despejar el equívoco".
+
+### Rasgos gramaticales
+- Formación de **colectivo con sufijo -al**: dos ejemplos explícitos —
+  - TACAL, "colectivo de taque, árbol nucífero" (p. 132/impresa).
+  - TURAGUAL, "colectivo de Turagua: árbol anonáceo" (p. 136/impresa).
+
+### Evidencia arqueológica
+- **TAIMATAIMA** (p. 133/impresa): "Lugar cercano a La Vela de Coro, Distrito Colina. Sitio arqueológico." — mención escueta, sin detalle de hallazgos, del célebre yacimiento paleoindio de Taima-Taima.
+- Mención tangencial no arqueológica pero geológica: "Formación Tacal, se lee en textos estratigráficos" (TACAL, p. 132/impresa) — referencia a nomenclatura geológica/estratigráfica que usa el topónimo, no a un sitio arqueológico propiamente.
+
+### Fuentes citadas en este lote
+Ninguna cita textual de autores/documentos históricos (Martí, censo 1881, Castellanos, Alvarado, etc.) aparece en las páginas 130-154. Esta parte del libro es puramente el cierre del diccionario alfabético (letras Q-Z), sin aparato de fuentes por entrada. **La sección FUENTES real del libro está en la página impresa 70**, fuera de este lote — pendiente de conseguir esas páginas.
+
+### Bibliografía
+No hay bibliografía en este lote. Su ubicación real en el libro es la sección "FUENTES" (p. 70) y posiblemente referencias dentro del "APÉNDICE" (pp. 73-80) — ninguna de las dos está en las imágenes p001-p024 de este scratchpad.
+
+### Sitios arqueológicos mencionados
+- Taima-Taima (ver arriba).
+
+### Pendiente / recomendación
+Para completar el mandato original de esta tarea (extraer el APÉNDICE, incluido presuntamente el artículo "Sobre el Nombre de Adícora", y la bibliografía/FUENTES), se necesita un lote de imágenes que cubra las páginas impresas **70 a 80** del libro — no están en `est6`. Recomiendo generar ese lote (p.ej. `est7` o renombrar) antes de dar por cerrada la minería de esta fuente.


### PR DESCRIPTION
docs(fuentes): Esteves 1989, el gazeteer de Paraguaná que faltaba

Juan de la Cruz Esteves, cronista de Paraguaná: "Topónimos indígenas de
Paraguaná y otros topónimos indígenas del estado Falcón" (Caracas, 1989,
patrocinado por la Refinería de Amuay de Lagoven). 146 páginas de entradas
topónimo por topónimo con ubicación, censo y etimología propuesta. Llegó por
correo de Nery Gil en seis PDF escaneados.

Es la fuente que desbloquea #92: hoy `asentamientos.yaml` tiene Paraguaná
prácticamente vacía porque no había nada en el repo que nombrara sus poblados.

## Lo que ya rinde con 6 de 146 páginas leídas

`bacoa` = 'lugar, paraje' CORROBORADO por segunda vez de forma independiente.
Es nuestro morfema más productivo —adabacoa, guadabacoa, quibacoas,
yacarebacoa, sazaribacoa— y hasta ahora descansaba solo en Zavala.

Cinco morfemas nuevos: `ure` 'raíz' (Esteves dice que está presente en muchos
topónimos de Paraguaná, o sea candidato a productivo), `bara` 'árbol', `guani`
'abeja', `dabuda` 'barro de loza', `dara` 'alcaraván'. Y Semeruco corrobora el
`cemirucos` que ya teníamos.

Siete topónimos con ubicación y censo de casas y vecinos.

## Las fuentes que Esteves usa, que es lo que se le pedía

La Visita Pastoral del obispo Mariano Martí (1773) es la que hay que
perseguir: colonial, primaria, y Oliver ya la cita como "Martí 1969", así que
la edición moderna existe y es rastreable. Además: el censo de 1881, los libros
de bautizos de Jadacaquiva 1835-1842, y los papeles de posesión de
Urupaguaduco.

## Con su advertencia de época

Las fuentes de Esteves son de 1773, 1835-42 y 1881: más LEJOS del precontacto
que la carta de Bastidas de 1538, no más cerca. Nada de esta obra puede
sostener `precontacto: si` en el registro de nodos. Lo que da es el inventario
de topónimos, que es justo lo que #92 necesita.

Un punto a favor de su método: en `Acaboa` rechaza la etimología de "Caoba"
porque ese árbol no existe en la flora autóctona de Paraguaná. Es el mismo
control ecológico que aplica el proyecto.

Y la grafía del apellido es Esteves con -s: los archivos dicen "Estevez", pero
la portada y la introducción de Lagoven dicen Esteves. Manda la fuente.

Bibliografía regenerada: 31 obras. Los guardianes en verde.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
