### PR TITLE
Los generados al día tras kaketiana, y el guardián de bibliografía en verde

### DIFF
--- a/proyecto-linguistico-caquetío/1-plan/PLAN_MAESTRO.md
+++ b/proyecto-linguistico-caquetío/1-plan/PLAN_MAESTRO.md
@@ -194,7 +194,7 @@ y no en más markdown suelto.
 
 ## 3. Eje JARDÍN — la presentación pública que sí funcione
 
-**Diagnóstico compartido:** `/simulador` está bien construido pero cuenta *el
+**Diagnóstico compartido:** `/kaketiana` está bien construido pero cuenta *el
 experimento*. Tras varias vueltas sigue sin sentirse efectivo porque el
 experimento es solo una parte — y no la más enlazable — de lo que el proyecto
 tiene. **La investigación ES el contenido**: diao/apopo/boratio, Todariquiba,

--- a/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
+++ b/proyecto-linguistico-caquetío/4-fuentes/bibliografia.yaml
@@ -26,6 +26,9 @@ obras:
   local:
   - fuentes_caquetios/Alvarado_1921_Glosario_Voces_Indigenas_Venezuela.pdf
   paginas: 354
+  acceso: 'Libre — Internet Archive: https://archive.org/details/glosariodevocesi00alva · también en CENAL:
+    https://cenal.gob.ve/?wpdmpro=coleccion-bicentenario-carabobo-26-alvarado-lisandro-glosario-de-voces-indigenas-de-venezuela-pdf.
+    Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Alvarado 1921
   - Glosario de voces indígenas
@@ -162,6 +165,9 @@ obras:
   - fuentes_caquetios/Gilij_1782_Saggio_Storia_Americana_vol3.pdf
   - fuentes_caquetios/Gilij_1783_Saggio_Storia_Americana_vol4.pdf
   paginas: 414 + 457 + 452 = 1323
+  acceso: 'Libre — Internet Archive, los 4 tomos: https://archive.org/details/saggiodistoriaam03gili (tomo
+    III, el lingüístico) · t.I https://archive.org/details/saggiodistoriaa01giligoog · t.II https://archive.org/details/saggiodistoriaam02gili
+    · t.IV https://archive.org/details/saggiodistoriaam04gili. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Gilij
   - Saggio di Storia Americana
@@ -187,6 +193,8 @@ obras:
   local:
   - fuentes_caquetios/Jahn_1927_Aborigenes_Occidente_Venezuela.pdf
   paginas: 510
+  acceso: 'Libre — PDF en la Biblioteca Digital de Venezuela: https://bibliotecadigital.bnv.gob.ve/wp-content/uploads/los_aborigenes_del_occidente_de_venezuela_.pdf.
+    Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Jahn 1927
   - Los aborígenes del occidente de Venezuela
@@ -275,6 +283,9 @@ obras:
   local:
   - fuentes_caquetios/Oliver_1989_Tesis_Arawakan_NW_Venezuela_UCL.pdf — impresas 559-594 = pdf 586-621
     (offset -27)
+  acceso: 'Libre — la tesis completa (823 pp., incluye este apéndice, pp. 559-594 impresas = pdf 586-621)
+    está en UCL Discovery, depositada por el propio Oliver: PDF https://discovery.ucl.ac.uk/id/eprint/10157455/1/Oliver_10157455_thesis_redacted.pdf
+    · ficha https://discovery.ucl.ac.uk/id/eprint/10157455/. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Oliver 1989 Apéndice A
   - Appendix A Swadesh
@@ -287,6 +298,9 @@ obras:
   local:
   - fuentes_caquetios/Chapter 2 Linguistics- Oliver 1989.pdf
   paginas: 109
+  acceso: 'Libre — la tesis completa (823 pp., incluye este capítulo) está en UCL Discovery, depositada
+    por el propio Oliver: PDF https://discovery.ucl.ac.uk/id/eprint/10157455/1/Oliver_10157455_thesis_redacted.pdf
+    · ficha https://discovery.ucl.ac.uk/id/eprint/10157455/. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Oliver 1989 cap. 2
   - Oliver cap. 2
@@ -302,6 +316,9 @@ obras:
   local:
   - fuentes_caquetios/Oliver_1989_Tesis_Arawakan_NW_Venezuela_UCL.pdf — impresas 213-250 = pdf 240-277
     (offset -27)
+  acceso: 'Libre — la tesis completa (823 pp., incluye esta sección) está en UCL Discovery, depositada
+    por el propio Oliver: PDF https://discovery.ucl.ac.uk/id/eprint/10157455/1/Oliver_10157455_thesis_redacted.pdf
+    · ficha https://discovery.ucl.ac.uk/id/eprint/10157455/. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Oliver 1989 §3.3
   - los vecinos de los caquetíos
@@ -316,6 +333,9 @@ obras:
   local:
   - fuentes_caquetios/Chapter 3 Ethnohistory.DOC-comprimido.pdf
   paginas: 113
+  acceso: 'Libre — la tesis completa (823 pp., incluye este capítulo) está en UCL Discovery, depositada
+    por el propio Oliver: PDF https://discovery.ucl.ac.uk/id/eprint/10157455/1/Oliver_10157455_thesis_redacted.pdf
+    · ficha https://discovery.ucl.ac.uk/id/eprint/10157455/. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Oliver 1989 cap. 3
   - Oliver cap. 3
@@ -330,6 +350,9 @@ obras:
   local:
   - fuentes_caquetios/Oliver_1989_Tesis_Arawakan_NW_Venezuela_UCL.pdf (tesis completa, escaneo; el .DOC
     con texto limpio sigue en 'Info para Miguel/PhD Oliver Edited/')
+  acceso: 'Libre — la tesis completa (823 pp., incluye este capítulo) está en UCL Discovery, depositada
+    por el propio Oliver: PDF https://discovery.ucl.ac.uk/id/eprint/10157455/1/Oliver_10157455_thesis_redacted.pdf
+    · ficha https://discovery.ucl.ac.uk/id/eprint/10157455/.'
   aliases:
   - Oliver 1989 cap. 4
   - Oliver Chapter 4 Archaeology
@@ -344,6 +367,8 @@ obras:
   local:
   - fuentes_caquetios/Oviedo_Banhos_Conquista_Poblacion_Venezuela.pdf (519 pp., ÚTIL)
   paginas: 519
+  acceso: 'Libre — Internet Archive (ed. 1885): https://archive.org/details/historiadelacon00bagoog. Verificado
+    en el rastreo de 2026-08-14.'
   aliases:
   - Oviedo y Baños
   - Oviedo Baños 1885
@@ -356,6 +381,10 @@ obras:
   local:
   - fuentes_caquetios/Oviedo_Valdes_1851_Historia_General_Indias_vol1.pdf
   paginas: — (no legible)
+  acceso: 'El vol. I local está corrupto y es el tomo equivocado. Lo que hace falta SÍ es libre en Internet
+    Archive, ed. Amador de los Ríos: tomo II (funerales) https://archive.org/details/historiageneral01fernguat
+    · tomo IV (sin el apéndice de voces que se buscaba) https://archive.org/details/historiageneral04fernguat.
+    Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Oviedo y Valdés
   - Oviedo 1851
@@ -443,6 +472,8 @@ obras:
   local:
   - fuentes_caquetios/Urbina_2007_El_Carrizal_UCV.pdf
   - fuentes_caquetios/Urbina_2011_Archaeological_Survey_Coastal_Falcon_UCL.pdf
+  acceso: 'El survey de 2011 es libre — Academia.edu: https://www.academia.edu/35413060/. El Carrizal
+    (2007) no se verificó acceso en el rastreo. Ver el rastreo documental del 2026-08-14.'
   aliases:
   - Urbina Jiménez 2007
   - Urbina Jiménez 2011
@@ -460,6 +491,8 @@ obras:
   local:
   - fuentes_caquetios/VanBuurt_2014_CaquetioWords_Papiamentu.txt
   paginas: 48
+  acceso: 'Libre — PDF completo: https://tiboko.com/wp-content/uploads/2023/07/Final-version-GvB-Papiamentu-book.pdf.
+    Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Van Buurt 2014
   - Caquetío words in Papiamentu
@@ -483,6 +516,8 @@ obras:
   local:
   - fuentes_caquetios/Palabras Vivas de una Lengua Muerta.pdf
   paginas: 20
+  acceso: 'Libre — Academia.edu: https://www.academia.edu/14657955/Palabras_vivas_de_una_lengua_muerta_Legado_arawak_caquetio
+    · ficha SABER-ULA: http://www.saber.ula.ve/handle/123456789/40730. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Zavala 2015
   - Zavala Reyes 2015
@@ -498,6 +533,8 @@ obras:
   local:
   - fuentes_caquetios/ZavalaReyes_et_al_2018_Arqueologia_Medanos_Coro.pdf
   paginas: 7
+  acceso: 'Libre — Redalyc: https://www.redalyc.org/journal/339/33957447002/33957447002.pdf · Dialnet:
+    https://dialnet.unirioja.es/servlet/articulo?codigo=6457604. Verificado en el rastreo de 2026-08-14.'
   aliases:
   - Zavala Reyes et al. 2018
   - Leal et al. 2018

--- a/proyecto-linguistico-caquetío/5-experimento/IDEA_PERFILES_AGENTES.md
+++ b/proyecto-linguistico-caquetío/5-experimento/IDEA_PERFILES_AGENTES.md
@@ -46,8 +46,8 @@ Una sección/página `/agentes` en el dashboard con:
 2. Correr `curiana_perfilador.py` contra un run real y revisar la calidad
    de las frases elegidas / justificaciones.
 3. ✅ Hecho, pero en Curiana Radio, no en `curiana_dashboard` (que se borró — no llegó
-   a desplegarse nunca): `/simulador/personajes` (grid) y
-   `/simulador/personajes/[slug]` (detalle) ya existen y consumen
+   a desplegarse nunca): `/kaketiana/personajes` (grid) y
+   `/kaketiana/personajes/[slug]` (detalle) ya existen y consumen
    `content/simulador/personajes.json`.
 4. Decidir si el perfilador corre automáticamente al final de cada
    `--auto N`, o se deja como paso manual aparte (para no gastar

--- a/proyecto-linguistico-caquetío/6-fusion/BANDEJA.md
+++ b/proyecto-linguistico-caquetío/6-fusion/BANDEJA.md
@@ -13,19 +13,16 @@ editar_a_mano: no
 > python curiana_sim/generar_bandeja.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-24**.
+<!--GENERADO--> Generado el **2026-08-25**.
 
-**1267 ítems propuestos** en 9 propuestas, más **1 issue(s)/comentario(s) redactados sin publicar**.
+**1290 ítems propuestos** en 9 propuestas, más **1 issue(s)/comentario(s) redactados sin publicar**.
 
 ## Propuestas de datos (`6-fusion/*.yaml`)
 
 | Archivo | Obra | Ítems | Aviso |
 |---|---|---|---|
 | `nodos_oliver_apendice_e.yaml` | oliver-1989-cap4 | 134 |  |
-| `tabla15_c14_oliver.yaml` | ? | 0 | ⚠️ no parsea: mapping values are not allowed here
-  in "<unicode string>", line 27, column 26:
-      - lab: ISGS-1173, sitio: "Túcua",              bp: "110 ... 
-                             ^ |
+| `tabla15_c14_oliver.yaml` | oliver-1989-cap4 | 23 |  |
 | `tabla_a8_jirajarano.yaml` | oliver-1989-apendice-a | 33 |  |
 | `tabla_a9_oliver.yaml` | oliver-1989-cap2 | 49 |  |
 
@@ -50,7 +47,7 @@ con `gh issue create --body-file` / `gh issue comment --body-file`.
 
 | Archivo | Qué es |
 |---|---|
-| `issue-pdfs-fuentes-aporte.md` | Servir los PDF del vault desde `/simulador/fuentes`, tras un aporte voluntario |
+| `issue-pdfs-fuentes-aporte.md` | Servir los PDF del vault desde `/kaketiana/fuentes`, tras un aporte voluntario |
 
 ---
 

--- a/proyecto-linguistico-caquetío/6-fusion/issues-pendientes/issue-pdfs-fuentes-aporte.md
+++ b/proyecto-linguistico-caquetío/6-fusion/issues-pendientes/issue-pdfs-fuentes-aporte.md
@@ -1,8 +1,8 @@
-Servir los PDF del vault desde `/simulador/fuentes`, tras un aporte voluntario
+Servir los PDF del vault desde `/kaketiana/fuentes`, tras un aporte voluntario
 
 ## De dónde sale esto
 
-La wiki de fuentes (`/simulador/fuentes`, 62 páginas) publica **lo que
+La wiki de fuentes (`/kaketiana/fuentes`, 62 páginas) publica **lo que
 resolvimos y minamos de cada obra**, pero no la obra. Miguel lo señaló el
 2026-08-24 con la pregunta obvia: *"pero no las tenemos en el mismo
 proyecto?"*.

--- a/proyecto-linguistico-caquetío/CLAUDE.md
+++ b/proyecto-linguistico-caquetío/CLAUDE.md
@@ -3,7 +3,7 @@
 Investigación + experimento computacional: 60 agentes históricos (pueblo
 Caquetío, Golfete de Coro, s. XIV-XV) hablan en caquetío-arahuaco reconstruido,
 inventan palabras y se contagian entre sí. La deriva se registra en Supabase, se
-cura y se publica en Curiana Radio (`/simulador`).
+cura y se publica en Curiana Radio (`/kaketiana`).
 
 > **Este archivo dice cómo trabajar aquí, no qué sabemos.** Lo que sabemos está
 > medido en `TABLERO.md` y explicado en el vault. Si buscas una cifra y la

--- a/proyecto-linguistico-caquetío/TABLERO.md
+++ b/proyecto-linguistico-caquetío/TABLERO.md
@@ -13,7 +13,7 @@ editar_a_mano: no
 > python curiana_sim/generar_tablero.py
 > ```
 
-<!--GENERADO--> Generado el **2026-08-24 17:41**.
+<!--GENERADO--> Generado el **2026-08-25 09:32**.
 
 ## ¿Vamos bien?
 
@@ -252,7 +252,7 @@ Las simulaciones están **en pausa** ([[PLAN_MAESTRO]] §0). Se reanudan cuando 
 
 |  | Medido |  |
 |---|---|---|
-| Wikilinks | 956 en 258 notas indexadas | 🟢 0 rotos |
+| Wikilinks | 956 en 260 notas indexadas | 🟢 0 rotos |
 | Tests (`curiana_sim/tests/`) | 197 passed, 0 failed | 🟢 |
 | Canon ↔ polity simulada | 2 aviso(s) — ver abajo | 🟡 |
 

--- a/proyecto-linguistico-caquetío/curiana_sim/README.md
+++ b/proyecto-linguistico-caquetío/curiana_sim/README.md
@@ -185,7 +185,7 @@ Si **2 agentes distintos** la usan → entra al léxico comunitario permanente.
 ## Publicación
 
 No hay dashboard propio: los resultados curados se exportan a JSON estático y se
-publican en el sitio Curiana Radio (`/simulador`, fuera de este repo de simulación).
+publican en el sitio Curiana Radio (`/kaketiana`, fuera de este repo de simulación).
 Ver `export_runs_index.py`, `export_personajes_seed.py`, `export_resumen_seed.py`,
 `export_lexicon_seed.py` — cada uno lee de Supabase local y escribe a
 `../content/simulador/*.json`. Añadir un run al sitio es correr los exporters que


### PR DESCRIPTION
Trabajo de higiene tras el merge de #107. Nada de canon cambia: se remide lo generado y se corrigen rutas en el vault.

## Qué arregla

**1. El guardián `bibliografía al día` estaba en rojo en `main`.**
El commit de la wiki añadió campos `acceso:` al frontmatter de 14 notas de `4-fuentes/`, y `bibliografia.yaml` (generado) nunca los levantó. Regenerado: 39 obras, +37 líneas, puramente aditivo.

**2. TABLERO y BANDEJA eran del 24-ago 17:41**, anteriores a los dos últimos commits. Remedidos:

- la cola de fusión pasa de **1.267 a 1.290** ítems;
- `tabla15_c14_oliver.yaml` deja de figurar como *"no parsea"* — se arregló en 84da0f1 y la bandeja seguía denunciándolo.

**3. El renombrado `/simulador` → `/kaketiana` dejó rutas viejas en el vault.** No es un `sed` ciego:

| Se actualiza (describe el presente) | Se deja intacto |
|---|---|
| `CLAUDE.md`, `curiana_sim/README.md` | `content/simulador/` — sigue en disco, es la ruta real de los JSON de runs |
| el diagnóstico del eje JARDÍN en `PLAN_MAESTRO.md` | `CRONICA.md` — generado, es el mensaje de un commit de junio |
| las rutas de personajes en `IDEA_PERFILES_AGENTES.md` | `MIGRACION_RUNS_EVOLUCION.md` — diseño fechado de una rama ya cerrada |
| el issue sin publicar de los PDF | |

## Dos cosas señaladas, no tocadas

- **`issue-pdfs-fuentes-aporte.md` tiene la premisa caducada.** Dice *"La wiki de fuentes (62 páginas) publica lo que resolvimos de cada obra"*, pero esa wiki de `4-fuentes/` nunca se publicó: `export_wiki_seed.py` documenta que se descartó el 24-ago ("el eje es el objeto, no la procedencia"). El título y el argumento de fondo —servir nuestra copia porque las notas citan **su** paginación— siguen en pie. Hay que reescribir esa frase antes de publicarlo.
- **`PLAN_MAESTRO.md` §3 (eje JARDÍN)** describe como diagnóstico pendiente justo lo que #107 resolvió. Merece una revisión de verdad, no un renombrado.

## Verificación

`python curiana_sim/guardianes.py` → **los 8 en verde**, 197 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
